### PR TITLE
Factorisation import librairie de définitions

### DIFF
--- a/admin/admin_db_sauve.php
+++ b/admin/admin_db_sauve.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/admin/admin_index.php
+++ b/admin/admin_index.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/admin/admin_jours_chomes.php
+++ b/admin/admin_jours_chomes.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/admin/admin_jours_fermeture.php
+++ b/admin/admin_jours_fermeture.php
@@ -24,10 +24,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/calcul_nb_jours_pris.php
+++ b/calcul_nb_jours_pris.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/calendrier.php
+++ b/calendrier.php
@@ -23,11 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '');
-include ROOT_PATH . 'define.php';
-
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/config/index.php
+++ b/config/index.php
@@ -23,11 +23,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
+require ROOT_PATH . 'define.php';
 include INCLUDE_PATH . 'fonction.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
 $session =(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/deconnexion.php
+++ b/deconnexion.php
@@ -1,9 +1,7 @@
 <?php
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/define_new.php
+++ b/define_new.php
@@ -1,7 +1,7 @@
 <?php
 
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+define('_PHP_CONGES', 1);
 defined( 'ROOT_PATH' ) or die( 'ROOT_PATH not defined !' );
 
 if (!defined( 'DEFINE_INCLUDE' )) {

--- a/edition/edit_user.php
+++ b/edition/edit_user.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/edition/edition_papier.php
+++ b/edition/edition_papier.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/edition/edition_pdf.php
+++ b/edition/edition_pdf.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/export/export_vcalendar.php
+++ b/export/export_vcalendar.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/export/fonctions_export.php
+++ b/export/fonctions_export.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/imprim_calendrier.php
+++ b/imprim_calendrier.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 

--- a/index.php
+++ b/index.php
@@ -3,35 +3,33 @@
 Libertempo : Gestion Interactive des Congés
 Copyright (C) 2005 (cedric chauvineau)
 
-Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les 
+Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
 termes de la Licence Publique Générale GNU publiée par la Free Software Foundation.
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE, 
-ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation 
+Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE,
+ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation
 dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pour plus de détails.
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps 
-que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation, 
+Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
+que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
 *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU General Public License as published by the Free Software Foundation; either 
+of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-@define('_PHP_CONGES', 1);
-@define('ROOT_PATH', '');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+define('ROOT_PATH', '');
+require 'define.php';
 
 // test si dbconnect.php est présent !
 if (!is_readable( CONFIG_PATH .'dbconnect.php'))
 {
-	echo "connexion a la database impossible, consultez le fichier INSTALL.txt !<br>\n"; 
+	echo "connexion a la database impossible, consultez le fichier INSTALL.txt !<br>\n";
 	exit;
 }
 

--- a/install/index.php
+++ b/install/index.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 //include ROOT_PATH .'fonctions_conges.php' ;
 session_start();

--- a/install/install.php
+++ b/install/install.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 include ROOT_PATH .'fonctions_conges.php' ;
 include INCLUDE_PATH .'fonction.php';

--- a/install/mise_a_jour.php
+++ b/install/mise_a_jour.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 include ROOT_PATH .'fonctions_conges.php' ;
 include INCLUDE_PATH .'fonction.php';

--- a/install/upgrade_from_v1.4.0.php
+++ b/install/upgrade_from_v1.4.0.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 /*******************************************************************/
 // SCRIPT DE MIGRATION DE LA VERSION 1.4.0 vers 1.4.1

--- a/install/upgrade_from_v1.4.2.php
+++ b/install/upgrade_from_v1.4.2.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 /*******************************************************************/
 // SCRIPT DE MIGRATION DE LA VERSION 1.4.2 vers 1.5.0

--- a/install/upgrade_from_v1.5.0.php
+++ b/install/upgrade_from_v1.5.0.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 /*******************************************************************/
 // SCRIPT DE MIGRATION DE LA VERSION 1.5.0 vers 1.6.0

--- a/install/upgrade_from_v1.6.0.php
+++ b/install/upgrade_from_v1.6.0.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 /*******************************************************************/
 // SCRIPT DE MIGRATION DE LA VERSION 1.6.0 vers 1.7.0

--- a/utilisateur/user_index.php
+++ b/utilisateur/user_index.php
@@ -23,10 +23,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
-include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+require ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 


### PR DESCRIPTION
Les `define` sont dupliqués partout dans les fichiers d'affichage, j'ai donc commencé le chantier de factoriser ces définitions dans le fichier adapté. La constante `ROOT_PATH` sert à plusieurs choses en même temps (path dans le système de fichier et path vis à vis du serveur) je ne l'ai donc pas touchée pour le moment.

J'en ai profité pour rendre l'import beaucoup plus restrictif via un `require` plutôt qu'un `include` et de ce fait la condition `defined(truc)` n'a plus de sens, je l'ai donc fait sautée.

## But
C'est une première étape d'un long parcours vers la création d'un point d'entrée unique dans l'application. En évitant la définition de constantes (dans ce cas) n'importe où dans l'appli, on a pas le risque d'oublier quelque chose à un endroit.


## Note 
J'en profite pour te demander le sens de la duplicité de `define.php` et `define_new.php`