### PR TITLE
Séparation affichage / logique dans le module du haut responsable

### DIFF
--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -1249,7 +1249,7 @@ class Fonctions
         // Récuperation des informations des users:
         $tab_info_users=array();
         // si l'admin peut voir tous les users  OU si l'admin n'est pas responsable
-        if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" || is_hr($_SESSION['userlogin']) )
+        if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" || is_hr($_SESSION['userlogin']) ) {
             $tab_info_users = recup_infos_all_users($DEBUG);
         } else {
             $tab_info_users = recup_infos_all_users_du_resp($_SESSION['userlogin'], $DEBUG);

--- a/edition/Fonctions.php
+++ b/edition/Fonctions.php
@@ -241,7 +241,7 @@ class Fonctions
     	/* Bilan des Conges */
     	/********************/
     	// affichage du tableau récapitulatif des solde de congés d'un user
-    	affiche_tableau_bilan_conges_user($login,  $DEBUG);
+    	echo affiche_tableau_bilan_conges_user($login,  $DEBUG);
     	echo "<br><br><br>\n";
 
     	\edition\Fonctions::affiche_nouvelle_edition($login,  $DEBUG);

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -31,597 +31,599 @@ defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
 // affichage du calendrier avec les case à cocher, du mois du début du congés
 function  affiche_calendrier_saisie_date($user_login, $year, $mois, $type_debut_fin , $DEBUG=FALSE) {
-	$jour_today			= date('j');
-	$jour_today_name		= date('D');
-	$first_jour_mois_timestamp	= mktime(0,0,0,$mois,1,$year);
-	$last_jour_mois_timestamp	= mktime(0,0,0,$mois +1 , 0,$year);
-	$mois_name			= date_fr('F', $first_jour_mois_timestamp);
-	$first_jour_mois_rang		= date('w', $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
-	$last_jour_mois_rang		= date('w', $last_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
-	$nb_jours_mois			= ( $last_jour_mois_timestamp - $first_jour_mois_timestamp + 60*60 *12 ) / (24 * 60 * 60); // + 60*60 *12 for fucking DST
+    $jour_today            = date('j');
+    $jour_today_name        = date('D');
+    $first_jour_mois_timestamp    = mktime(0,0,0,$mois,1,$year);
+    $last_jour_mois_timestamp    = mktime(0,0,0,$mois +1 , 0,$year);
+    $mois_name            = date_fr('F', $first_jour_mois_timestamp);
+    $first_jour_mois_rang        = date('w', $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+    $last_jour_mois_rang        = date('w', $last_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+    $nb_jours_mois            = ( $last_jour_mois_timestamp - $first_jour_mois_timestamp + 60*60 *12 ) / (24 * 60 * 60); // + 60*60 *12 for fucking DST
 
-	if( $first_jour_mois_rang == 0 )
-		$first_jour_mois_rang=7 ; // jour de la semaine en chiffre (1=lun , 7=dim)
+    if( $first_jour_mois_rang == 0 )
+        $first_jour_mois_rang=7 ; // jour de la semaine en chiffre (1=lun , 7=dim)
 
-	if( $last_jour_mois_rang == 0 )
-		$last_jour_mois_rang=7 ; // jour de la semaine en chiffre (1=lun , 7=dim)
+    if( $last_jour_mois_rang == 0 )
+        $last_jour_mois_rang=7 ; // jour de la semaine en chiffre (1=lun , 7=dim)
 
-	echo '<table class="calendrier_saisie_date_debut" cellpadding="0" cellspacing="0">
-		<thead>
-		<tr align="center" bgcolor="'.$_SESSION['config']['light_grey_bgcolor'].'">
-		<td colspan=7 class="titre"> '.$mois_name.' '.$year.' </td>
-		</tr>
-		<tr bgcolor="'.$_SESSION['config']['light_grey_bgcolor'].'">
-		<td class="cal-saisie2">'. _('lundi_1c') .'</td>
-		<td class="cal-saisie2">'. _('mardi_1c') .'</td>
-		<td class="cal-saisie2">'. _('mercredi_1c') .'</td>
-		<td class="cal-saisie2">'. _('jeudi_1c') .'</td>
-		<td class="cal-saisie2">'. _('vendredi_1c') .'</td>
-		<td class="cal-saisie2">'. _('samedi_1c') .'</td>
-		<td class="cal-saisie2">'. _('dimanche_1c') .'</td>
-		</tr>
-		</thead>
-		<tbody>';
-	$start_nb_day_before = $first_jour_mois_rang -1;
-	$stop_nb_day_before = 7 - $last_jour_mois_rang ;
+    echo '<table class="calendrier_saisie_date_debut" cellpadding="0" cellspacing="0">
+        <thead>
+        <tr align="center" bgcolor="'.$_SESSION['config']['light_grey_bgcolor'].'">
+        <td colspan=7 class="titre"> '.$mois_name.' '.$year.' </td>
+        </tr>
+        <tr bgcolor="'.$_SESSION['config']['light_grey_bgcolor'].'">
+        <td class="cal-saisie2">'. _('lundi_1c') .'</td>
+        <td class="cal-saisie2">'. _('mardi_1c') .'</td>
+        <td class="cal-saisie2">'. _('mercredi_1c') .'</td>
+        <td class="cal-saisie2">'. _('jeudi_1c') .'</td>
+        <td class="cal-saisie2">'. _('vendredi_1c') .'</td>
+        <td class="cal-saisie2">'. _('samedi_1c') .'</td>
+        <td class="cal-saisie2">'. _('dimanche_1c') .'</td>
+        </tr>
+        </thead>
+        <tbody>';
+    $start_nb_day_before = $first_jour_mois_rang -1;
+    $stop_nb_day_before = 7 - $last_jour_mois_rang ;
 
-	for ( $i = - $start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i ++) {
-		if ( ($i + $start_nb_day_before ) % 7 == 0)
-			echo '<tr>';
-		$j_timestamp=mktime (0,0,0,$mois, $i +1 ,$year);
-		$td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
-				if ($i < 0 || $i > $nb_jours_mois )
-					echo '<td class="'.$td_second_class.'">-</td>';
-				else
-					affiche_cellule_jour_cal_saisie($user_login, $j_timestamp, $td_second_class, $type_debut_fin , $DEBUG);
-				if ( ($i + $start_nb_day_before ) % 7 == 6)
-					echo '<tr>';
-	}
-	echo '</tbody></table>';
+    for ( $i = - $start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i ++) {
+        if ( ($i + $start_nb_day_before ) % 7 == 0)
+            echo '<tr>';
+        $j_timestamp=mktime (0,0,0,$mois, $i +1 ,$year);
+        $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
+                if ($i < 0 || $i > $nb_jours_mois )
+                    echo '<td class="'.$td_second_class.'">-</td>';
+                else
+                    affiche_cellule_jour_cal_saisie($user_login, $j_timestamp, $td_second_class, $type_debut_fin , $DEBUG);
+                if ( ($i + $start_nb_day_before ) % 7 == 6)
+                    echo '<tr>';
+    }
+    echo '</tbody></table>';
 }
 
 function affiche_cellule_calendrier_echange_absence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $j, $DEBUG=FALSE)
 {
-	$bgcolor=$_SESSION['config']['temps_partiel_bgcolor'];
-	if( $val_matin == 'Y' && $val_aprem == 'Y')
-		echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-j"></td>';
-	elseif( $val_matin == 'Y' && $val_aprem == 'N' )
-		echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_rtt_am_travail_pm_w35">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-a"></td>';
-	elseif( $val_matin == 'N' && $val_aprem == 'Y' )
-		echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_travail_am_rtt_pm_w35">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-p"></td>';
-	else {
-		$bgcolor=$_SESSION['config']['semaine_bgcolor'];
-		echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'</td>';
-	}
+    $bgcolor=$_SESSION['config']['temps_partiel_bgcolor'];
+    if( $val_matin == 'Y' && $val_aprem == 'Y')
+        echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-j"></td>';
+    elseif( $val_matin == 'Y' && $val_aprem == 'N' )
+        echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_rtt_am_travail_pm_w35">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-a"></td>';
+    elseif( $val_matin == 'N' && $val_aprem == 'Y' )
+        echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_travail_am_rtt_pm_w35">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-p"></td>';
+    else {
+        $bgcolor=$_SESSION['config']['semaine_bgcolor'];
+        echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'</td>';
+    }
 }
 
 function affiche_cellule_calendrier_echange_presence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $j, $DEBUG=FALSE)
 {
-	$bgcolor = $_SESSION['config']['temps_partiel_bgcolor'];
-	if( $val_matin == 'Y' && $val_aprem == 'Y' )  // rtt le matin et l'apres midi !
-		echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'</td>';
-	elseif( $val_matin == 'Y' && $val_aprem == 'N' )
-		echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_rtt_am_travail_pm_w35">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-p"></td>';
-	elseif( $val_matin == 'N' && $val_aprem == 'Y' )
-		echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_travail_am_rtt_pm_w35">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-a"></td>';
-	else
-	{
-		$bgcolor = $_SESSION['config']['semaine_bgcolor'];
-		echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-j"></td>';
-	}
+    $bgcolor = $_SESSION['config']['temps_partiel_bgcolor'];
+    if( $val_matin == 'Y' && $val_aprem == 'Y' )  // rtt le matin et l'apres midi !
+        echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'</td>';
+    elseif( $val_matin == 'Y' && $val_aprem == 'N' )
+        echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_rtt_am_travail_pm_w35">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-p"></td>';
+    elseif( $val_matin == 'N' && $val_aprem == 'Y' )
+        echo '<td bgcolor='.$bgcolor.' class="cal-day_semaine_travail_am_rtt_pm_w35">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-a"></td>';
+    else
+    {
+        $bgcolor = $_SESSION['config']['semaine_bgcolor'];
+        echo '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-j"></td>';
+    }
 }
 
 // retourne le nom du jour de la semaine en francais sur 2 caracteres
 function get_j_name_fr_2c($timestamp)
 {
-	$jour_name_fr_2c=array(0=>'di',1=>'lu', 2=>'ma',3=>'me',4=>'je',5=>'ve',6=>'sa',);
-	$jour_num=date('w', $timestamp);
-	if (isset($jour_name_fr_2c[$jour_num]))
-		return $jour_name_fr_2c[$jour_num];
-	else
-		return false;
+    $jour_name_fr_2c=array(0=>'di',1=>'lu', 2=>'ma',3=>'me',4=>'je',5=>'ve',6=>'sa',);
+    $jour_num=date('w', $timestamp);
+    if (isset($jour_name_fr_2c[$jour_num]))
+        return $jour_name_fr_2c[$jour_num];
+    else
+        return false;
 }
 
 
 //affiche le formulaire de saisie d'une nouvelle demande de conges
 function saisie_nouveau_conges($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet,  $DEBUG=FALSE)
 {
-	//$DEBUG=TRUE;
-	if( $DEBUG ) { echo 'user_login = '.$user_login.', year_calendrier_saisie_debut = '.$year_calendrier_saisie_debut.', mois_calendrier_saisie_debut = '.$mois_calendrier_saisie_debut.',year_calendrier_saisie_fin = '.$year_calendrier_saisie_fin.', mois_calendrier_saisie_fin = '.$mois_calendrier_saisie_fin.', onglet = '.$onglet.'<br>';}
+    //$DEBUG=TRUE;
+    if( $DEBUG ) { echo 'user_login = '.$user_login.', year_calendrier_saisie_debut = '.$year_calendrier_saisie_debut.', mois_calendrier_saisie_debut = '.$mois_calendrier_saisie_debut.',year_calendrier_saisie_fin = '.$year_calendrier_saisie_fin.', mois_calendrier_saisie_fin = '.$mois_calendrier_saisie_fin.', onglet = '.$onglet.'<br>';}
 
-	$PHP_SELF=$_SERVER['PHP_SELF'];
-	$session=session_id();
-	$mois_calendrier_saisie_debut_prec=0; $year_calendrier_saisie_debut_prec=0;
-	$mois_calendrier_saisie_debut_suiv=0; $year_calendrier_saisie_debut_suiv=0;
-	$mois_calendrier_saisie_fin_prec=0; $year_calendrier_saisie_fin_prec=0;
-	$mois_calendrier_saisie_fin_suiv=0; $year_calendrier_saisie_fin_suiv=0;
-	init_tab_jours_fermeture($user_login);
+    $PHP_SELF=$_SERVER['PHP_SELF'];
+    $session=session_id();
+    $mois_calendrier_saisie_debut_prec=0; $year_calendrier_saisie_debut_prec=0;
+    $mois_calendrier_saisie_debut_suiv=0; $year_calendrier_saisie_debut_suiv=0;
+    $mois_calendrier_saisie_fin_prec=0; $year_calendrier_saisie_fin_prec=0;
+    $mois_calendrier_saisie_fin_suiv=0; $year_calendrier_saisie_fin_suiv=0;
+    init_tab_jours_fermeture($user_login);
 
-	echo '<form NAME="dem_conges" action="'.$PHP_SELF.'?session='.$session.'&onglet='.$onglet.'" method="POST">' ;
-	// il faut indiquer le champ de formulaire 'login_user' car il est récupéré par le javascript qui apelle le calcul automatique.
-	// echo '<input type="hidden" name="login_user" value="'.$user_login.'">';
+    echo '<form NAME="dem_conges" action="'.$PHP_SELF.'?session='.$session.'&onglet='.$onglet.'" method="POST">' ;
+    // il faut indiquer le champ de formulaire 'login_user' car il est récupéré par le javascript qui apelle le calcul automatique.
+    // echo '<input type="hidden" name="login_user" value="'.$user_login.'">';
 
-	echo '<table cellpadding="0" cellspacing="5" border="0">';
-	echo '<tr align="center">';
-	echo '<td>';
-	echo '<table cellpadding="0" cellspacing="0" border="0">';
-	echo '<tr align="center">';
-	echo '<td>';
-	echo '<fieldset class="cal_saisie">';
-	echo '<table cellpadding="0" cellspacing="0" border="0">';
-	echo '<tr align="center">';
-	echo "<td>\n";
-	/******************************************************************/
-	// affichage du calendrier de saisie de la date de DEBUT de congès
-	/******************************************************************/
-	echo '<table cellpadding="0" cellspacing="0" width="250" border="0">';
-	echo '<tr>';
-	init_var_navigation_mois_year($mois_calendrier_saisie_debut, $year_calendrier_saisie_debut,
-					$mois_calendrier_saisie_debut_prec, $year_calendrier_saisie_debut_prec,
-					$mois_calendrier_saisie_debut_suiv, $year_calendrier_saisie_debut_suiv,
-					$mois_calendrier_saisie_fin, $year_calendrier_saisie_fin,
-					$mois_calendrier_saisie_fin_prec, $year_calendrier_saisie_fin_prec,
-					$mois_calendrier_saisie_fin_suiv, $year_calendrier_saisie_fin_suiv );
+    echo '<table cellpadding="0" cellspacing="5" border="0">';
+    echo '<tr align="center">';
+    echo '<td>';
+    echo '<table cellpadding="0" cellspacing="0" border="0">';
+    echo '<tr align="center">';
+    echo '<td>';
+    echo '<fieldset class="cal_saisie">';
+    echo '<table cellpadding="0" cellspacing="0" border="0">';
+    echo '<tr align="center">';
+    echo "<td>\n";
+    /******************************************************************/
+    // affichage du calendrier de saisie de la date de DEBUT de congès
+    /******************************************************************/
+    echo '<table cellpadding="0" cellspacing="0" width="250" border="0">';
+    echo '<tr>';
+    init_var_navigation_mois_year($mois_calendrier_saisie_debut, $year_calendrier_saisie_debut,
+                    $mois_calendrier_saisie_debut_prec, $year_calendrier_saisie_debut_prec,
+                    $mois_calendrier_saisie_debut_suiv, $year_calendrier_saisie_debut_suiv,
+                    $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin,
+                    $mois_calendrier_saisie_fin_prec, $year_calendrier_saisie_fin_prec,
+                    $mois_calendrier_saisie_fin_suiv, $year_calendrier_saisie_fin_suiv );
 
-	// affichage des boutons de défilement
-	// recul du mois saisie début
-	echo '<td align="center" class="big">';
-	echo '<a href="'.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut_prec.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut_prec.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin.'&user_login='.$user_login.'&onglet='.$onglet.'">';
-	echo ' <img src="'. TEMPLATE_PATH . 'img/simfirs.gif" width="16" height="16" border="0" alt="'. _('divers_mois_precedent') .'" title="'. _('divers_mois_precedent') .'"> ';
-	echo '</a>';
-	echo '</td>';
-	echo '<td align="center" class="big">'. _('divers_debut_maj') .' :</td>';
+    // affichage des boutons de défilement
+    // recul du mois saisie début
+    echo '<td align="center" class="big">';
+    echo '<a href="'.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut_prec.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut_prec.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin.'&user_login='.$user_login.'&onglet='.$onglet.'">';
+    echo ' <img src="'. TEMPLATE_PATH . 'img/simfirs.gif" width="16" height="16" border="0" alt="'. _('divers_mois_precedent') .'" title="'. _('divers_mois_precedent') .'"> ';
+    echo '</a>';
+    echo '</td>';
+    echo '<td align="center" class="big">'. _('divers_debut_maj') .' :</td>';
 
-	// affichage des boutons de défilement
-	// avance du mois saisie début
-	// si le mois de saisie fin est antérieur ou égal au mois de saisie début, on avance les 2 , sinon on avance que le mois de saisie début
-	if( (($year_calendrier_saisie_debut_suiv==$year_calendrier_saisie_fin) && ($mois_calendrier_saisie_debut_suiv>=$mois_calendrier_saisie_fin)) || ($year_calendrier_saisie_debut_suiv>$year_calendrier_saisie_fin) )
-		$lien_mois_debut_suivant = $PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut_suiv.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut_suiv.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_debut_suiv.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_debut_suiv.'&user_login='.$user_login.'&onglet='.$onglet ;
-	else
-		$lien_mois_debut_suivant = $PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut_suiv.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut_suiv.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin.'&user_login='.$user_login.'&onglet='.$onglet ;
+    // affichage des boutons de défilement
+    // avance du mois saisie début
+    // si le mois de saisie fin est antérieur ou égal au mois de saisie début, on avance les 2 , sinon on avance que le mois de saisie début
+    if( (($year_calendrier_saisie_debut_suiv==$year_calendrier_saisie_fin) && ($mois_calendrier_saisie_debut_suiv>=$mois_calendrier_saisie_fin)) || ($year_calendrier_saisie_debut_suiv>$year_calendrier_saisie_fin) )
+        $lien_mois_debut_suivant = $PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut_suiv.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut_suiv.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_debut_suiv.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_debut_suiv.'&user_login='.$user_login.'&onglet='.$onglet ;
+    else
+        $lien_mois_debut_suivant = $PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut_suiv.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut_suiv.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin.'&user_login='.$user_login.'&onglet='.$onglet ;
 
-	echo '<td align="center" class="big">';
-	echo '<a href="'.$lien_mois_debut_suivant.'">';
-	echo ' <img src="'. TEMPLATE_PATH . 'img/simlast.gif" width="16" height="16" border="0" alt="'. _('divers_mois_suivant') .'" title="'. _('divers_mois_suivant') .'"> ';
-	echo '</a>';
-	echo '</td>';
-	echo '</tr>';
-	echo '</table>';
-	/*** calendrier saisie date debut ***/
-	affiche_calendrier_saisie_date($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, 'new_debut', $DEBUG);
-	echo '</td>';
-	/**************************************************/
-	/* cellule 2 : boutons radio matin ou après midi */
-	echo '<td align="left">';
-	echo '<input type="radio" name="new_demi_jour_deb" ';
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		// attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-		if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-			echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
-		else
-			echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
-	}
+    echo '<td align="center" class="big">';
+    echo '<a href="'.$lien_mois_debut_suivant.'">';
+    echo ' <img src="'. TEMPLATE_PATH . 'img/simlast.gif" width="16" height="16" border="0" alt="'. _('divers_mois_suivant') .'" title="'. _('divers_mois_suivant') .'"> ';
+    echo '</a>';
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+    /*** calendrier saisie date debut ***/
+    affiche_calendrier_saisie_date($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, 'new_debut', $DEBUG);
+    echo '</td>';
+    /**************************************************/
+    /* cellule 2 : boutons radio matin ou après midi */
+    echo '<td align="left">';
+    echo '<input type="radio" name="new_demi_jour_deb" ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
+            echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
+        else
+            echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
+    }
 
-	echo 'value="am" checked><b><u>'. _('form_am') .'</u></b><br><br>';
-	echo '<input type="radio" name="new_demi_jour_deb" ';
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-			echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
-		else
-			echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
-	}
+    echo 'value="am" checked><b><u>'. _('form_am') .'</u></b><br><br>';
+    echo '<input type="radio" name="new_demi_jour_deb" ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
+            echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
+        else
+            echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
+    }
 
-	echo 'value="pm"><b><u>'. _('form_pm') .'</u></b><br><br>';
-	echo '</td>';
-	/**************************************************/
-	echo '</tr>';
-	echo '</table>';
-	echo '</fieldset>';
-	echo '</td>';
-	echo '</tr>';
-	echo '<tr align="center">';
-	echo '<td><img src="'. TEMPLATE_PATH . 'img/shim.gif" width="15" height="10" border="0" vspace="0" hspace="0"></td>';
-	echo '</tr>';
-	echo '<tr align="center">';
-	echo '<td>';
-	echo '<fieldset class="cal_saisie">';
-	echo '<table cellpadding="0" cellspacing="0" border="0">';
-	echo '<tr align="center">';
-	echo '<td>';
-	/******************************************************************/
-	// affichage du calendrier de saisie de la date de FIN de congès
-	/******************************************************************/
-	echo '<table cellpadding="0" cellspacing="0" width="250" border="0">';
-	echo '<tr>';
-	$mois_calendrier_saisie_fin_prec = $mois_calendrier_saisie_fin==1 ? 12 : $mois_calendrier_saisie_fin-1 ;
-	$mois_calendrier_saisie_fin_suiv = $mois_calendrier_saisie_fin==12 ? 1 : $mois_calendrier_saisie_fin+1 ;
+    echo 'value="pm"><b><u>'. _('form_pm') .'</u></b><br><br>';
+    echo '</td>';
+    /**************************************************/
+    echo '</tr>';
+    echo '</table>';
+    echo '</fieldset>';
+    echo '</td>';
+    echo '</tr>';
+    echo '<tr align="center">';
+    echo '<td><img src="'. TEMPLATE_PATH . 'img/shim.gif" width="15" height="10" border="0" vspace="0" hspace="0"></td>';
+    echo '</tr>';
+    echo '<tr align="center">';
+    echo '<td>';
+    echo '<fieldset class="cal_saisie">';
+    echo '<table cellpadding="0" cellspacing="0" border="0">';
+    echo '<tr align="center">';
+    echo '<td>';
+    /******************************************************************/
+    // affichage du calendrier de saisie de la date de FIN de congès
+    /******************************************************************/
+    echo '<table cellpadding="0" cellspacing="0" width="250" border="0">';
+    echo '<tr>';
+    $mois_calendrier_saisie_fin_prec = $mois_calendrier_saisie_fin==1 ? 12 : $mois_calendrier_saisie_fin-1 ;
+    $mois_calendrier_saisie_fin_suiv = $mois_calendrier_saisie_fin==12 ? 1 : $mois_calendrier_saisie_fin+1 ;
 
-	// affichage des boutons de défilement
-	// recul du mois saisie fin
-	// si le mois de saisie fin est antérieur ou égal au mois de saisie début, on recule les 2 , sinon on recule que le mois de saisie fin
-	if( (($year_calendrier_saisie_debut==$year_calendrier_saisie_fin_prec) && ($mois_calendrier_saisie_debut>=$mois_calendrier_saisie_fin_prec)) || ($year_calendrier_saisie_debut>$year_calendrier_saisie_fin_prec) )
-		$lien_mois_fin_precedent = ''.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_fin_prec.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_prec.'&user_login='.$user_login.'&onglet='.$onglet;
-	else
-		$lien_mois_fin_precedent = ''.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_prec.'&user_login='.$user_login.'&onglet='.$onglet;
+    // affichage des boutons de défilement
+    // recul du mois saisie fin
+    // si le mois de saisie fin est antérieur ou égal au mois de saisie début, on recule les 2 , sinon on recule que le mois de saisie fin
+    if( (($year_calendrier_saisie_debut==$year_calendrier_saisie_fin_prec) && ($mois_calendrier_saisie_debut>=$mois_calendrier_saisie_fin_prec)) || ($year_calendrier_saisie_debut>$year_calendrier_saisie_fin_prec) )
+        $lien_mois_fin_precedent = ''.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_fin_prec.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_prec.'&user_login='.$user_login.'&onglet='.$onglet;
+    else
+        $lien_mois_fin_precedent = ''.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_prec.'&user_login='.$user_login.'&onglet='.$onglet;
 
-	echo '<td align="center" class="big">';
-	echo '<a href="'.$lien_mois_fin_precedent.'">';
-	echo ' <img src="'. TEMPLATE_PATH . 'img/simfirs.gif" width="16" height="16" border="0" alt="'. _('divers_mois_precedent') .'" title="'. _('divers_mois_precedent') .'">';
-	echo ' </a>';
-	echo '</td>';
-	echo '<td align="center" class="big">'. _('divers_fin_maj') .' :</td>';
+    echo '<td align="center" class="big">';
+    echo '<a href="'.$lien_mois_fin_precedent.'">';
+    echo ' <img src="'. TEMPLATE_PATH . 'img/simfirs.gif" width="16" height="16" border="0" alt="'. _('divers_mois_precedent') .'" title="'. _('divers_mois_precedent') .'">';
+    echo ' </a>';
+    echo '</td>';
+    echo '<td align="center" class="big">'. _('divers_fin_maj') .' :</td>';
 
-	// affichage des boutons de défilement
-	// avance du mois saisie fin
-	echo '<td align="center" class="big">';
-	echo '<a href="'.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_suiv.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_suiv.'&user_login='.$user_login.'&onglet='.$onglet.'">';
-	echo ' <img src="'. TEMPLATE_PATH . 'img/simlast.gif" width="16" height="16" border="0" alt="'. _('divers_mois_suivant') .'" title="'. _('divers_mois_suivant') .'"> ';
-	echo '</a>';
-	echo '</td>';
-	echo '</tr>';
-	echo '</table>';
-	/*** calendrier saisie date fin ***/
-	affiche_calendrier_saisie_date($user_login, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, 'new_fin',  $DEBUG);
-	echo '</td>';
-	/**************************************************/
-	/* cellule 2 : boutons radio matin ou après midi */
-	echo '<td align="left">';
-	echo '<input type="radio" name="new_demi_jour_fin" ';
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		// attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-		if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-			echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
-		else
-			echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
-	}
-	echo 'value="am"><b><u>'. _('form_am') .'</u></b><br><br>';
-	echo '<input type="radio" name="new_demi_jour_fin"  ';
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-			echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
-		else
-			echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
-	}
-	echo 'value="pm" checked><b><u>'. _('form_pm') .'</u></b><br><br>';
-	echo '</td>';
-	/**************************************************/
-	echo '</tr>';
-	echo '</table>';
-	echo '</fieldset>';
-	echo '</td>';
-	echo '</tr>';
-	echo '</table>';
-	echo '</td>';
-	echo '<td><img src="'. TEMPLATE_PATH . 'img/shim.gif" width="15" height="2" border="0" vspace="0" hspace="0"></td>';
-	echo '<td>';
+    // affichage des boutons de défilement
+    // avance du mois saisie fin
+    echo '<td align="center" class="big">';
+    echo '<a href="'.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_suiv.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_suiv.'&user_login='.$user_login.'&onglet='.$onglet.'">';
+    echo ' <img src="'. TEMPLATE_PATH . 'img/simlast.gif" width="16" height="16" border="0" alt="'. _('divers_mois_suivant') .'" title="'. _('divers_mois_suivant') .'"> ';
+    echo '</a>';
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+    /*** calendrier saisie date fin ***/
+    affiche_calendrier_saisie_date($user_login, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, 'new_fin',  $DEBUG);
+    echo '</td>';
+    /**************************************************/
+    /* cellule 2 : boutons radio matin ou après midi */
+    echo '<td align="left">';
+    echo '<input type="radio" name="new_demi_jour_fin" ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
+            echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
+        else
+            echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
+    }
+    echo 'value="am"><b><u>'. _('form_am') .'</u></b><br><br>';
+    echo '<input type="radio" name="new_demi_jour_fin"  ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
+            echo 'onClick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return true;"' ;
+        else
+            echo 'onChange="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;"' ;
+    }
+    echo 'value="pm" checked><b><u>'. _('form_pm') .'</u></b><br><br>';
+    echo '</td>';
+    /**************************************************/
+    echo '</tr>';
+    echo '</table>';
+    echo '</fieldset>';
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+    echo '</td>';
+    echo '<td><img src="'. TEMPLATE_PATH . 'img/shim.gif" width="15" height="2" border="0" vspace="0" hspace="0"></td>';
+    echo '<td>';
 
-	/*******************/
-	/*   formulaire   .*/
-	/*******************/
-	echo '<table cellpadding="0" cellspacing="2" border="0" >';
-	echo '<tr>';
-	echo '<td valign="top">';
-	echo '<table cellpadding="2" cellspacing="3" border="0" >';
-	//echo '<input type="hidden" name="login_user" value="'.'.$_SESSION['userlogin'].'.'">';
-	echo '<input type="hidden" name="login_user" value="'.$user_login.'">';
-	echo '<input type="hidden" name="session" value="'.$session.'">';
-	// bouton 'compter les jours'
-	if($_SESSION['config']['affiche_bouton_calcul_nb_jours_pris'])
-	{
-		echo '<tr><td colspan="2">';
-		echo '<input type="button" onclick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;" value="'. _('saisie_conges_compter_jours') .'">';
-		echo '</td></tr>';
-	}
-	// zones de texte
-	echo '<tr align="center"><td><b>'. _('saisie_conges_nb_jours') .'</b></td><td><b>'. _('divers_comment_maj_1') .'</b></td></tr>';
-	if($_SESSION['config']['disable_saise_champ_nb_jours_pris'])  // zone de texte en readonly et grisée
-		$text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="" style="background-color: #D4D4D4; " readonly="readonly">' ;
-	else
-		$text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="">' ;
+    /*******************/
+    /*   formulaire   .*/
+    /*******************/
+    echo '<table cellpadding="0" cellspacing="2" border="0" >';
+    echo '<tr>';
+    echo '<td valign="top">';
+    echo '<table cellpadding="2" cellspacing="3" border="0" >';
+    //echo '<input type="hidden" name="login_user" value="'.'.$_SESSION['userlogin'].'.'">';
+    echo '<input type="hidden" name="login_user" value="'.$user_login.'">';
+    echo '<input type="hidden" name="session" value="'.$session.'">';
+    // bouton 'compter les jours'
+    if($_SESSION['config']['affiche_bouton_calcul_nb_jours_pris'])
+    {
+        echo '<tr><td colspan="2">';
+        echo '<input type="button" onclick="compter_jours(new_debut, new_fin, login_user, new_demi_jour_deb, new_demi_jour_fin);return false;" value="'. _('saisie_conges_compter_jours') .'">';
+        echo '</td></tr>';
+    }
+    // zones de texte
+    echo '<tr align="center"><td><b>'. _('saisie_conges_nb_jours') .'</b></td><td><b>'. _('divers_comment_maj_1') .'</b></td></tr>';
+    if($_SESSION['config']['disable_saise_champ_nb_jours_pris'])  // zone de texte en readonly et grisée
+        $text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="" style="background-color: #D4D4D4; " readonly="readonly">' ;
+    else
+        $text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="">' ;
 
-	$text_commentaire='<input type="text" name="new_comment" size="25" maxlength="30" value="">' ;
-	echo '<tr align="center">';
-	echo '<td>'.($text_nb_jours).'</td><td>'.($text_commentaire).'</td>';
-	echo '</tr>';
-	echo '<tr align="center"><td><img src="'. TEMPLATE_PATH . 'img/shim.gif" width="15" height="10" border="0" vspace="0" hspace="0"></td><td></td></tr>';
-	echo '<tr align="center">';
-	echo '<td colspan=2>';
-	echo '<input type="hidden" name="user_login" value="'.$user_login.'">';
-	echo '<input type="hidden" name="new_demande_conges" value=1>';
-	// boutons du formulaire
-	// les classes "button_type_submit" et "button_type_cancel"
-	// servent à choisir leur position (droite gauche) dans vos feuilles de style (voir style.css)
-	echo '<input type="submit" class="button_type_submit" value="'. _('form_submit') .'">   <input type="reset" class="button_type_cancel" value="'. _('form_cancel') .'">';
-	echo '</td>';
-	echo '</tr>';
-	echo '</table>';
-	echo '</td>';
-	/*****************/
-	/* boutons radio */
-	/*****************/
-	// recup d tableau des types de conges
-	$tab_type_conges=recup_tableau_types_conges( $DEBUG);
-	// recup du tableau des types d'absence
-	$tab_type_absence=recup_tableau_types_absence( $DEBUG);
-	// recup d tableau des types de conges exceptionnels
-	$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
-	$already_checked = false;
+    $text_commentaire='<input type="text" name="new_comment" size="25" maxlength="30" value="">' ;
+    echo '<tr align="center">';
+    echo '<td>'.($text_nb_jours).'</td><td>'.($text_commentaire).'</td>';
+    echo '</tr>';
+    echo '<tr align="center"><td><img src="'. TEMPLATE_PATH . 'img/shim.gif" width="15" height="10" border="0" vspace="0" hspace="0"></td><td></td></tr>';
+    echo '<tr align="center">';
+    echo '<td colspan=2>';
+    echo '<input type="hidden" name="user_login" value="'.$user_login.'">';
+    echo '<input type="hidden" name="new_demande_conges" value=1>';
+    // boutons du formulaire
+    // les classes "button_type_submit" et "button_type_cancel"
+    // servent à choisir leur position (droite gauche) dans vos feuilles de style (voir style.css)
+    echo '<input type="submit" class="button_type_submit" value="'. _('form_submit') .'">   <input type="reset" class="button_type_cancel" value="'. _('form_cancel') .'">';
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+    echo '</td>';
+    /*****************/
+    /* boutons radio */
+    /*****************/
+    // recup d tableau des types de conges
+    $tab_type_conges=recup_tableau_types_conges( $DEBUG);
+    // recup du tableau des types d'absence
+    $tab_type_absence=recup_tableau_types_absence( $DEBUG);
+    // recup d tableau des types de conges exceptionnels
+    $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
+    $already_checked = false;
 
-	echo '<td align="left" valign="top">';
-	// si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
-	// OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
-	// OU si le user est un RH ou un admin
-	if( ( $_SESSION['config']['user_saisie_demande'] && $user_login==$_SESSION['userlogin'] ) || ( $_SESSION['config']['user_saisie_demande']==FALSE && $user_login!=$_SESSION['userlogin'] ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
-	{
-		// congés
-		echo '<b><i><u>'. _('divers_conges') .' :</u></i></b><br>';
-		foreach($tab_type_conges as $id => $libelle)
-		{
-			if($id==1)
-			{
-				echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
-				$already_checked = true;
-			}
-			else
-				echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
-		}
-	}
-	// si le user a droit de saisir une mission ET si on est PAS dans une fenetre de responsable
-	// OU si le resp a droit de saisir une mission ET si on est PAS dans une fenetre dd'utilisateur
-	// OU si le resp a droit de saisir une mission ET si le resp est resp de lui meme
-	if( (($_SESSION['config']['user_saisie_mission'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&($user_login!=$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&(is_resp_of_user($_SESSION['userlogin'], $user_login,  $DEBUG))) )
-	{
-		echo '<br>';
-		// absences
-		echo '<b><i><u>'. _('divers_absences') .' :</u></i></b><br>';
-		foreach($tab_type_absence as $id => $libelle)
-		{
-			if (!$already_checked)
-			{
-				echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
-				$already_checked = true;
-			}
-			else
-				echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
-		}
-	}
-	// si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
-	// OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
-	if( ($_SESSION['config']['gestion_conges_exceptionnels']) && ((($_SESSION['config']['user_saisie_demande'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['user_saisie_demande']==FALSE)&&($user_login!=$_SESSION['userlogin'])) ) )
-	{
-		echo '<br>';
-		// congés exceptionnels
-		echo '<b><i><u>'. _('divers_conges_exceptionnels') .' :</u></i></b><br>';
-		foreach($tab_type_conges_exceptionnels as $id => $libelle)
-		{
-			if($id==1)
-				echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
-			 else
-				echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
-		}
-	}
+    echo '<td align="left" valign="top">';
+    // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
+    // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
+    // OU si le user est un RH ou un admin
+    if( ( $_SESSION['config']['user_saisie_demande'] && $user_login==$_SESSION['userlogin'] ) || ( $_SESSION['config']['user_saisie_demande']==FALSE && $user_login!=$_SESSION['userlogin'] ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
+    {
+        // congés
+        echo '<b><i><u>'. _('divers_conges') .' :</u></i></b><br>';
+        foreach($tab_type_conges as $id => $libelle)
+        {
+            if($id==1)
+            {
+                echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
+                $already_checked = true;
+            }
+            else
+                echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
+        }
+    }
+    // si le user a droit de saisir une mission ET si on est PAS dans une fenetre de responsable
+    // OU si le resp a droit de saisir une mission ET si on est PAS dans une fenetre dd'utilisateur
+    // OU si le resp a droit de saisir une mission ET si le resp est resp de lui meme
+    if( (($_SESSION['config']['user_saisie_mission'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&($user_login!=$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&(is_resp_of_user($_SESSION['userlogin'], $user_login,  $DEBUG))) )
+    {
+        echo '<br>';
+        // absences
+        echo '<b><i><u>'. _('divers_absences') .' :</u></i></b><br>';
+        foreach($tab_type_absence as $id => $libelle)
+        {
+            if (!$already_checked)
+            {
+                echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
+                $already_checked = true;
+            }
+            else
+                echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
+        }
+    }
+    // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
+    // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
+    if( ($_SESSION['config']['gestion_conges_exceptionnels']) && ((($_SESSION['config']['user_saisie_demande'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['user_saisie_demande']==FALSE)&&($user_login!=$_SESSION['userlogin'])) ) )
+    {
+        echo '<br>';
+        // congés exceptionnels
+        echo '<b><i><u>'. _('divers_conges_exceptionnels') .' :</u></i></b><br>';
+        foreach($tab_type_conges_exceptionnels as $id => $libelle)
+        {
+            if($id==1)
+                echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
+             else
+                echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
+        }
+    }
 
-	echo '</td>';
-	echo '</tr>';
-	echo '</table>';
-	echo '</td>';
-	echo '</tr>';
-	echo '</table>';
-	echo '</form>' ;
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+    echo '</td>';
+    echo '</tr>';
+    echo '</table>';
+    echo '</form>' ;
 }
 
 function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet,  $DEBUG=FALSE)
 {
-	$PHP_SELF=$_SERVER['PHP_SELF'];
-	$session=session_id();
-	$new_date_fin = date('d/m/Y');
+    $PHP_SELF=$_SERVER['PHP_SELF'];
+    $session=session_id();
+    $new_date_fin = date('d/m/Y');
+    $return = '';
 
-	echo '<form NAME="dem_conges" action="'.$PHP_SELF.'?session='.$session.'&onglet='.$onglet.'" method="POST">
-		<div class="row">
-		<div class="col-md-6">
-		<div class="form-inline">';
-	echo "<div class=\"form-group\">\n
-		<label for=\"new_deb\">" . _('divers_date_debut') . "</label><input type=\"text\" class=\"form-control date\" name=\"new_debut\" value=\"$new_date_fin\">\n
-		</div>";
-	echo '<input type="radio" name="new_demi_jour_deb" ';
+    $return .= '<form NAME="dem_conges" action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">
+        <div class="row">
+        <div class="col-md-6">
+        <div class="form-inline">';
+    $return .= '<div class="form-group"><label for="new_deb">' . _('divers_date_debut') . '</label><input type="text" class="form-control date" name="new_debut" value="' . $new_date_fin . '"></div>';
+    $return .= '<input type="radio" name="new_demi_jour_deb" ';
 
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-	// attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-	if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-		echo 'onClick="compter_jours();return true;"' ;
-	else
-		echo 'onChange="compter_jours();return false;"' ;
-	}
-	echo 'value="am" checked>&nbsp;'. _('form_am');
-	echo '<input type="radio" name="new_demi_jour_deb" ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
+            $return .= 'onClick="compter_jours();return true;"';
+        } else {
+            $return .= 'onChange="compter_jours();return false;"';
+        }
+    }
+    $return .= 'value="am" checked>&nbsp;' .  _('form_am');
+    $return .= '<input type="radio" name="new_demi_jour_deb" ';
 
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-			echo 'onClick="compter_jours();return true;"' ;
-		else
-			echo 'onChange="compter_jours();return false;"' ;
-	}
-	echo 'value="pm">&nbsp;'. _('form_pm');
-	echo '</div>';
-	echo '</div>';
-	echo '<div class="col-md-6">';
-	echo '<div class="form-inline">';
-	echo "<div class=\"form-group\">\n";
-	echo "<label for=\"new_fin\">" . _('divers_date_fin') . "</label><input type=\"text\" class=\"form-control date\" name=\"new_fin\" value=\"$new_date_fin\">\n";
-	echo "</div>";
-	echo '<input type="radio" name="new_demi_jour_fin" ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
+            $return .= 'onClick="compter_jours();return true;"';
+        } else {
+            $return .= 'onChange="compter_jours();return false;"';
+        }
+    }
+    $return .= 'value="pm">&nbsp;' .  _('form_pm');
+    $return .= '</div>';
+    $return .= '</div>';
+    $return .= '<div class="col-md-6">';
+    $return .= '<div class="form-inline">';
+    $return .= '<div class="form-group">';
+    $return .= '<label for="new_fin">' . _('divers_date_fin') . '</label><input type="text" class="form-control date" name="new_fin" value="' . $new_date_fin . '">';
+    $return .= '</div>';
+    $return .= '<input type="radio" name="new_demi_jour_fin" ';
 
-	if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		// attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-		if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-			echo 'onClick="compter_jours();return true;"' ;
-		else
-			echo 'onChange="compter_jours();return false;"' ;
-		}
-		echo 'value="am">&nbsp;'. _('form_am');
-		echo '<input class="form-controm" type="radio" name="new_demi_jour_fin"  ';
+    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+    {
+        // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
+        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
+            $return .= 'onClick="compter_jours();return true;"' ;
+        } else {
+            $return .= 'onChange="compter_jours();return false;"' ;
+        }
+        $return .= 'value="am">&nbsp;'. _('form_am');
+        $return .= '<input class="form-controm" type="radio" name="new_demi_jour_fin" ';
 
-		if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-		{
-			if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-				echo 'onClick="compter_jours();return true;"' ;
-			else
-				echo 'onChange="compter_jours();return false;"' ;
-		}
-		echo 'value="pm" checked>&nbsp;'. _('form_pm');
-		echo '</div>';
-		echo '</div>';
-		echo '</div>';
-		echo "<hr/>\n";
+        if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+        {
+            if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
+                $return .= 'onClick="compter_jours();return true;"' ;
+            } else {
+                $return .= 'onChange="compter_jours();return false;"' ;
+            }
+        }
+        $return .= 'value="pm" checked>&nbsp;' . _('form_pm');
+        $return .= '</div>';
+        $return .= '</div>';
+        $return .= '</div>';
+        $return .= '<hr/>';
 
-		/*****************/
-		/* boutons radio */
-		/*****************/
-		// recup du tableau des types de conges
-		$tab_type_conges=recup_tableau_types_conges( $DEBUG);
-		// recup du tableau des types d'absence
-		$tab_type_absence=recup_tableau_types_absence( $DEBUG);
-		// recup d tableau des types de conges exceptionnels
-		$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
-		$already_checked = false;
+        /*****************/
+        /* boutons radio */
+        /*****************/
+        // recup du tableau des types de conges
+        $tab_type_conges=recup_tableau_types_conges( $DEBUG);
+        // recup du tableau des types d'absence
+        $tab_type_absence=recup_tableau_types_absence( $DEBUG);
+        // recup d tableau des types de conges exceptionnels
+        $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
+        $already_checked = false;
 
-		echo '<div class="row type-conges">';
-		// si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
-		// OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
-		// OU si le user est un RH ou un admin
-		if( ( $_SESSION['config']['user_saisie_demande'] && $user_login==$_SESSION['userlogin'] ) || ( $_SESSION['config']['user_saisie_demande']==FALSE && $user_login!=$_SESSION['userlogin'] ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
-		{
-			// congés
-			echo '<div class="col-md-4">';
-			echo '<label>'. _('divers_conges') .'</label>';
-			foreach($tab_type_conges as $id => $libelle)
-			{
-				if($id==1)
-				{
-					echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
-					$already_checked = true;
-				}
-				else
-					echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
-			}
-			echo '</div>';
-		}
+        $return .= '<div class="row type-conges">';
+        // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
+        // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
+        // OU si le user est un RH ou un admin
+        if( ( $_SESSION['config']['user_saisie_demande'] && $user_login==$_SESSION['userlogin'] ) || ( $_SESSION['config']['user_saisie_demande']==FALSE && $user_login!=$_SESSION['userlogin'] ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
+        {
+            // congés
+            $return .= '<div class="col-md-4">';
+            $return .= '<label>' . _('divers_conges') . '</label>';
+            foreach($tab_type_conges as $id => $libelle) {
+                if($id==1) {
+                    $return .= '<input type="radio" name="new_type" value="' . $id . '" checked>'. $libelle . '<br>';
+                    $already_checked = true;
+                } else {
+                    $return .= '<input type="radio" name="new_type" value="' . $id . '">' . $libelle . '<br>';
+                }
+            }
+            $return .= '</div>';
+        }
 
-		// si le user a droit de saisir une mission ET si on est PAS dans une fenetre de responsable
-		// OU si le resp a droit de saisir une mission ET si on est PAS dans une fenetre dd'utilisateur
-		// OU si le resp a droit de saisir une mission ET si le resp est resp de lui meme
-		if( (($_SESSION['config']['user_saisie_mission'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&($user_login!=$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&(is_resp_of_user($_SESSION['userlogin'], $user_login,  $DEBUG))) )
-		{
-			// absences
-			echo '<div class="col-md-4">';
-			echo '<label>'. _('divers_absences') .'</label>';
-			foreach($tab_type_absence as $id => $libelle) {
-				if (!$already_checked){
-					echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
-					$already_checked = true;
-				}
-				else
-					echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
-			}
-			echo '</div>';
-		}
+        // si le user a droit de saisir une mission ET si on est PAS dans une fenetre de responsable
+        // OU si le resp a droit de saisir une mission ET si on est PAS dans une fenetre dd'utilisateur
+        // OU si le resp a droit de saisir une mission ET si le resp est resp de lui meme
+        if( (($_SESSION['config']['user_saisie_mission'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&($user_login!=$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&(is_resp_of_user($_SESSION['userlogin'], $user_login,  $DEBUG))) )
+        {
+            // absences
+            $return .= '<div class="col-md-4">';
+            $return .= '<label>' . _('divers_absences') . '</label>';
+            foreach($tab_type_absence as $id => $libelle) {
+                if (!$already_checked) {
+                    $return .= '<input type="radio" name="new_type" value="' . $id . '" checked>' . $libelle . '<br>';
+                    $already_checked = true;
+                } else {
+                    $return .= '<input type="radio" name="new_type" value="' . $id . '">' . $libelle . '<br>';
+                }
+            }
+            $return .= '</div>';
+        }
 
-		// si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
-		// OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
-		if( ($_SESSION['config']['gestion_conges_exceptionnels']) && ((($_SESSION['config']['user_saisie_demande'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['user_saisie_demande']==FALSE)&&($user_login!=$_SESSION['userlogin'])) ) )
-		{
-		// congés exceptionnels
-		echo '<div class="col-md-4">';
-		echo '<label>'. _('divers_conges_exceptionnels') .'</label>';
-		foreach($tab_type_conges_exceptionnels as $id => $libelle) {
-			if($id==1) {
-				echo '<input type="radio" name="new_type" value="'.$id.'" checked> '.$libelle.'<br>';
-			}
-			else
-				echo '<input type="radio" name="new_type" value="'.$id.'"> '.$libelle.'<br>';
-		}
-		echo '</div>';
-	}
-	echo '</div>';
-	echo "<hr/>\n";
-	echo '<label>' . _('divers_comment_maj_1') . '</label><input class="form-control" type="text" name="new_comment" size="25" maxlength="30" value="">';
+        // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
+        // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
+        if( ($_SESSION['config']['gestion_conges_exceptionnels']) && ((($_SESSION['config']['user_saisie_demande'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['user_saisie_demande']==FALSE)&&($user_login!=$_SESSION['userlogin'])) ) )
+        {
+            // congés exceptionnels
+            $return .= '<div class="col-md-4">';
+            $return .= '<label>' . _('divers_conges_exceptionnels') . '</label>';
+            foreach($tab_type_conges_exceptionnels as $id => $libelle) {
+                if($id==1) {
+                    $return .= '<input type="radio" name="new_type" value="' . $id . '" checked> ' . $libelle . '<br>';
+                } else {
+                    $return .= '<input type="radio" name="new_type" value="' . $id . '">' . $libelle . '<br>';
+                }
+            }
+            $return .= '</div>';
+        }
+    }
+    $return .= '</div>';
+    $return .= '<hr/>';
+    $return .= '<label>' . _('divers_comment_maj_1') . '</label><input class="form-control" type="text" name="new_comment" size="25" maxlength="30" value="">';
 
-	// zones de texte
-	echo '<label>' . _('saisie_conges_nb_jours') .'&nbsp</label>';
-	if($_SESSION['config']['disable_saise_champ_nb_jours_pris'])  // zone de texte en readonly et grisée
-		$text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="" style="background-color: #D4D4D4; " readonly="readonly">' ;
-	else
-		$text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="3" value="">' ;
+    // zones de texte
+    $return .= '<label>' . _('saisie_conges_nb_jours') .'&nbsp</label>';
+    if($_SESSION['config']['disable_saise_champ_nb_jours_pris']) { // zone de texte en readonly et grisée
+        $text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="" style="background-color: #D4D4D4; " readonly="readonly">' ;
+    } else {
+        $text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="3" value="">' ;
+    }
 
-	echo "$text_nb_jours\n";
+    $return .= $text_nb_jours;
 
-	if($_SESSION['config']['affiche_bouton_calcul_nb_jours_pris'])
-	{
-		echo '<input type="button" class="btn btn-success" onclick="compter_jours();return false;" value="'. _('saisie_conges_compter_jours') .'">';
-	}
-	echo '<p id="comment_nbj" style="color:red">&nbsp;</p>';
-	echo '<br>';
-	echo '<input type="hidden" name="user_login" value="'.$user_login.'">';
-	echo '<input type="hidden" name="new_demande_conges" value=1>';
-	echo '<input type="hidden" name="session" value="'.$session.'">';
-	// boutons du formulaire
-	echo '<input type="submit" class="btn btn-success" value="'. _('form_submit') .'">';
-	echo "<a class=\"btn\" href=\"$PHP_SELF?session=$session\">". _('form_cancel') ."</a>\n";
-	echo "</form>\n";
+    if($_SESSION['config']['affiche_bouton_calcul_nb_jours_pris']) {
+        $return .= '<input type="button" class="btn btn-success" onclick="compter_jours();return false;" value="' . _('saisie_conges_compter_jours') . '">';
+    }
+    $return .= '<p id="comment_nbj" style="color:red">&nbsp;</p>';
+    $return .= '<br>';
+    $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
+    $return .= '<input type="hidden" name="new_demande_conges" value=1>';
+    $return .= '<input type="hidden" name="session" value="' . $session . '">';
+    // boutons du formulaire
+    $return .= '<input type="submit" class="btn btn-success" value="' . _('form_submit') . '">';
+    $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+    $return .= '</form>';
+    return $return;
 }
 
 // initialisation des variables pour la navigation mois précédent / mois suivant
 // certains arguments sont passés par référence (avec &) car on change leur valeur
-function init_var_navigation_mois_year( $mois_calendrier_saisie_debut, $year_calendrier_saisie_debut, &$mois_calendrier_saisie_debut_prec, &$year_calendrier_saisie_debut_prec,	&$mois_calendrier_saisie_debut_suiv, &$year_calendrier_saisie_debut_suiv, $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin, &$mois_calendrier_saisie_fin_prec, &$year_calendrier_saisie_fin_prec, &$mois_calendrier_saisie_fin_suiv, &$year_calendrier_saisie_fin_suiv )
+function init_var_navigation_mois_year( $mois_calendrier_saisie_debut, $year_calendrier_saisie_debut, &$mois_calendrier_saisie_debut_prec, &$year_calendrier_saisie_debut_prec,    &$mois_calendrier_saisie_debut_suiv, &$year_calendrier_saisie_debut_suiv, $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin, &$mois_calendrier_saisie_fin_prec, &$year_calendrier_saisie_fin_prec, &$mois_calendrier_saisie_fin_suiv, &$year_calendrier_saisie_fin_suiv )
 {
-	if($mois_calendrier_saisie_debut==1)
-	{
-		$mois_calendrier_saisie_debut_prec=12;
-		$year_calendrier_saisie_debut_prec=$year_calendrier_saisie_debut-1 ;
-	}
-	else
-	{
-		$mois_calendrier_saisie_debut_prec=$mois_calendrier_saisie_debut-1 ;
-		$year_calendrier_saisie_debut_prec=$year_calendrier_saisie_debut ;
-	}
-	if($mois_calendrier_saisie_debut==12)
-	{
-		$mois_calendrier_saisie_debut_suiv=1;
-		$year_calendrier_saisie_debut_suiv=$year_calendrier_saisie_debut+1 ;
-	}
-	else
-	{
-		$mois_calendrier_saisie_debut_suiv=$mois_calendrier_saisie_debut+1 ;
-		$year_calendrier_saisie_debut_suiv=$year_calendrier_saisie_debut ;
-	}
+    if($mois_calendrier_saisie_debut==1)
+    {
+        $mois_calendrier_saisie_debut_prec=12;
+        $year_calendrier_saisie_debut_prec=$year_calendrier_saisie_debut-1 ;
+    }
+    else
+    {
+        $mois_calendrier_saisie_debut_prec=$mois_calendrier_saisie_debut-1 ;
+        $year_calendrier_saisie_debut_prec=$year_calendrier_saisie_debut ;
+    }
+    if($mois_calendrier_saisie_debut==12)
+    {
+        $mois_calendrier_saisie_debut_suiv=1;
+        $year_calendrier_saisie_debut_suiv=$year_calendrier_saisie_debut+1 ;
+    }
+    else
+    {
+        $mois_calendrier_saisie_debut_suiv=$mois_calendrier_saisie_debut+1 ;
+        $year_calendrier_saisie_debut_suiv=$year_calendrier_saisie_debut ;
+    }
 
-	if($mois_calendrier_saisie_fin==1)
-	{
-		$mois_calendrier_saisie_fin_prec=12;
-		$year_calendrier_saisie_fin_prec=$year_calendrier_saisie_fin-1 ;
-	}
-	else
-	{
-		$mois_calendrier_saisie_fin_prec=$mois_calendrier_saisie_fin-1 ;
-		$year_calendrier_saisie_fin_prec=$year_calendrier_saisie_fin ;
-	}
-	if($mois_calendrier_saisie_fin==12)
-	{
-		$mois_calendrier_saisie_fin_suiv=1;
-		$year_calendrier_saisie_fin_suiv=$year_calendrier_saisie_fin+1 ;
-	}
-	else
-	{
-		$mois_calendrier_saisie_fin_suiv=$mois_calendrier_saisie_fin+1 ;
-		$year_calendrier_saisie_fin_suiv=$year_calendrier_saisie_fin ;
-	}
+    if($mois_calendrier_saisie_fin==1)
+    {
+        $mois_calendrier_saisie_fin_prec=12;
+        $year_calendrier_saisie_fin_prec=$year_calendrier_saisie_fin-1 ;
+    }
+    else
+    {
+        $mois_calendrier_saisie_fin_prec=$mois_calendrier_saisie_fin-1 ;
+        $year_calendrier_saisie_fin_prec=$year_calendrier_saisie_fin ;
+    }
+    if($mois_calendrier_saisie_fin==12)
+    {
+        $mois_calendrier_saisie_fin_suiv=1;
+        $year_calendrier_saisie_fin_suiv=$year_calendrier_saisie_fin+1 ;
+    }
+    else
+    {
+        $mois_calendrier_saisie_fin_suiv=$mois_calendrier_saisie_fin+1 ;
+        $year_calendrier_saisie_fin_suiv=$year_calendrier_saisie_fin ;
+    }
 }
 
 
@@ -630,58 +632,58 @@ function init_var_navigation_mois_year( $mois_calendrier_saisie_debut, $year_cal
 // ex : 10.00 devient 10  , 5.50 devient 5.5  , et 3.05 reste 3.05
 function affiche_decimal($str, $DEBUG=FALSE)
 {
-	$champs=explode('.', $str);
-	$int=$champs[0];
-	$decimal='00';
-	if (count($champs)>1)
-		$decimal = $champs[1];
-	if($decimal=='00')
-		return $int ;
-	elseif (preg_match('/[0-9][1-9]$/' , $decimal ))
-		return $str;
-	elseif (preg_match('/([0-9]?)0?$/' , $decimal, $regs ))
-		return $int.'.'.$regs[1] ;
-	else {
-		echo 'ERREUR: affiche_decimal('.$str.') : '.$str.' n\'a pas le format attendu !!!!<br>';
-		exit;
-	}
+    $champs=explode('.', $str);
+    $int=$champs[0];
+    $decimal='00';
+    if (count($champs)>1)
+        $decimal = $champs[1];
+    if($decimal=='00')
+        return $int ;
+    elseif (preg_match('/[0-9][1-9]$/' , $decimal ))
+        return $str;
+    elseif (preg_match('/([0-9]?)0?$/' , $decimal, $regs ))
+        return $int.'.'.$regs[1] ;
+    else {
+        echo 'ERREUR: affiche_decimal('.$str.') : '.$str.' n\'a pas le format attendu !!!!<br>';
+        exit;
+    }
 }
 
 // verif validité des valeurs saisies lors d'une demande de conges par un user ou d'une saisie de conges par le responsable
 //  (attention : le $new_nb_jours est passé par référence car on le modifie si besoin)
 function verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, &$new_nb_jours, $new_comment)
 {
-	$verif = true;
+    $verif = true;
 
-	// leur champs doivent etre renseignés dans le formulaire
-	if( $new_debut == '' || $new_fin == '' || $new_nb_jours == '' )
-	{
-		echo '<br>'. _('verif_saisie_erreur_valeur_manque') .'<br>';
-		$verif = false;
-	}
+    // leur champs doivent etre renseignés dans le formulaire
+    if( $new_debut == '' || $new_fin == '' || $new_nb_jours == '' )
+    {
+        echo '<br>'. _('verif_saisie_erreur_valeur_manque') .'<br>';
+        $verif = false;
+    }
 
-	if ( !preg_match('/([0-9]+)([\.\,]*[0-9]{1,2})*$/', $new_nb_jours) )
-	{
-		echo '<br>'. _('verif_saisie_erreur_nb_jours_bad') .'<br>';
-		$verif = false;
-	}
-	elseif ( preg_match('/([0-9]+)\,([0-9]{1,2})$/', $new_nb_jours, $reg) )
-		$new_nb_jours=$reg[1].'.'.$reg[2]; // on remplace la virgule par un point pour les décimaux
+    if ( !preg_match('/([0-9]+)([\.\,]*[0-9]{1,2})*$/', $new_nb_jours) )
+    {
+        echo '<br>'. _('verif_saisie_erreur_nb_jours_bad') .'<br>';
+        $verif = false;
+    }
+    elseif ( preg_match('/([0-9]+)\,([0-9]{1,2})$/', $new_nb_jours, $reg) )
+        $new_nb_jours=$reg[1].'.'.$reg[2]; // on remplace la virgule par un point pour les décimaux
 
-	// si la date de fin est antéreieure à la date debut
-	if(strnatcmp($new_debut, $new_fin)>0)
-	{
-		echo '<br>'. _('verif_saisie_erreur_fin_avant_debut') .'<br>';
-		$verif = false;
-	}
+    // si la date de fin est antéreieure à la date debut
+    if(strnatcmp($new_debut, $new_fin)>0)
+    {
+        echo '<br>'. _('verif_saisie_erreur_fin_avant_debut') .'<br>';
+        $verif = false;
+    }
 
-	// si la date debut et fin = même jour mais début=après midi et fin=matin !!
-	if( $new_debut == $new_fin && $new_demi_jour_deb=='pm' && $new_demi_jour_fin == 'am' )
-	{
-		echo '<br>'. _('verif_saisie_erreur_debut_apres_fin') .'<br>';
-		$verif = false;
-	}
-	return $verif;
+    // si la date debut et fin = même jour mais début=après midi et fin=matin !!
+    if( $new_debut == $new_fin && $new_demi_jour_deb=='pm' && $new_demi_jour_fin == 'am' )
+    {
+        echo '<br>'. _('verif_saisie_erreur_debut_apres_fin') .'<br>';
+        $verif = false;
+    }
+    return $verif;
 }
 
 
@@ -689,13 +691,13 @@ function verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new
 // (une classe pour les jours de semaine et une pour les jours de week end)
 function get_td_class_of_the_day_in_the_week($timestamp_du_jour)
 {
-	$j_name = date('D', $timestamp_du_jour);
-	$j_date = date('Y-m-d', $timestamp_du_jour);
+    $j_name = date('D', $timestamp_du_jour);
+    $j_date = date('Y-m-d', $timestamp_du_jour);
 
-	if( ( $j_name=='Sat' && !$_SESSION['config']['samedi_travail'] ) || ($j_name=='Sun' && !$_SESSION['config']['dimanche_travail'] ) || est_chome($timestamp_du_jour) || est_ferme($timestamp_du_jour) )
-		return 'weekend';
-	else
-		return 'semaine';
+    if( ( $j_name=='Sat' && !$_SESSION['config']['samedi_travail'] ) || ($j_name=='Sun' && !$_SESSION['config']['dimanche_travail'] ) || est_chome($timestamp_du_jour) || est_ferme($timestamp_du_jour) )
+        return 'weekend';
+    else
+        return 'semaine';
 }
 
 
@@ -703,55 +705,55 @@ function get_td_class_of_the_day_in_the_week($timestamp_du_jour)
 // attention : les param $val_matin et $val_aprem sont passées par référence (avec &) car on change leur valeur
 function recup_infos_artt_du_jour($sql_login, $j_timestamp, &$val_matin, &$val_aprem,  $DEBUG=FALSE)
 {
-	$num_semaine = date('W', $j_timestamp);
-	$jour_name_fr_2c = get_j_name_fr_2c($j_timestamp); // nom du jour de la semaine en francais sur 2 caracteres
+    $num_semaine = date('W', $j_timestamp);
+    $jour_name_fr_2c = get_j_name_fr_2c($j_timestamp); // nom du jour de la semaine en francais sur 2 caracteres
 
-	// on ne cherche pas d'artt les samedis ou dimanches quand il ne sont pas travaillés (cf config de php_conges)
-	if ( ( $jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail'] )  && ( $jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'] ) )
-	{
-		// verif si le jour fait l'objet d'un echange ....
-		$date_j			= date('Y-m-d', $j_timestamp);
-		$sql_echange_rtt = 'SELECT e_absence FROM conges_echange_rtt WHERE e_login="'.\includes\SQL::quote($sql_login).'" AND e_date_jour="'.\includes\SQL::quote($date_j).'" ';
-		$res_echange_rtt = \includes\SQL::query($sql_echange_rtt);
-		$num_echange_rtt = $res_echange_rtt->num_rows;
-		// si le jour est l'objet d'un echange, on tient compte de l'échange
-		if( $num_echange_rtt != 0 )
-		{
-			$result_echange_rtt = $res_echange_rtt->fetch_array();
-			if ( in_array($result_echange_rtt['e_absence'] , array( 'J' , 'M') ) )
-				$val_matin = 'Y';
-			else
-				$val_matin = 'N';
-			if ( in_array($result_echange_rtt['e_absence'] , array( 'J' , 'A') ) )
-				$val_aprem = 'Y';
-			else
-				$val_aprem = 'N';
-		}
-		// sinon, on lit la table conges_artt normalement
-		else
-		{
-			$par_sem = $num_semaine % 2 == 0 ? 'p' : 'imp';
+    // on ne cherche pas d'artt les samedis ou dimanches quand il ne sont pas travaillés (cf config de php_conges)
+    if ( ( $jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail'] )  && ( $jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'] ) )
+    {
+        // verif si le jour fait l'objet d'un echange ....
+        $date_j            = date('Y-m-d', $j_timestamp);
+        $sql_echange_rtt = 'SELECT e_absence FROM conges_echange_rtt WHERE e_login="'.\includes\SQL::quote($sql_login).'" AND e_date_jour="'.\includes\SQL::quote($date_j).'" ';
+        $res_echange_rtt = \includes\SQL::query($sql_echange_rtt);
+        $num_echange_rtt = $res_echange_rtt->num_rows;
+        // si le jour est l'objet d'un echange, on tient compte de l'échange
+        if( $num_echange_rtt != 0 )
+        {
+            $result_echange_rtt = $res_echange_rtt->fetch_array();
+            if ( in_array($result_echange_rtt['e_absence'] , array( 'J' , 'M') ) )
+                $val_matin = 'Y';
+            else
+                $val_matin = 'N';
+            if ( in_array($result_echange_rtt['e_absence'] , array( 'J' , 'A') ) )
+                $val_aprem = 'Y';
+            else
+                $val_aprem = 'N';
+        }
+        // sinon, on lit la table conges_artt normalement
+        else
+        {
+            $par_sem = $num_semaine % 2 == 0 ? 'p' : 'imp';
 
-			//on calcule la key du tableau $result_artt qui correspond au jour j que l'on est en train d'afficher
-			$key_artt_matin = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_am' ;
-			$key_artt_aprem = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_pm' ;
+            //on calcule la key du tableau $result_artt qui correspond au jour j que l'on est en train d'afficher
+            $key_artt_matin = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_am' ;
+            $key_artt_aprem = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_pm' ;
 
-			// recup des ARTT et temps-partiels du user
-			$sql_artt='SELECT '.\includes\SQL::quote($key_artt_matin).', '.\includes\SQL::quote($key_artt_aprem).' FROM conges_artt WHERE a_login = "'.\includes\SQL::quote($sql_login).'" AND a_date_debut_grille <=  "'.\includes\SQL::quote($date_j).'" AND a_date_fin_grille >= "'.\includes\SQL::quote($date_j).'";';
-			$res_artt = \includes\SQL::query($sql_artt);
-			$result_artt = $res_artt->fetch_array();
+            // recup des ARTT et temps-partiels du user
+            $sql_artt='SELECT '.\includes\SQL::quote($key_artt_matin).', '.\includes\SQL::quote($key_artt_aprem).' FROM conges_artt WHERE a_login = "'.\includes\SQL::quote($sql_login).'" AND a_date_debut_grille <=  "'.\includes\SQL::quote($date_j).'" AND a_date_fin_grille >= "'.\includes\SQL::quote($date_j).'";';
+            $res_artt = \includes\SQL::query($sql_artt);
+            $result_artt = $res_artt->fetch_array();
 
-			if($result_artt[$key_artt_matin] == 'Y')
-				$val_matin='Y';
-			else
-				$val_matin='N';
+            if($result_artt[$key_artt_matin] == 'Y')
+                $val_matin='Y';
+            else
+                $val_matin='N';
 
-			if($result_artt[$key_artt_aprem] == 'Y')
-				$val_aprem='Y';
-			else
-				$val_aprem='N';
-		}
-	}
+            if($result_artt[$key_artt_aprem] == 'Y')
+                $val_aprem='Y';
+            else
+                $val_aprem='N';
+        }
+    }
 }
 
 
@@ -760,60 +762,60 @@ function recup_infos_artt_du_jour($sql_login, $j_timestamp, &$val_matin, &$val_a
 function recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, &$val_matin, &$val_aprem, $tab_rtt_echange, $tab_rtt_planifiees, $DEBUG=FALSE)
 {
 
-	//$tab_rtt_echange  //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
-	//il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
-	// qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
-	// jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
-	//$tab_rtt_planifiees  //tableau indexé dont la clé est le login_user
-	// il contient pour chaque clé login : un tableau ($tab_user_grille) indexé dont la
-	// clé est la date_fin_grille.
-	// qui contient lui meme pour chaque clé : un tableau ($tab_user_rtt) qui contient enfin
-	// les infos pour le matin et l'après midi ('Y' si rtt, 'N' sinon) sur 2 semaines
-	// ( du sem_imp_lu_am au sem_p_ve_pm ) + la date de début et de fin de la grille
+    //$tab_rtt_echange  //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
+    //il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
+    // qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
+    // jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
+    //$tab_rtt_planifiees  //tableau indexé dont la clé est le login_user
+    // il contient pour chaque clé login : un tableau ($tab_user_grille) indexé dont la
+    // clé est la date_fin_grille.
+    // qui contient lui meme pour chaque clé : un tableau ($tab_user_rtt) qui contient enfin
+    // les infos pour le matin et l'après midi ('Y' si rtt, 'N' sinon) sur 2 semaines
+    // ( du sem_imp_lu_am au sem_p_ve_pm ) + la date de début et de fin de la grille
 
-	$num_semaine = date('W', $j_timestamp);
-	$jour_name_fr_2c = get_j_name_fr_2c($j_timestamp); // nom du jour de la semaine en francais sur 2 caracteres
+    $num_semaine = date('W', $j_timestamp);
+    $jour_name_fr_2c = get_j_name_fr_2c($j_timestamp); // nom du jour de la semaine en francais sur 2 caracteres
 
-	// on ne cherche pas d'artt les samedis ou dimanches quand il ne sont pas travaillés (cf config de php_conges)
-	if ( ( $jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail'] )  && ( $jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'] ) )
-	{
-		// verif si le jour fait l'objet d'un echange ....
-		// si le jour est l'objet d'un echange, on tient compte de l'échange
-		$date_j = date('Y-m-d', $j_timestamp);
-		if(isset($tab_rtt_echange[$date_j]) && array_key_exists($sql_login, $tab_rtt_echange[$date_j]))   // si la periode correspond au user que l'on est en train de traiter
-		{
-			$tab_day = $tab_rtt_echange[$date_j];  // on recup le tableau du jour
-			$val_matin = $tab_day[$sql_login]["val_matin"];
-			$val_aprem = $tab_day[$sql_login]["val_aprem"];
-		}
-		// sinon, on lit la table conges_artt normalement
-		else
-		{
-			$par_sem = $num_semaine % 2 == 0 ? 'p' : 'imp';
+    // on ne cherche pas d'artt les samedis ou dimanches quand il ne sont pas travaillés (cf config de php_conges)
+    if ( ( $jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail'] )  && ( $jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'] ) )
+    {
+        // verif si le jour fait l'objet d'un echange ....
+        // si le jour est l'objet d'un echange, on tient compte de l'échange
+        $date_j = date('Y-m-d', $j_timestamp);
+        if(isset($tab_rtt_echange[$date_j]) && array_key_exists($sql_login, $tab_rtt_echange[$date_j]))   // si la periode correspond au user que l'on est en train de traiter
+        {
+            $tab_day = $tab_rtt_echange[$date_j];  // on recup le tableau du jour
+            $val_matin = $tab_day[$sql_login]["val_matin"];
+            $val_aprem = $tab_day[$sql_login]["val_aprem"];
+        }
+        // sinon, on lit la table conges_artt normalement
+        else
+        {
+            $par_sem = $num_semaine % 2 == 0 ? 'p' : 'imp';
 
-			//on calcule la key du tableau $result_artt qui correspond au jour j que l'on est en train d'afficher
-			$key_artt_matin = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_am' ;
-			$key_artt_aprem = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_pm' ;
+            //on calcule la key du tableau $result_artt qui correspond au jour j que l'on est en train d'afficher
+            $key_artt_matin = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_am' ;
+            $key_artt_aprem = 'sem_'.$par_sem.'_'.$jour_name_fr_2c.'_pm' ;
 
-			// recup des ARTT et temps-partiels du user :
-			// recup des grille du user
-			$tab_grille_user = array();
-			if(array_key_exists($sql_login, $tab_rtt_planifiees))
-				$tab_grille_user = $tab_rtt_planifiees[$sql_login];
-			// parcours du tableau des grille pour trouver la key qui correspond à la bonne période
-			if(count($tab_grille_user))
-			{
-				foreach ($tab_grille_user as $key => $value)
-				{
-					if( $date_j >= $value['date_debut_grille'] && $date_j <= $value['date_fin_grille'] ) // date_jour comprise entre date_deb_grille et date_fin grille
-					{
-						$val_matin  = $value[$key_artt_matin];
-						$val_aprem  = $value[$key_artt_aprem];
-					}
-				}
-			}
-		}
-	}
+            // recup des ARTT et temps-partiels du user :
+            // recup des grille du user
+            $tab_grille_user = array();
+            if(array_key_exists($sql_login, $tab_rtt_planifiees))
+                $tab_grille_user = $tab_rtt_planifiees[$sql_login];
+            // parcours du tableau des grille pour trouver la key qui correspond à la bonne période
+            if(count($tab_grille_user))
+            {
+                foreach ($tab_grille_user as $key => $value)
+                {
+                    if( $date_j >= $value['date_debut_grille'] && $date_j <= $value['date_fin_grille'] ) // date_jour comprise entre date_deb_grille et date_fin grille
+                    {
+                        $val_matin  = $value[$key_artt_matin];
+                        $val_aprem  = $value[$key_artt_aprem];
+                    }
+                }
+            }
+        }
+    }
 }
 
 
@@ -823,18 +825,18 @@ function recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, &$val_matin
 //  (attention : le $nombre est passé par référence car on le modifie si besoin)
 function verif_saisie_decimal(&$nombre, $DEBUG=FALSE)
 {
-	if ( !preg_match('/^-?([0-9]+)([\.\,]?[0-9]?[0-9]?)$/', $nombre) )
-	{
-		echo "<br>". _('verif_saisie_erreur_nb_bad') ." ($nombre)<br>\n";
-		return false;
-	}
+    if ( !preg_match('/^-?([0-9]+)([\.\,]?[0-9]?[0-9]?)$/', $nombre) )
+    {
+        echo "<br>". _('verif_saisie_erreur_nb_bad') ." ($nombre)<br>\n";
+        return false;
+    }
 
-	if( preg_match('/^([0-9]+)\,([0-9]{1,2})$/', $nombre, $reg) )
-		$nombre=$reg[1].".".$reg[2]; // on remplace la virgule par un point pour les décimaux
-	elseif( preg_match('/^-([0-9]+)\,([0-9]{1,2})$/', $nombre, $reg) )
-		$nombre="-".$reg[1].".".$reg[2]; // on remplace la virgule par un point pour les décimaux
+    if( preg_match('/^([0-9]+)\,([0-9]{1,2})$/', $nombre, $reg) )
+        $nombre=$reg[1].".".$reg[2]; // on remplace la virgule par un point pour les décimaux
+    elseif( preg_match('/^-([0-9]+)\,([0-9]{1,2})$/', $nombre, $reg) )
+        $nombre="-".$reg[1].".".$reg[2]; // on remplace la virgule par un point pour les décimaux
 
-	return true;
+    return true;
 }
 
 
@@ -842,28 +844,28 @@ function verif_saisie_decimal(&$nombre, $DEBUG=FALSE)
 // donne la date en francais (dans la langue voulue)(meme formats que la fonction PHP date() cf manuel php)
 function date_fr($code, $timestmp)
 {
-	$les_mois_longs  = array('pas_de_zero',  _('janvier') ,  _('fevrier') ,  _('mars') ,  _('avril') , _('mai') ,  _('juin') ,  _('juillet') ,  _('aout') , _('septembre') ,  _('octobre') ,  _('novembre') ,  _('decembre') );
-	$les_jours_longs  = array( _('dimanche') ,  _('lundi') ,  _('mardi') ,  _('mercredi') , _('jeudi') ,  _('vendredi') ,  _('samedi') );
-	$les_jours_courts = array( _('dimanche_short') ,  _('lundi_short') ,  _('mardi_short') , _('mercredi_short') ,  _('jeudi_short') ,  _('vendredi_short') ,  _('samedi_short') );
+    $les_mois_longs  = array('pas_de_zero',  _('janvier') ,  _('fevrier') ,  _('mars') ,  _('avril') , _('mai') ,  _('juin') ,  _('juillet') ,  _('aout') , _('septembre') ,  _('octobre') ,  _('novembre') ,  _('decembre') );
+    $les_jours_longs  = array( _('dimanche') ,  _('lundi') ,  _('mardi') ,  _('mercredi') , _('jeudi') ,  _('vendredi') ,  _('samedi') );
+    $les_jours_courts = array( _('dimanche_short') ,  _('lundi_short') ,  _('mardi_short') , _('mercredi_short') ,  _('jeudi_short') ,  _('vendredi_short') ,  _('samedi_short') );
 
-	switch ($code)
-	{
-		case 'F':
-			return $les_mois_longs[ date('n', $timestmp) ];
-			break;
+    switch ($code)
+    {
+        case 'F':
+            return $les_mois_longs[ date('n', $timestmp) ];
+            break;
 
-		case 'l':
-			return $les_jours_longs[ date('w', $timestmp) ];
-			break;
+        case 'l':
+            return $les_jours_longs[ date('w', $timestmp) ];
+            break;
 
-		case 'D':
-			return $les_jours_courts[ date('w', $timestmp) ];
-			break;
+        case 'D':
+            return $les_jours_courts[ date('w', $timestmp) ];
+            break;
 
-		default:
-			return date($code, $timestmp);
-			break;
-	}
+        default:
+            return date($code, $timestmp);
+            break;
+    }
 }
 
 
@@ -876,75 +878,75 @@ function date_fr($code, $timestmp)
 function alerte_mail($login_expediteur, $destinataire, $num_periode, $objet,  $DEBUG=FALSE)
 {
 
-	/*********************************************/
-	// recup des infos concernant l'expéditeur ....
-	$mail_array		= find_email_adress_for_user($login_expediteur, $DEBUG);
-	$mail_sender_name	= $mail_array[0];
-	$mail_sender_addr	= $mail_array[1];
+    /*********************************************/
+    // recup des infos concernant l'expéditeur ....
+    $mail_array        = find_email_adress_for_user($login_expediteur, $DEBUG);
+    $mail_sender_name    = $mail_array[0];
+    $mail_sender_addr    = $mail_array[1];
 
-	/*********************************************/
-	// recherche des infos concernant le destinataire ...
-	// recherche du login du (des) destinataire(s) dans la base
-	$dest_mail  = '';
-	if( $destinataire == ':responsable:' )  // c'est un message au responsable
-	{
-		$tab_resp   = get_tab_resp_du_user($login_expediteur,  $DEBUG);
-		foreach($tab_resp as $item_login => $item_presence)
-		{
-			// recherche de l'adresse mail du (des) responsable(s) :
-			$mail_array_dest = find_email_adress_for_user($item_login, $DEBUG);
-			$mail_dest_name = $mail_array_dest[0];
-			$mail_dest_addr = $mail_array_dest[1];
+    /*********************************************/
+    // recherche des infos concernant le destinataire ...
+    // recherche du login du (des) destinataire(s) dans la base
+    $dest_mail  = '';
+    if( $destinataire == ':responsable:' )  // c'est un message au responsable
+    {
+        $tab_resp   = get_tab_resp_du_user($login_expediteur,  $DEBUG);
+        foreach($tab_resp as $item_login => $item_presence)
+        {
+            // recherche de l'adresse mail du (des) responsable(s) :
+            $mail_array_dest = find_email_adress_for_user($item_login, $DEBUG);
+            $mail_dest_name = $mail_array_dest[0];
+            $mail_dest_addr = $mail_array_dest[1];
 
-			if( $mail_dest_addr == '' )
-				echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
-			else
-			{
-				// on change l'objet si c'est un "new_demande" à un resp absent et qu'on gere les absence de resp !
-				if( $_SESSION['config']['gestion_cas_absence_responsable'] && $item_presence == 'absent' && $objet == 'new_demande' )
-					$new_objet  = 'new_demande_resp_absent';
-				else
-					$new_objet  = $objet;
+            if( $mail_dest_addr == '' )
+                echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
+            else
+            {
+                // on change l'objet si c'est un "new_demande" à un resp absent et qu'on gere les absence de resp !
+                if( $_SESSION['config']['gestion_cas_absence_responsable'] && $item_presence == 'absent' && $objet == 'new_demande' )
+                    $new_objet  = 'new_demande_resp_absent';
+                else
+                    $new_objet  = $objet;
 
-				constuct_and_send_mail($new_objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG);
-			}
-		}
+                constuct_and_send_mail($new_objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG);
+            }
+        }
 
-	}
-	else   // c'est un message du responsale à un user
-	{
-		$dest_login		= $destinataire ;
-		$mail_array_dest	= find_email_adress_for_user($dest_login, $DEBUG);
-		$mail_dest_name 	= $mail_array_dest[0];
-		$mail_dest_addr 	= $mail_array_dest[1];
+    }
+    else   // c'est un message du responsale à un user
+    {
+        $dest_login        = $destinataire ;
+        $mail_array_dest    = find_email_adress_for_user($dest_login, $DEBUG);
+        $mail_dest_name     = $mail_array_dest[0];
+        $mail_dest_addr     = $mail_array_dest[1];
 
-		if( $mail_dest_addr == '' )
-			echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
-		else
-			constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG);
+        if( $mail_dest_addr == '' )
+            echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
+        else
+            constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG);
 
-		/****************************/
-		if( $objet == 'valid_conges' )  // c'est un mail de première validation de demande : il faut faire une copie au(x) grand(s) responsable(s)
-		{
-			// on recup la liste des grands resp du user
-			$tab_grd_resp   = array();
-			get_tab_grd_resp_du_user($dest_login, $tab_grd_resp,  $DEBUG);
+        /****************************/
+        if( $objet == 'valid_conges' )  // c'est un mail de première validation de demande : il faut faire une copie au(x) grand(s) responsable(s)
+        {
+            // on recup la liste des grands resp du user
+            $tab_grd_resp   = array();
+            get_tab_grd_resp_du_user($dest_login, $tab_grd_resp,  $DEBUG);
 
-			if( count($tab_grd_resp) != 0 ) {
-				foreach($tab_grd_resp as $item_login) {
-					// recherche de l'adresse mail du (des) responsable(s) :
-					$mail_array_dest = find_email_adress_for_user($item_login, $DEBUG);
-					$mail_dest_name = $mail_array_dest[0];
-					$mail_dest_addr = $mail_array_dest[1];
+            if( count($tab_grd_resp) != 0 ) {
+                foreach($tab_grd_resp as $item_login) {
+                    // recherche de l'adresse mail du (des) responsable(s) :
+                    $mail_array_dest = find_email_adress_for_user($item_login, $DEBUG);
+                    $mail_dest_name = $mail_array_dest[0];
+                    $mail_dest_addr = $mail_array_dest[1];
 
-					if( $mail_dest_addr == '' )
-						echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
-					else
-						constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG);
-				}
-			}
-		}
-	}
+                    if( $mail_dest_addr == '' )
+                        echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
+                    else
+                        constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG);
+                }
+            }
+        }
+    }
 }
 
 
@@ -952,135 +954,135 @@ function alerte_mail($login_expediteur, $destinataire, $num_periode, $objet,  $D
 function constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode,  $DEBUG=FALSE)
 {
 
-	require_once( LIBRARY_PATH .'phpmailer/PHPMailerAutoload.php' );  // ajout de la classe phpmailer
+    require_once( LIBRARY_PATH .'phpmailer/PHPMailerAutoload.php' );  // ajout de la classe phpmailer
 
-	/*********************************************/
-	// init du mail
-	$mail = new PHPMailer();
+    /*********************************************/
+    // init du mail
+    $mail = new PHPMailer();
 
-	if (file_exists(CONFIG_PATH .'config_SMTP.php'))
-	{
-		include_once CONFIG_PATH .'config_SMTP.php';
+    if (file_exists(CONFIG_PATH .'config_SMTP.php'))
+    {
+        include_once CONFIG_PATH .'config_SMTP.php';
 
-		if(!empty($config_SMTP_host))
-		{
-			$mail->IsSMTP();
-			$mail->Host = $config_SMTP_host;
-			$mail->Port = $config_SMTP_port;
+        if(!empty($config_SMTP_host))
+        {
+            $mail->IsSMTP();
+            $mail->Host = $config_SMTP_host;
+            $mail->Port = $config_SMTP_port;
 
-			if (!empty($config_SMTP_user))
-			{
-				$mail->SMTPAuth = true;
-				$mail->Username = $config_SMTP_user;
-				$mail->Password = $config_SMTP_pwd;
-			}
-			if (!empty($config_SMTP_sec))
-				$mail->SMTPSecure = $config_SMTP_sec;
-		}
-	}
-	else
-	{
-		if(file_exists('/usr/sbin/sendmail'))
-			$mail->IsSendmail();   // send message using the $Sendmail program
-		elseif(file_exists('/var/qmail/bin/sendmail'))
-			$mail->IsQmail(); // send message using the qmail MTA
-		else
-			$mail->IsMail(); // send message using PHP mail() function
-	}
+            if (!empty($config_SMTP_user))
+            {
+                $mail->SMTPAuth = true;
+                $mail->Username = $config_SMTP_user;
+                $mail->Password = $config_SMTP_pwd;
+            }
+            if (!empty($config_SMTP_sec))
+                $mail->SMTPSecure = $config_SMTP_sec;
+        }
+    }
+    else
+    {
+        if(file_exists('/usr/sbin/sendmail'))
+            $mail->IsSendmail();   // send message using the $Sendmail program
+        elseif(file_exists('/var/qmail/bin/sendmail'))
+            $mail->IsQmail(); // send message using the qmail MTA
+        else
+            $mail->IsMail(); // send message using PHP mail() function
+    }
 
-	// initialisation du langage utilisé par php_mailer
-	$mail->SetLanguage( 'fr', LIBRARY_PATH .'phpmailer/language/');
-	$mail->FromName	= $mail_sender_name;
-	$mail->From		= $mail_sender_addr;
-	$mail->AddAddress($mail_dest_addr);
+    // initialisation du langage utilisé par php_mailer
+    $mail->SetLanguage( 'fr', LIBRARY_PATH .'phpmailer/language/');
+    $mail->FromName    = $mail_sender_name;
+    $mail->From        = $mail_sender_addr;
+    $mail->AddAddress($mail_dest_addr);
 
-	/*********************************************/
-	// recup des infos de l'absence
-	if ($num_periode == "test")
-	{
-		// affiche : "23 / 01 / 2008 (am)"
-		$sql_date_deb = "01 / 01 / 2001 (am)";
-		// affiche : "23 / 01 / 2008 (am)"
-		$sql_date_deb = "02 / 01 / 2001 (am)";
-		$sql_nb_jours = 2;
-		$sql_commentaire = "Test comment";
-		$sql_type_absence = "cp";
-		$mail->SMTPDebug = 3; // Much easier if something fails
-	}
-	else
-	{
-		$select_abs = 'SELECT conges_periode.p_date_deb,conges_periode.p_demi_jour_deb,conges_periode.p_date_fin,conges_periode.p_demi_jour_fin,conges_periode.p_nb_jours,conges_periode.p_commentaire,conges_type_absence.ta_libelle
-				FROM conges_periode, conges_type_absence WHERE conges_periode.p_num='.$num_periode.' AND conges_periode.p_type = conges_type_absence.ta_id;';
-		$res_abs = \includes\SQL::query($select_abs);
-		$rec_abs = $res_abs->fetch_array();
-		$tab_date_deb = explode('-', $rec_abs['p_date_deb']);
-		// affiche : "23 / 01 / 2008 (am)"
-		$sql_date_deb = $tab_date_deb[2]." / ".$tab_date_deb[1]." / ".$tab_date_deb[0]." (".$rec_abs["p_demi_jour_deb"].")" ;
-		$tab_date_fin= explode("-", $rec_abs["p_date_fin"]);
-		// affiche : "23 / 01 / 2008 (am)"
-		$sql_date_fin = $tab_date_fin[2]." / ".$tab_date_fin[1]." / ".$tab_date_fin[0]." (".$rec_abs["p_demi_jour_fin"].")" ;
-		$sql_nb_jours = $rec_abs["p_nb_jours"];
-		$sql_commentaire = $rec_abs["p_commentaire"];
-		$sql_type_absence = $rec_abs["ta_libelle"];
-	}
+    /*********************************************/
+    // recup des infos de l'absence
+    if ($num_periode == "test")
+    {
+        // affiche : "23 / 01 / 2008 (am)"
+        $sql_date_deb = "01 / 01 / 2001 (am)";
+        // affiche : "23 / 01 / 2008 (am)"
+        $sql_date_deb = "02 / 01 / 2001 (am)";
+        $sql_nb_jours = 2;
+        $sql_commentaire = "Test comment";
+        $sql_type_absence = "cp";
+        $mail->SMTPDebug = 3; // Much easier if something fails
+    }
+    else
+    {
+        $select_abs = 'SELECT conges_periode.p_date_deb,conges_periode.p_demi_jour_deb,conges_periode.p_date_fin,conges_periode.p_demi_jour_fin,conges_periode.p_nb_jours,conges_periode.p_commentaire,conges_type_absence.ta_libelle
+                FROM conges_periode, conges_type_absence WHERE conges_periode.p_num='.$num_periode.' AND conges_periode.p_type = conges_type_absence.ta_id;';
+        $res_abs = \includes\SQL::query($select_abs);
+        $rec_abs = $res_abs->fetch_array();
+        $tab_date_deb = explode('-', $rec_abs['p_date_deb']);
+        // affiche : "23 / 01 / 2008 (am)"
+        $sql_date_deb = $tab_date_deb[2]." / ".$tab_date_deb[1]." / ".$tab_date_deb[0]." (".$rec_abs["p_demi_jour_deb"].")" ;
+        $tab_date_fin= explode("-", $rec_abs["p_date_fin"]);
+        // affiche : "23 / 01 / 2008 (am)"
+        $sql_date_fin = $tab_date_fin[2]." / ".$tab_date_fin[1]." / ".$tab_date_fin[0]." (".$rec_abs["p_demi_jour_fin"].")" ;
+        $sql_nb_jours = $rec_abs["p_nb_jours"];
+        $sql_commentaire = $rec_abs["p_commentaire"];
+        $sql_type_absence = $rec_abs["ta_libelle"];
+    }
 
-	/*********************************************/
-	// construction des sujets et corps des messages
-	if($objet=="valid_conges")
-	{
-		$key1="mail_prem_valid_conges_sujet" ;
-		$key2="mail_prem_valid_conges_contenu" ;
-	}
-	elseif($objet=="accept_conges")
-	{
-		$key1="mail_valid_conges_sujet" ;
-		$key2="mail_valid_conges_contenu" ;
-	}
-	else
-	{
-		$key1="mail_".$objet."_sujet" ;
-		$key2="mail_".$objet."_contenu" ;
-	}
-	$sujet = $_SESSION['config'][$key1];
-	$contenu = $_SESSION['config'][$key2];
-	$contenu = str_replace("__URL_ACCUEIL_CONGES__", $_SESSION['config']['URL_ACCUEIL_CONGES'], $contenu);
-	$contenu = str_replace("__SENDER_NAME__", $mail_sender_name, $contenu);
-	$contenu = str_replace("__DESTINATION_NAME__", $mail_dest_name, $contenu);
-	$contenu = str_replace("__NB_OF_DAY__", $sql_nb_jours, $contenu);
-	$contenu = str_replace("__DATE_DEBUT__", $sql_date_deb, $contenu);
-	$contenu = str_replace("__DATE_FIN__", $sql_date_fin, $contenu);
-	$contenu = str_replace("__RETOUR_LIGNE__", "\r\n", $contenu);
-	$contenu = str_replace("__COMMENT__", $sql_commentaire, $contenu);
-	$contenu = str_replace("__TYPE_ABSENCE__", $sql_type_absence, $contenu);
+    /*********************************************/
+    // construction des sujets et corps des messages
+    if($objet=="valid_conges")
+    {
+        $key1="mail_prem_valid_conges_sujet" ;
+        $key2="mail_prem_valid_conges_contenu" ;
+    }
+    elseif($objet=="accept_conges")
+    {
+        $key1="mail_valid_conges_sujet" ;
+        $key2="mail_valid_conges_contenu" ;
+    }
+    else
+    {
+        $key1="mail_".$objet."_sujet" ;
+        $key2="mail_".$objet."_contenu" ;
+    }
+    $sujet = $_SESSION['config'][$key1];
+    $contenu = $_SESSION['config'][$key2];
+    $contenu = str_replace("__URL_ACCUEIL_CONGES__", $_SESSION['config']['URL_ACCUEIL_CONGES'], $contenu);
+    $contenu = str_replace("__SENDER_NAME__", $mail_sender_name, $contenu);
+    $contenu = str_replace("__DESTINATION_NAME__", $mail_dest_name, $contenu);
+    $contenu = str_replace("__NB_OF_DAY__", $sql_nb_jours, $contenu);
+    $contenu = str_replace("__DATE_DEBUT__", $sql_date_deb, $contenu);
+    $contenu = str_replace("__DATE_FIN__", $sql_date_fin, $contenu);
+    $contenu = str_replace("__RETOUR_LIGNE__", "\r\n", $contenu);
+    $contenu = str_replace("__COMMENT__", $sql_commentaire, $contenu);
+    $contenu = str_replace("__TYPE_ABSENCE__", $sql_type_absence, $contenu);
 
-	// construction du corps du mail
-	$mail->Subject = stripslashes(utf8_decode($sujet ));
-	$mail->Body = stripslashes(utf8_decode($contenu ));
+    // construction du corps du mail
+    $mail->Subject = stripslashes(utf8_decode($sujet ));
+    $mail->Body = stripslashes(utf8_decode($contenu ));
 
 
-	/*********************************************/
-	// ENVOI du mail
-	if( $DEBUG )
-	{
-		echo "SUBJECT = ".$sujet."<br>\n";
-		echo "CONTENU = ".$mail->FromName." ".$contenu."<br>\n";
-	}
-	else
-	{
-		if(!isset($mail_dest_addr))
-		{
-			echo "<b>ERROR : No recipient address for the message!</b><br>\n";
-			echo "<b>Message was not sent </b><br>";
-		}
-		else
-		{
-			if(!$mail->Send())
-			{
-				echo "<b>Message was not sent </b><br>";
-				echo "<b>Mailer Error: " . $mail->ErrorInfo."</b><br>";
-			}
-		}
-	}
+    /*********************************************/
+    // ENVOI du mail
+    if( $DEBUG )
+    {
+        echo "SUBJECT = ".$sujet."<br>\n";
+        echo "CONTENU = ".$mail->FromName." ".$contenu."<br>\n";
+    }
+    else
+    {
+        if(!isset($mail_dest_addr))
+        {
+            echo "<b>ERROR : No recipient address for the message!</b><br>\n";
+            echo "<b>Message was not sent </b><br>";
+        }
+        else
+        {
+            if(!$mail->Send())
+            {
+                echo "<b>Message was not sent </b><br>";
+                echo "<b>Mailer Error: " . $mail->ErrorInfo."</b><br>";
+            }
+        }
+    }
 }
 
 
@@ -1090,60 +1092,60 @@ function constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $m
 function find_email_adress_for_user($login, $DEBUG=FALSE)
 {
 
-	$found_mail=array();
+    $found_mail=array();
 
-	if($_SESSION['config']['where_to_find_user_email']=="ldap") // recherche du mail du user dans un annuaire LDAP
-	{
-		// cnx à l'annuaire ldap :
-		$ds = ldap_connect($_SESSION['config']['ldap_server']);
-		if($_SESSION['config']['ldap_protocol_version'] != 0)
-			ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $_SESSION['config']['ldap_protocol_version']) ;
-		if ($_SESSION['config']['ldap_user'] == "")
-			 $bound = ldap_bind($ds);
-		else $bound = ldap_bind($ds, $_SESSION['config']['ldap_user'], $_SESSION['config']['ldap_pass']);
+    if($_SESSION['config']['where_to_find_user_email']=="ldap") // recherche du mail du user dans un annuaire LDAP
+    {
+        // cnx à l'annuaire ldap :
+        $ds = ldap_connect($_SESSION['config']['ldap_server']);
+        if($_SESSION['config']['ldap_protocol_version'] != 0)
+            ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $_SESSION['config']['ldap_protocol_version']) ;
+        if ($_SESSION['config']['ldap_user'] == "")
+             $bound = ldap_bind($ds);
+        else $bound = ldap_bind($ds, $_SESSION['config']['ldap_user'], $_SESSION['config']['ldap_pass']);
 
-		// recherche des entrées correspondantes au "login" passé en paramètre :
-		$filter = "(".$_SESSION['config']['ldap_login']."=".$login.")";
+        // recherche des entrées correspondantes au "login" passé en paramètre :
+        $filter = "(".$_SESSION['config']['ldap_login']."=".$login.")";
 
-		$sr   = ldap_search($ds, $_SESSION['config']['searchdn'], $filter);
-		$data = ldap_get_entries($ds,$sr);
+        $sr   = ldap_search($ds, $_SESSION['config']['searchdn'], $filter);
+        $data = ldap_get_entries($ds,$sr);
 
-		foreach ($data as $info)
-		{
-			$found_mail=array();
-			// On récupère le nom et le mail de la personne.
-			// Utilisation de la fonction utf8_decode pour corriger les caractères accentués
-			// (qnd les noms ou prénoms ont des accents, "ç", ...
+        foreach ($data as $info)
+        {
+            $found_mail=array();
+            // On récupère le nom et le mail de la personne.
+            // Utilisation de la fonction utf8_decode pour corriger les caractères accentués
+            // (qnd les noms ou prénoms ont des accents, "ç", ...
 
-			// Les champs LDAP utilisés, bien que censés être uniformes, sont ceux d'un AD 2003.
-			$ldap_prenom= $_SESSION['config']['ldap_prenom'];
-			$ldap_nom	= $_SESSION['config']['ldap_nom'];
-			$ldap_mail	= $_SESSION['config']['ldap_mail'];
-			$nom	= utf8_decode($info[$ldap_prenom][0])." ".strtoupper(utf8_decode($info[$ldap_nom][0])) ;
-			$addr	= $info[$ldap_mail][0] ;
-			array_push($found_mail, $nom) ;
-			array_push($found_mail, $addr) ;
-		}
-	}
-	elseif($_SESSION['config']['where_to_find_user_email']=="dbconges") // recherche du mail du user dans la base db_conges
-	{
-		$req = 'SELECT u_nom, u_prenom, u_email FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'" ';
-		$res = \includes\SQL::query($req);
-		$rec = $res->fetch_array();
+            // Les champs LDAP utilisés, bien que censés être uniformes, sont ceux d'un AD 2003.
+            $ldap_prenom= $_SESSION['config']['ldap_prenom'];
+            $ldap_nom    = $_SESSION['config']['ldap_nom'];
+            $ldap_mail    = $_SESSION['config']['ldap_mail'];
+            $nom    = utf8_decode($info[$ldap_prenom][0])." ".strtoupper(utf8_decode($info[$ldap_nom][0])) ;
+            $addr    = $info[$ldap_mail][0] ;
+            array_push($found_mail, $nom) ;
+            array_push($found_mail, $addr) ;
+        }
+    }
+    elseif($_SESSION['config']['where_to_find_user_email']=="dbconges") // recherche du mail du user dans la base db_conges
+    {
+        $req = 'SELECT u_nom, u_prenom, u_email FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'" ';
+        $res = \includes\SQL::query($req);
+        $rec = $res->fetch_array();
 
-		$sql_nom = $rec["u_nom"];
-		$sql_prenom = $rec["u_prenom"];
-		$sql_email = $rec["u_email"];
+        $sql_nom = $rec["u_nom"];
+        $sql_prenom = $rec["u_prenom"];
+        $sql_email = $rec["u_email"];
 
-		array_push($found_mail, $sql_prenom." ".strtoupper($sql_nom)) ;
-		array_push($found_mail, $sql_email) ;
+        array_push($found_mail, $sql_prenom." ".strtoupper($sql_nom)) ;
+        array_push($found_mail, $sql_email) ;
 
-	}
-	else
-	{
-		return FALSE;
-	}
-	return $found_mail ;
+    }
+    else
+    {
+        return FALSE;
+    }
+    return $found_mail ;
 }
 
 
@@ -1152,27 +1154,27 @@ function find_email_adress_for_user($login, $DEBUG=FALSE)
 /**************************************************/
 function recup_tableau_rtt_echange($mois, $first_jour, $year,  $tab_logins = false)
 {
-	$tab_rtt_echange=array();
-	//tableau indexé dont la clé est la date sous forme yyyy-mm-dd
-	//il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
-	// qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
-	// jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
+    $tab_rtt_echange=array();
+    //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
+    //il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
+    // qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
+    // jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
 
-	// construction du tableau $tab_rtt_echange:
+    // construction du tableau $tab_rtt_echange:
 
-	$date_deb   = date("Y-m-d", mktime (0,0,0,$mois, $first_jour, $year) );
-	$date_fin   = date("Y-m-d", mktime (0,0,0,$mois + 1 , $first_jour, $year) );
+    $date_deb   = date("Y-m-d", mktime (0,0,0,$mois, $first_jour, $year) );
+    $date_fin   = date("Y-m-d", mktime (0,0,0,$mois + 1 , $first_jour, $year) );
 
-	$sql	= 'SELECT e_login, e_absence, e_date_jour FROM conges_echange_rtt WHERE e_date_jour >= "'.\includes\SQL::quote($date_deb).'" AND  e_date_jour < "'.\includes\SQL::quote($date_fin).'"'.($tab_logins !== false ? 'AND e_login IN (\''.implode('\', \'', $tab_logins).'\')' : '' ).';';
-	$result = \includes\SQL::query($sql);
-	while($l = $result->fetch_array()) {
-		$tab_echange = array();
-		$tab_echange["val_matin"] = ($l["e_absence"]=='J' || $l["e_absence"]='M' ? 'Y' : 'N');
-		$tab_echange["val_aprem"] = ($l["e_absence"]=='J' || $l["e_absence"]='A' ? 'Y' : 'N');
-		$tab_rtt_echange[ $l['e_date_jour'] ][ $l["e_login"] ] = $tab_echange;
-	}
+    $sql    = 'SELECT e_login, e_absence, e_date_jour FROM conges_echange_rtt WHERE e_date_jour >= "'.\includes\SQL::quote($date_deb).'" AND  e_date_jour < "'.\includes\SQL::quote($date_fin).'"'.($tab_logins !== false ? 'AND e_login IN (\''.implode('\', \'', $tab_logins).'\')' : '' ).';';
+    $result = \includes\SQL::query($sql);
+    while($l = $result->fetch_array()) {
+        $tab_echange = array();
+        $tab_echange["val_matin"] = ($l["e_absence"]=='J' || $l["e_absence"]='M' ? 'Y' : 'N');
+        $tab_echange["val_aprem"] = ($l["e_absence"]=='J' || $l["e_absence"]='A' ? 'Y' : 'N');
+        $tab_rtt_echange[ $l['e_date_jour'] ][ $l["e_login"] ] = $tab_echange;
+    }
 
-	return $tab_rtt_echange;
+    return $tab_rtt_echange;
 }
 
 
@@ -1182,28 +1184,28 @@ function recup_tableau_rtt_echange($mois, $first_jour, $year,  $tab_logins = fal
 /**************************************************/
 function recup_tableau_rtt_planifiees($mois, $first_jour, $year , $tab_logins = false ) {
 
-	$tab_rtt_planifiees=array();
-	//tableau indexé dont la clé est le login_user
-	// il contient pour chaque clé login : un tableau ($tab_user_grille) indexé dont la
-	// clé est la date_fin_grille.
-	// qui contient lui meme pour chaque clé : un tableau ($tab_user_rtt) qui contient enfin
-	// les infos pour le matin et l'après midi ('Y' si rtt, 'N' sinon) sur 2 semaines
-	// ( du sem_imp_lu_am au sem_p_ve_pm ) + la date de début et de fin de la grille
+    $tab_rtt_planifiees=array();
+    //tableau indexé dont la clé est le login_user
+    // il contient pour chaque clé login : un tableau ($tab_user_grille) indexé dont la
+    // clé est la date_fin_grille.
+    // qui contient lui meme pour chaque clé : un tableau ($tab_user_rtt) qui contient enfin
+    // les infos pour le matin et l'après midi ('Y' si rtt, 'N' sinon) sur 2 semaines
+    // ( du sem_imp_lu_am au sem_p_ve_pm ) + la date de début et de fin de la grille
 
-	// construction du tableau $tab_rtt_planifie:
-	$sql	= 'SELECT a_login AS login, a_date_debut_grille AS date_debut_grille, a_date_fin_grille AS date_fin_grille,
-			sem_imp_lu_am, sem_imp_lu_pm, sem_imp_ma_am, sem_imp_ma_pm, sem_imp_me_am, sem_imp_me_pm,
-			sem_imp_je_am, sem_imp_je_pm, sem_imp_ve_am, sem_imp_ve_pm, sem_imp_sa_am, sem_imp_sa_pm,
-			sem_imp_di_am, sem_imp_di_pm, sem_p_lu_am, sem_p_lu_pm, sem_p_ma_am, sem_p_ma_pm,
-			sem_p_me_am, sem_p_me_pm, sem_p_je_am, sem_p_je_pm, sem_p_ve_am, sem_p_ve_pm,
-			sem_p_sa_am, sem_p_sa_pm, sem_p_di_am, sem_p_di_pm
-			FROM conges_artt'.($tab_logins === false ?'': ' WHERE a_login IN ( \''.implode('\', \'', $tab_logins ).'\')').';';
-	$result = \includes\SQL::query($sql);
+    // construction du tableau $tab_rtt_planifie:
+    $sql    = 'SELECT a_login AS login, a_date_debut_grille AS date_debut_grille, a_date_fin_grille AS date_fin_grille,
+            sem_imp_lu_am, sem_imp_lu_pm, sem_imp_ma_am, sem_imp_ma_pm, sem_imp_me_am, sem_imp_me_pm,
+            sem_imp_je_am, sem_imp_je_pm, sem_imp_ve_am, sem_imp_ve_pm, sem_imp_sa_am, sem_imp_sa_pm,
+            sem_imp_di_am, sem_imp_di_pm, sem_p_lu_am, sem_p_lu_pm, sem_p_ma_am, sem_p_ma_pm,
+            sem_p_me_am, sem_p_me_pm, sem_p_je_am, sem_p_je_pm, sem_p_ve_am, sem_p_ve_pm,
+            sem_p_sa_am, sem_p_sa_pm, sem_p_di_am, sem_p_di_pm
+            FROM conges_artt'.($tab_logins === false ?'': ' WHERE a_login IN ( \''.implode('\', \'', $tab_logins ).'\')').';';
+    $result = \includes\SQL::query($sql);
 
-	while($l = $result->fetch_array()) // pour chaque lignes
-		$tab_rtt_planifiees[ $l['login'] ][ $l['date_fin_grille'] ] = $l;
+    while($l = $result->fetch_array()) // pour chaque lignes
+        $tab_rtt_planifiees[ $l['login'] ][ $l['date_fin_grille'] ] = $l;
 
-	return $tab_rtt_planifiees;
+    return $tab_rtt_planifiees;
 }
 
 
@@ -1211,22 +1213,22 @@ function recup_tableau_rtt_planifiees($mois, $first_jour, $year , $tab_logins = 
 function affiche_selection_new_jour($default)
 {
     $return = '';
-	$return .= '<select class="form-control" name="new_jour">';
-	for($i=1; $i<10; $i++) {
-		if($default=="0$i") {
-			$return .= '<option value="0' . $i . '" selected >0' . $i . '</option>';
+    $return .= '<select class="form-control" name="new_jour">';
+    for($i=1; $i<10; $i++) {
+        if($default=="0$i") {
+            $return .= '<option value="0' . $i . '" selected >0' . $i . '</option>';
         } else {
-			$return .= '<option value="0' . $i . '">0' . $i . '</option>';
+            $return .= '<option value="0' . $i . '">0' . $i . '</option>';
         }
-	}
-	for($i=10; $i<32; $i++) {
-		if($default=="$i") {
+    }
+    for($i=10; $i<32; $i++) {
+        if($default=="$i") {
             $return .= '<option value="' . $i . '" selected >' . $i . '</option>';
         } else {
-			$return .= '<option value="' . $i . '">' . $i . '</option>';
+            $return .= '<option value="' . $i . '">' . $i . '</option>';
         }
-	}
-	$return .= '</select>';
+    }
+    $return .= '</select>';
     return $return;
 }
 
@@ -1234,23 +1236,23 @@ function affiche_selection_new_jour($default)
 function affiche_selection_new_mois($default)
 {
     $return = '';
-	$return .= '<select class="form-control" name="new_mois" >';
-	for($i=1; $i<10; $i++) {
-		$return .= $default . ' : ' . $i . '<br>';
-		if($default=="0$i") {
-			$return .= '<option value="0' . $i . '" selected >0' . $i . '</option>';
+    $return .= '<select class="form-control" name="new_mois" >';
+    for($i=1; $i<10; $i++) {
+        $return .= $default . ' : ' . $i . '<br>';
+        if($default=="0$i") {
+            $return .= '<option value="0' . $i . '" selected >0' . $i . '</option>';
         } else {
-			$return .= '<option value="0' . $i . '">0' . $i . '</option>';
+            $return .= '<option value="0' . $i . '">0' . $i . '</option>';
         }
-	}
-	for($i=10; $i<13; $i++) {
-		if($default=="$i") {
-			$return .= '<option value="' . $i . '" selected >' . $i . '</option>';
+    }
+    for($i=10; $i<13; $i++) {
+        if($default=="$i") {
+            $return .= '<option value="' . $i . '" selected >' . $i . '</option>';
         } else {
-			$return .= '<option value="' . $i . '">' . $i . '</option>';
+            $return .= '<option value="' . $i . '">' . $i . '</option>';
         }
-	}
-	$return .= '</select>';
+    }
+    $return .= '</select>';
     return $return;
 }
 
@@ -1258,15 +1260,15 @@ function affiche_selection_new_mois($default)
 function affiche_selection_new_year($an_debut, $an_fin, $default)
 {
     $return = '';
-	$return .= '<select class="form-control" name="new_year">';
-	for($i=$an_debut; $i<$an_fin+1; $i++) {
-		if($default=="$i") {
-			$return .= '<option value="' . $i . '" selected >' . $i . '</option>';
+    $return .= '<select class="form-control" name="new_year">';
+    for($i=$an_debut; $i<$an_fin+1; $i++) {
+        if($default=="$i") {
+            $return .= '<option value="' . $i . '" selected >' . $i . '</option>';
         } else {
-			$return .= '<option value="' . $i . '">' . $i . '</option>';
+            $return .= '<option value="' . $i . '">' . $i . '</option>';
         }
-	}
-	$return .= '</select>';
+    }
+    $return .= '</select>';
     return $return;
 }
 
@@ -1281,70 +1283,70 @@ function eng_date_to_fr($une_date, $DEBUG=FALSE)
 // affichage de la cellule correspondant au jour dans les calendrier de saisie (demande de conges, etc ...)
 function affiche_cellule_jour_cal_saisie($login, $j_timestamp, $td_second_class, $result,  $DEBUG=FALSE)
 {
-	$date_j=date('Y-m-d', $j_timestamp);
-	$j=date('d', $j_timestamp);
-	$class_am='travail_am';
-	$class_pm='travail_pm';
-	$val_matin='';
-	$val_aprem='';
+    $date_j=date('Y-m-d', $j_timestamp);
+    $j=date('d', $j_timestamp);
+    $class_am='travail_am';
+    $class_pm='travail_pm';
+    $val_matin='';
+    $val_aprem='';
 
-	// recup des infos ARTT ou Temps Partiel :
-	// la fonction suivante change les valeurs de $val_matin $val_aprem ....
-	recup_infos_artt_du_jour($login, $j_timestamp, $val_matin, $val_aprem,  $DEBUG);
+    // recup des infos ARTT ou Temps Partiel :
+    // la fonction suivante change les valeurs de $val_matin $val_aprem ....
+    recup_infos_artt_du_jour($login, $j_timestamp, $val_matin, $val_aprem,  $DEBUG);
 
-	//## AFICHAGE ##
-	if($val_matin=='Y')
-	{
-		$class_am='rtt_am';
-	}
-	if($val_aprem=='Y')
-	{
-		$class_pm = 'rtt_pm';
-	}
+    //## AFICHAGE ##
+    if($val_matin=='Y')
+    {
+        $class_am='rtt_am';
+    }
+    if($val_aprem=='Y')
+    {
+        $class_pm = 'rtt_pm';
+    }
 
 
-	$jour_today=date('j');
-	$mois_today=date('m');
-	$year_today=date('Y');
-	$timestamp_today = mktime (0,0,0,$mois_today,$jour_today,$year_today);
-	// si la saisie de conges pour une periode passée est interdite : pas de case à cocher dans les dates avant aujourd'hui
-	if( $_SESSION['config']['interdit_saisie_periode_date_passee']  && $j_timestamp < $timestamp_today )
-		echo '<td  class="cal-saisie '.$td_second_class.' '.$class_am.' '.$class_pm.'">'.$j.'</td>';
-	else
-	{
-		echo '<td  class="cal-saisie '.$td_second_class.' '.$class_am.' '.$class_pm.'">'.$j.'<input type="radio" name="'.$result.'" ';
-		if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-		{
-			// attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-			if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
-				echo 'onClick="compter_jours();return true;"';
-			else
-				echo 'onChange="compter_jours();return false;"';
-		}
-		echo ' value="'.$date_j.'"></td>';
-	}
+    $jour_today=date('j');
+    $mois_today=date('m');
+    $year_today=date('Y');
+    $timestamp_today = mktime (0,0,0,$mois_today,$jour_today,$year_today);
+    // si la saisie de conges pour une periode passée est interdite : pas de case à cocher dans les dates avant aujourd'hui
+    if( $_SESSION['config']['interdit_saisie_periode_date_passee']  && $j_timestamp < $timestamp_today )
+        echo '<td  class="cal-saisie '.$td_second_class.' '.$class_am.' '.$class_pm.'">'.$j.'</td>';
+    else
+    {
+        echo '<td  class="cal-saisie '.$td_second_class.' '.$class_am.' '.$class_pm.'">'.$j.'<input type="radio" name="'.$result.'" ';
+        if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
+        {
+            // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
+            if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
+                echo 'onClick="compter_jours();return true;"';
+            else
+                echo 'onChange="compter_jours();return false;"';
+        }
+        echo ' value="'.$date_j.'"></td>';
+    }
 }
 
 // recup du nom d'un groupe grace à son group_id
 function get_group_name_from_id($groupe_id)
 {
-	$req_name='SELECT g_groupename FROM conges_groupe WHERE g_gid='.\includes\SQL::quote($groupe_id);
-	$ReqLog_name = \includes\SQL::query($req_name);
-	$resultat_name = $ReqLog_name->fetch_array();
-	return $resultat_name["g_groupename"];
+    $req_name='SELECT g_groupename FROM conges_groupe WHERE g_gid='.\includes\SQL::quote($groupe_id);
+    $ReqLog_name = \includes\SQL::query($req_name);
+    $resultat_name = $ReqLog_name->fetch_array();
+    return $resultat_name["g_groupename"];
 }
 
 // recup du nom d'un groupe grace à son group_id
 function get_groups_name()
 {
-	$sql	= 'SELECT g_gid, g_groupename FROM conges_groupe;';
-	$requete	= \includes\SQL::query($sql);
-	$tab = array();
-	while( $l = $requete->fetch_array() )
-	{
-		$tab[ $l['g_gid'] ] = $l['g_groupename'];
-	}
-	return $tab;
+    $sql    = 'SELECT g_gid, g_groupename FROM conges_groupe;';
+    $requete    = \includes\SQL::query($sql);
+    $tab = array();
+    while( $l = $requete->fetch_array() )
+    {
+        $tab[ $l['g_gid'] ] = $l['g_groupename'];
+    }
+    return $tab;
 }
 
 // recup de la liste de TOUS les users dont $resp_login est responsable
@@ -1353,175 +1355,175 @@ function get_groups_name()
 function get_list_all_users_du_resp($resp_login,  $DEBUG=FALSE)
 {
 
-	$list_users="";
-	$sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' AND u_login!='$resp_login'";
-	$sql1 = $sql1." AND  ( u_resp_login='$resp_login' " ;
-	if($_SESSION['config']['gestion_groupes'] )
-	{
-		$list_users_group=get_list_users_des_groupes_du_resp_sauf_resp($resp_login, $DEBUG);
-		if($list_users_group!="")
-			$sql1=$sql1." OR u_login IN ($list_users_group) ";
-	}
+    $list_users="";
+    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' AND u_login!='$resp_login'";
+    $sql1 = $sql1." AND  ( u_resp_login='$resp_login' " ;
+    if($_SESSION['config']['gestion_groupes'] )
+    {
+        $list_users_group=get_list_users_des_groupes_du_resp_sauf_resp($resp_login, $DEBUG);
+        if($list_users_group!="")
+            $sql1=$sql1." OR u_login IN ($list_users_group) ";
+    }
 
-	$sql1=$sql1." ) " ;
-	$sql1 = $sql1." ORDER BY u_nom " ;
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $sql1=$sql1." ) " ;
+    $sql1 = $sql1." ORDER BY u_nom " ;
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	while ($resultat1 = $ReqLog1->fetch_array())
-	{
-		$current_login=$resultat1["u_login"];
-		if($list_users=="")
-			$list_users="'$current_login'";
-		else
-			$list_users=$list_users.", '$current_login'";
-	}
+    while ($resultat1 = $ReqLog1->fetch_array())
+    {
+        $current_login=$resultat1["u_login"];
+        if($list_users=="")
+            $list_users="'$current_login'";
+        else
+            $list_users=$list_users.", '$current_login'";
+    }
 
-	/************************************/
-	// gestion des absence des responsables :
-	// on recup la liste des users des resp absents, dont $resp_login est responsable
-	if($_SESSION['config']['gestion_cas_absence_responsable'])
-	{
-		// recup liste des resp absents, dont $resp_login est responsable
-		$sql_2='SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_resp=\'Y\' AND u_login!="'.\includes\SQL::quote($resp_login).'" AND u_login!=\'conges\' AND u_login!=\'admin\'';
-		$sql_2 = $sql_2." AND  ( u_resp_login='$resp_login' " ;
+    /************************************/
+    // gestion des absence des responsables :
+    // on recup la liste des users des resp absents, dont $resp_login est responsable
+    if($_SESSION['config']['gestion_cas_absence_responsable'])
+    {
+        // recup liste des resp absents, dont $resp_login est responsable
+        $sql_2='SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_resp=\'Y\' AND u_login!="'.\includes\SQL::quote($resp_login).'" AND u_login!=\'conges\' AND u_login!=\'admin\'';
+        $sql_2 = $sql_2." AND  ( u_resp_login='$resp_login' " ;
 
-		if($_SESSION['config']['gestion_groupes'] )
-		{
-			$list_users_group=get_list_users_des_groupes_du_resp_sauf_resp($resp_login, $DEBUG);
-			if($list_users_group!="")
-				$sql_2=$sql_2." OR u_login IN ($list_users_group) ";
-		}
+        if($_SESSION['config']['gestion_groupes'] )
+        {
+            $list_users_group=get_list_users_des_groupes_du_resp_sauf_resp($resp_login, $DEBUG);
+            if($list_users_group!="")
+                $sql_2=$sql_2." OR u_login IN ($list_users_group) ";
+        }
 
-		$sql_2=$sql_2." ) " ;
-		$sql_2 = $sql_2." ORDER BY u_nom " ;
+        $sql_2=$sql_2." ) " ;
+        $sql_2 = $sql_2." ORDER BY u_nom " ;
 
-		$ReqLog_2 = \includes\SQL::query($sql_2);
+        $ReqLog_2 = \includes\SQL::query($sql_2);
 
-		// on va verifier si les resp récupérés sont absents (si oui, c'est $resp_login qui traite leurs users
-		while ($resultat_2 = $ReqLog_2->fetch_array())
-		{
-			$current_resp=$resultat_2["u_login"];
-			// verif dans la base si le current_resp est absent :
-			$req = 'SELECT p_num FROM conges_periode WHERE p_login = "'.\includes\SQL::quote($current_resp).'" AND p_etat = \'ok\' AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW()) AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
-			$ReqLog_3 = \includes\SQL::query($req);
+        // on va verifier si les resp récupérés sont absents (si oui, c'est $resp_login qui traite leurs users
+        while ($resultat_2 = $ReqLog_2->fetch_array())
+        {
+            $current_resp=$resultat_2["u_login"];
+            // verif dans la base si le current_resp est absent :
+            $req = 'SELECT p_num FROM conges_periode WHERE p_login = "'.\includes\SQL::quote($current_resp).'" AND p_etat = \'ok\' AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW()) AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
+            $ReqLog_3 = \includes\SQL::query($req);
 
-			// si le current resp est absent : on recup la liste de ses users pour les traiter .....
-			if ($ReqLog_3->num_rows!=0)
-			{
-				if($list_users=="")
-					$list_users=get_list_all_users_du_resp($current_resp,  $DEBUG);
-				else
-					$list_users=$list_users.", ".get_list_all_users_du_resp($current_resp,  $DEBUG);
-			}
-		}
+            // si le current resp est absent : on recup la liste de ses users pour les traiter .....
+            if ($ReqLog_3->num_rows!=0)
+            {
+                if($list_users=="")
+                    $list_users=get_list_all_users_du_resp($current_resp,  $DEBUG);
+                else
+                    $list_users=$list_users.", ".get_list_all_users_du_resp($current_resp,  $DEBUG);
+            }
+        }
 
-	}
-	// FIN gestion des absence des responsables :
-	/************************************/
+    }
+    // FIN gestion des absence des responsables :
+    /************************************/
 
-	if( $DEBUG ) { echo "list_users = $list_users<br>\n" ;}
+    if( $DEBUG ) { echo "list_users = $list_users<br>\n" ;}
 
-	return $list_users;
+    return $list_users;
 }
 
 // recup de la liste des users d'un groupe donné
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_users_du_groupe($group_id,  $DEBUG=FALSE)
 {
-	$list_users=array();
-	$sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = '.intval($group_id).' ORDER BY gu_login ';
-	$ReqLog1 = \includes\SQL::query($sql1);
-	while ($resultat1 = $ReqLog1->fetch_array())
-		$list_users[] = '"'.\includes\SQL::quote($resultat1["gu_login"]).'"';
+    $list_users=array();
+    $sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = '.intval($group_id).' ORDER BY gu_login ';
+    $ReqLog1 = \includes\SQL::query($sql1);
+    while ($resultat1 = $ReqLog1->fetch_array())
+        $list_users[] = '"'.\includes\SQL::quote($resultat1["gu_login"]).'"';
 
-	$list_users = implode(' , ', $list_users);
+    $list_users = implode(' , ', $list_users);
 
-	if( $DEBUG ) { echo "list_users = $list_users<br>\n" ;}
+    if( $DEBUG ) { echo "list_users = $list_users<br>\n" ;}
 
-	return $list_users;
+    return $list_users;
 }
 
 // recup de la liste des groupes dont $resp_login est responsable
 // renvoit une liste de group_id séparés par des virgules
 function get_list_groupes_du_resp($resp_login,  $DEBUG=FALSE)
 {
-	$list_group="";
-	$sql1='SELECT gr_gid FROM conges_groupe_resp WHERE gr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY gr_gid';
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $list_group="";
+    $sql1='SELECT gr_gid FROM conges_groupe_resp WHERE gr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY gr_gid';
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	if($ReqLog1->num_rows !=0)
-	{
-		while ($resultat1 = $ReqLog1->fetch_array())
-		{
-			$current_group=$resultat1["gr_gid"];
-			if($list_group=="")
-				$list_group="$current_group";
-			else
-				$list_group=$list_group.", $current_group";
-		}
-	}
-	if( $DEBUG ) { echo "list_group = $list_group<br>\n" ;}
+    if($ReqLog1->num_rows !=0)
+    {
+        while ($resultat1 = $ReqLog1->fetch_array())
+        {
+            $current_group=$resultat1["gr_gid"];
+            if($list_group=="")
+                $list_group="$current_group";
+            else
+                $list_group=$list_group.", $current_group";
+        }
+    }
+    if( $DEBUG ) { echo "list_group = $list_group<br>\n" ;}
 
-	return $list_group;
+    return $list_group;
 }
 
 // recup de la liste des groupes dont $resp_login est grandresponsable
 // renvoit une liste de group_id séparés par des virgules
 function get_list_groupes_du_grand_resp($resp_login)
 {
-	$list_group="";
-	$sql1='SELECT ggr_gid FROM conges_groupe_grd_resp WHERE ggr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY ggr_gid';
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $list_group="";
+    $sql1='SELECT ggr_gid FROM conges_groupe_grd_resp WHERE ggr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY ggr_gid';
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	if($ReqLog1->num_rows!=0)
-	{
-		while ($resultat1 = $ReqLog1->fetch_array())
-		{
-			$current_group=$resultat1["ggr_gid"];
-			if($list_group=="")
-				$list_group="$current_group";
-			else
-				$list_group=$list_group.", $current_group";
-		}
-	}
-	return $list_group;
+    if($ReqLog1->num_rows!=0)
+    {
+        while ($resultat1 = $ReqLog1->fetch_array())
+        {
+            $current_group=$resultat1["ggr_gid"];
+            if($list_group=="")
+                $list_group="$current_group";
+            else
+                $list_group=$list_group.", $current_group";
+        }
+    }
+    return $list_group;
 }
 
 // recup de la liste des logins des groupes dont $resp_login est grandresponsable
 function get_list_login_du_grand_resp($resp_login)
 {
-	$list_logins = array();
-	$sql1='SELECT gu_login FROM conges_groupe_grd_resp JOIN conges_groupe_users ON ggr_gid = gu_gid WHERE ggr_login="'.\includes\SQL::quote($resp_login).'";';
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $list_logins = array();
+    $sql1='SELECT gu_login FROM conges_groupe_grd_resp JOIN conges_groupe_users ON ggr_gid = gu_gid WHERE ggr_login="'.\includes\SQL::quote($resp_login).'";';
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	if($ReqLog1->num_rows!=0)
-	{
-		while ($resultat1 = $ReqLog1->fetch_array())
-				$list_logins[] = $resultat1["gu_login"];
-	}
-	return $list_logins;
+    if($ReqLog1->num_rows!=0)
+    {
+        while ($resultat1 = $ReqLog1->fetch_array())
+                $list_logins[] = $resultat1["gu_login"];
+    }
+    return $list_logins;
 }
 
 // recup de la liste des groupes à double validation
 // renvoit une liste de gid séparés par des virgules
 function get_list_groupes_double_valid( $DEBUG=FALSE)
 {
-	$list_groupes_double_valid="";
-	$sql1="SELECT g_gid FROM conges_groupe WHERE g_double_valid='Y' ORDER BY g_gid ";
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $list_groupes_double_valid="";
+    $sql1="SELECT g_gid FROM conges_groupe WHERE g_double_valid='Y' ORDER BY g_gid ";
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	while ($resultat1 = $ReqLog1->fetch_array())
-	{
-		$current_gid=$resultat1["g_gid"];
-		if($list_groupes_double_valid=="")
-			$list_groupes_double_valid="$current_gid";
-		else
-			$list_groupes_double_valid=$list_groupes_double_valid.", $current_gid";
-	}
+    while ($resultat1 = $ReqLog1->fetch_array())
+    {
+        $current_gid=$resultat1["g_gid"];
+        if($list_groupes_double_valid=="")
+            $list_groupes_double_valid="$current_gid";
+        else
+            $list_groupes_double_valid=$list_groupes_double_valid.", $current_gid";
+    }
 
-	if( $DEBUG ) { echo "list_groupes_double_valid = $list_groupes_double_valid<br>\n" ;}
+    if( $DEBUG ) { echo "list_groupes_double_valid = $list_groupes_double_valid<br>\n" ;}
 
-	return $list_groupes_double_valid;
+    return $list_groupes_double_valid;
 
 }
 
@@ -1529,26 +1531,26 @@ function get_list_groupes_double_valid( $DEBUG=FALSE)
 // renvoit une liste de gid séparés par des virgules
 function get_list_groupes_double_valid_du_resp($resp_login,  $DEBUG=FALSE)
 {
-	$list_groupes_double_valid_du_resp="";
-	$list_groups=get_list_groupes_du_resp($resp_login,  $DEBUG);
+    $list_groupes_double_valid_du_resp="";
+    $list_groups=get_list_groupes_du_resp($resp_login,  $DEBUG);
 
-	if($list_groups!="") // si $resp_login est responsable d'au moins un groupe
-	{
-		$sql1='SELECT DISTINCT(g_gid) FROM conges_groupe WHERE g_double_valid=\'Y\' AND g_gid IN ('.\includes\SQL::quote($list_groups).') ORDER BY g_gid ';
-		$ReqLog1 = \includes\SQL::query($sql1);
+    if($list_groups!="") // si $resp_login est responsable d'au moins un groupe
+    {
+        $sql1='SELECT DISTINCT(g_gid) FROM conges_groupe WHERE g_double_valid=\'Y\' AND g_gid IN ('.\includes\SQL::quote($list_groups).') ORDER BY g_gid ';
+        $ReqLog1 = \includes\SQL::query($sql1);
 
-		while ($resultat1 = $ReqLog1->fetch_array())
-		{
-			$current_gid=$resultat1["g_gid"];
-			if($list_groupes_double_valid_du_resp=="")
-				$list_groupes_double_valid_du_resp="$current_gid";
-			else
-				$list_groupes_double_valid_du_resp=$list_groupes_double_valid_du_resp.", $current_gid";
-		}
-	}
-	if( $DEBUG ) { echo "list_groupes_double_valid_du_resp = $list_groupes_double_valid_du_resp<br>\n" ;}
+        while ($resultat1 = $ReqLog1->fetch_array())
+        {
+            $current_gid=$resultat1["g_gid"];
+            if($list_groupes_double_valid_du_resp=="")
+                $list_groupes_double_valid_du_resp="$current_gid";
+            else
+                $list_groupes_double_valid_du_resp=$list_groupes_double_valid_du_resp.", $current_gid";
+        }
+    }
+    if( $DEBUG ) { echo "list_groupes_double_valid_du_resp = $list_groupes_double_valid_du_resp<br>\n" ;}
 
-	return $list_groupes_double_valid_du_resp;
+    return $list_groupes_double_valid_du_resp;
 
 }
 
@@ -1557,76 +1559,76 @@ function get_list_groupes_double_valid_du_resp($resp_login,  $DEBUG=FALSE)
 function get_list_groupes_double_valid_du_grand_resp($resp_login,  $DEBUG=FALSE)
 {
 
-	$list_groupes_double_valid_du_grand_resp="";
+    $list_groupes_double_valid_du_grand_resp="";
 
-	$sql1='SELECT DISTINCT(ggr_gid) FROM conges_groupe_grd_resp WHERE ggr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY ggr_gid ';
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $sql1='SELECT DISTINCT(ggr_gid) FROM conges_groupe_grd_resp WHERE ggr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY ggr_gid ';
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	while ($resultat1 = $ReqLog1->fetch_array())
-	{
-		$current_gid=$resultat1["ggr_gid"];
-		if($list_groupes_double_valid_du_grand_resp=="")
-			$list_groupes_double_valid_du_grand_resp="$current_gid";
-		else
-			$list_groupes_double_valid_du_grand_resp=$list_groupes_double_valid_du_grand_resp.", $current_gid";
-	}
-	if( $DEBUG ) { echo "list_groupes_double_valid_du_grand_resp = $list_groupes_double_valid_du_grand_resp<br>\n" ;}
+    while ($resultat1 = $ReqLog1->fetch_array())
+    {
+        $current_gid=$resultat1["ggr_gid"];
+        if($list_groupes_double_valid_du_grand_resp=="")
+            $list_groupes_double_valid_du_grand_resp="$current_gid";
+        else
+            $list_groupes_double_valid_du_grand_resp=$list_groupes_double_valid_du_grand_resp.", $current_gid";
+    }
+    if( $DEBUG ) { echo "list_groupes_double_valid_du_grand_resp = $list_groupes_double_valid_du_grand_resp<br>\n" ;}
 
-	return $list_groupes_double_valid_du_grand_resp;
+    return $list_groupes_double_valid_du_grand_resp;
 }
 
 // recup de la liste des users des groupes dont $user_login est membre
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_users_des_groupes_du_user($user_login,  $DEBUG=FALSE)
 {
-	$list_users=array();
-	$list_groups=get_list_groupes_du_user($user_login,  $DEBUG);
-	if($list_groups!="") // si $user_login est membre d'au moins un groupe
-	{
-		$sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ('.$list_groups.') ORDER BY gu_login ';
-		$ReqLog1 = \includes\SQL::query($sql1);
+    $list_users=array();
+    $list_groups=get_list_groupes_du_user($user_login,  $DEBUG);
+    if($list_groups!="") // si $user_login est membre d'au moins un groupe
+    {
+        $sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ('.$list_groups.') ORDER BY gu_login ';
+        $ReqLog1 = \includes\SQL::query($sql1);
 
-		while ($resultat1 = $ReqLog1->fetch_array())
-			$list_users[] = '"'.\includes\SQL::quote($resultat1["gu_login"]).'"';
-	}
-	$list_users = implode(' , ', $list_users);
-	return $list_users;
+        while ($resultat1 = $ReqLog1->fetch_array())
+            $list_users[] = '"'.\includes\SQL::quote($resultat1["gu_login"]).'"';
+    }
+    $list_users = implode(' , ', $list_users);
+    return $list_users;
 }
 
 // recup de la liste des groupes dont $resp_login est membre
 // renvoit une liste de group_id séparés par des virgules
 function get_list_groupes_du_user($user_login,  $DEBUG=FALSE)
 {
-	$list_group=array();
-	$sql1='SELECT gu_gid FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($user_login).'" ORDER BY gu_gid';
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $list_group=array();
+    $sql1='SELECT gu_gid FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($user_login).'" ORDER BY gu_gid';
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	while ($resultat1 = $ReqLog1->fetch_array())
-		$list_group[] = $resultat1["gu_gid"];
-	$list_group = implode(' , ', $list_group);
-	return $list_group;
+    while ($resultat1 = $ReqLog1->fetch_array())
+        $list_group[] = $resultat1["gu_gid"];
+    $list_group = implode(' , ', $list_group);
+    return $list_group;
 }
 
 // recup de la liste de TOUS les users (sauf "conges" et "admin"
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_all_users($DEBUG=FALSE)
 {
-	$list_users="";
-	$sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_login " ;
-	$ReqLog1 = \includes\SQL::query($sql1);
+    $list_users="";
+    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_login " ;
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	while ($resultat1 = $ReqLog1->fetch_array())
-	{
-		$current_login=$resultat1["u_login"];
-		if($list_users=="")
-			$list_users="'$current_login'";
-		else
-			$list_users=$list_users.", '$current_login'";
-	}
+    while ($resultat1 = $ReqLog1->fetch_array())
+    {
+        $current_login=$resultat1["u_login"];
+        if($list_users=="")
+            $list_users="'$current_login'";
+        else
+            $list_users=$list_users.", '$current_login'";
+    }
 
-	if( $DEBUG ) { echo "list_users = $list_users<br>\n" ;}
+    if( $DEBUG ) { echo "list_users = $list_users<br>\n" ;}
 
-	return $list_users;
+    return $list_users;
 }
 
 
@@ -1634,16 +1636,16 @@ function get_list_all_users($DEBUG=FALSE)
 // renvoit une liste de group_id séparés par des virgules
 function get_list_all_groupes($DEBUG=FALSE)
 {
-	$list_group = array();
+    $list_group = array();
 
-	// on select dans conges_groupe_users pour ne récupérer QUE les groupes qui ont des users !!
-	$sql1="SELECT DISTINCT(gu_gid) FROM conges_groupe_users ORDER BY gu_gid";
-	$ReqLog1 = \includes\SQL::query($sql1);
+    // on select dans conges_groupe_users pour ne récupérer QUE les groupes qui ont des users !!
+    $sql1="SELECT DISTINCT(gu_gid) FROM conges_groupe_users ORDER BY gu_gid";
+    $ReqLog1 = \includes\SQL::query($sql1);
 
-	while ($resultat1 = $ReqLog1->fetch_array())
-		$list_group[] = $resultat1["gu_gid"];
+    while ($resultat1 = $ReqLog1->fetch_array())
+        $list_group[] = $resultat1["gu_gid"];
 
-	return implode(',',$list_group);
+    return implode(',',$list_group);
 }
 
 
@@ -1652,85 +1654,85 @@ function get_list_all_groupes($DEBUG=FALSE)
 //renvoit un tableau indexé de resp_login => "absent" ou "present"
 function get_tab_resp_du_user($user_login,  $DEBUG=FALSE)
 {
-	$tab_resp=array();
-	if( $DEBUG ) {echo ">> RECHERCHE des RESPONSABLES de : $user_login<br>\n";}
-	// recup du resp indiqué dans la table users (sauf s'il est resp de lui meme)
-	$req = 'SELECT u_resp_login FROM conges_users WHERE u_login=\''.\includes\SQL::quote($user_login).'\';';
-	$res = \includes\SQL::query($req);
-	$rec = $res->fetch_array();
-	if ($rec['u_resp_login'] !== NULL)
-		$tab_resp[$rec['u_resp_login']]="present";
+    $tab_resp=array();
+    if( $DEBUG ) {echo ">> RECHERCHE des RESPONSABLES de : $user_login<br>\n";}
+    // recup du resp indiqué dans la table users (sauf s'il est resp de lui meme)
+    $req = 'SELECT u_resp_login FROM conges_users WHERE u_login=\''.\includes\SQL::quote($user_login).'\';';
+    $res = \includes\SQL::query($req);
+    $rec = $res->fetch_array();
+    if ($rec['u_resp_login'] !== NULL)
+        $tab_resp[$rec['u_resp_login']]="present";
 
-	// recup des resp des groupes du user
-	if($_SESSION['config']['gestion_groupes'])
-	{
-		$list_groups=get_list_groupes_du_user($user_login,  $DEBUG);
-		if($list_groups!="")
-		{
-			$tab_gid=explode(",", $list_groups);
-			foreach($tab_gid as $gid)
-			{
-				$gid=trim($gid);
-				$sql2='SELECT gr_login FROM conges_groupe_resp WHERE gr_gid=' . \includes\SQL::quote($gid) . ' AND gr_login!=\'' . \includes\SQL::quote($user_login) . '\'';
-				$ReqLog1 = \includes\SQL::query($sql2);
+    // recup des resp des groupes du user
+    if($_SESSION['config']['gestion_groupes'])
+    {
+        $list_groups=get_list_groupes_du_user($user_login,  $DEBUG);
+        if($list_groups!="")
+        {
+            $tab_gid=explode(",", $list_groups);
+            foreach($tab_gid as $gid)
+            {
+                $gid=trim($gid);
+                $sql2='SELECT gr_login FROM conges_groupe_resp WHERE gr_gid=' . \includes\SQL::quote($gid) . ' AND gr_login!=\'' . \includes\SQL::quote($user_login) . '\'';
+                $ReqLog1 = \includes\SQL::query($sql2);
 
-				while ($resultat1 = $ReqLog1->fetch_array())
-				{
-					//attention à ne pas mettre 2 fois le meme resp dans le tableau
-					if (in_array($resultat1["gr_login"], $tab_resp)==FALSE)
-						$tab_resp[$resultat1["gr_login"]]="present";
-				}
-			}
-		}
-	}
+                while ($resultat1 = $ReqLog1->fetch_array())
+                {
+                    //attention à ne pas mettre 2 fois le meme resp dans le tableau
+                    if (in_array($resultat1["gr_login"], $tab_resp)==FALSE)
+                        $tab_resp[$resultat1["gr_login"]]="present";
+                }
+            }
+        }
+    }
 
-	if( $DEBUG ) {echo "tab_resp intermediaire =\n"; print_r($tab_resp); echo "<br>\n";}
+    if( $DEBUG ) {echo "tab_resp intermediaire =\n"; print_r($tab_resp); echo "<br>\n";}
 
-	/************************************/
-	// gestion des absence des responsables :
-	// on verifie que les resp sont présents, si tous absent, on cherhe les resp des resp, et ainsi de suite ....
-	if($_SESSION['config']['gestion_cas_absence_responsable'])
-	{
-		if( $DEBUG ) {echo "gestion des absence des responsables<br>\n"; }
+    /************************************/
+    // gestion des absence des responsables :
+    // on verifie que les resp sont présents, si tous absent, on cherhe les resp des resp, et ainsi de suite ....
+    if($_SESSION['config']['gestion_cas_absence_responsable'])
+    {
+        if( $DEBUG ) {echo "gestion des absence des responsables<br>\n"; }
 
-		// on va verifier si les resp récupérés sont absents
-		$nb_present=count($tab_resp);
-		foreach ($tab_resp as $current_resp => $presence )
-		{
-			// verif dans la base si le current_resp est absent :
-			$req = 'SELECT p_num
-					 FROM conges_periode
-					 WHERE p_login =\''.\includes\SQL::quote($current_resp).'\'
-					 AND p_etat = \'ok\'
-					 AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW())
-					 AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
-			$ReqLog_3 = \includes\SQL::query($req);
-			if($ReqLog_3->num_rows!=0)
-			{
-				$nb_present=$nb_present-1;
-				$tab_resp[$current_resp]="absent";
-			}
-		}
+        // on va verifier si les resp récupérés sont absents
+        $nb_present=count($tab_resp);
+        foreach ($tab_resp as $current_resp => $presence )
+        {
+            // verif dans la base si le current_resp est absent :
+            $req = 'SELECT p_num
+                     FROM conges_periode
+                     WHERE p_login =\''.\includes\SQL::quote($current_resp).'\'
+                     AND p_etat = \'ok\'
+                     AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW())
+                     AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
+            $ReqLog_3 = \includes\SQL::query($req);
+            if($ReqLog_3->num_rows!=0)
+            {
+                $nb_present=$nb_present-1;
+                $tab_resp[$current_resp]="absent";
+            }
+        }
 
-		//si aucun resp present on recupere les resp du resp
-		if($nb_present==0)
-		{
-			$new_tab_resp=array();
-			if( $DEBUG ) { echo "zero resp présent<br>\n"; }
-			foreach ($tab_resp as $current_resp => $presence)
-			{
-				// attention ,on evite le cas ou le user est son propre resp (sinon on boucle infiniment)
-				if($current_resp != $user_login)
-					$new_tab_resp = array_merge  ( $new_tab_resp , get_tab_resp_du_user($current_resp,  $DEBUG));
-			}
-			$tab_resp = array_merge  ( $tab_resp, $new_tab_resp);
-		}
-	}
-	// FIN gestion des absence des responsables :
-	/************************************/
+        //si aucun resp present on recupere les resp du resp
+        if($nb_present==0)
+        {
+            $new_tab_resp=array();
+            if( $DEBUG ) { echo "zero resp présent<br>\n"; }
+            foreach ($tab_resp as $current_resp => $presence)
+            {
+                // attention ,on evite le cas ou le user est son propre resp (sinon on boucle infiniment)
+                if($current_resp != $user_login)
+                    $new_tab_resp = array_merge  ( $new_tab_resp , get_tab_resp_du_user($current_resp,  $DEBUG));
+            }
+            $tab_resp = array_merge  ( $tab_resp, $new_tab_resp);
+        }
+    }
+    // FIN gestion des absence des responsables :
+    /************************************/
 
-	if( $DEBUG ) {echo "return tab_resp =\n"; print_r($tab_resp); echo "<br>\n";}
-	return $tab_resp;
+    if( $DEBUG ) {echo "return tab_resp =\n"; print_r($tab_resp); echo "<br>\n";}
+    return $tab_resp;
 }
 
 
@@ -1739,30 +1741,30 @@ function get_tab_resp_du_user($user_login,  $DEBUG=FALSE)
 // le login du user est passé en paramêtre ainsi que le tableau (vide) des resp
 function get_tab_grd_resp_du_user($user_login, &$tab_grd_resp,  $DEBUG=FALSE)
 {
-	// recup des resp des groupes du user
-	if($_SESSION['config']['gestion_groupes'])
-	{
-		$list_groups=get_list_groupes_du_user($user_login,  $DEBUG);
-		if( $DEBUG ) { echo "list_groups : <br>$list_groups<br>\n"; }
+    // recup des resp des groupes du user
+    if($_SESSION['config']['gestion_groupes'])
+    {
+        $list_groups=get_list_groupes_du_user($user_login,  $DEBUG);
+        if( $DEBUG ) { echo "list_groups : <br>$list_groups<br>\n"; }
 
-		if($list_groups!="")
-		{
-			$tab_gid=explode(",", $list_groups);
-			foreach($tab_gid as $gid)
-			{
-				$gid=trim($gid);
-				$sql1='SELECT ggr_login FROM conges_groupe_grd_resp WHERE ggr_gid='.\includes\SQL::quote($gid);
-				$ReqLog1 = \includes\SQL::query($sql1);
+        if($list_groups!="")
+        {
+            $tab_gid=explode(",", $list_groups);
+            foreach($tab_gid as $gid)
+            {
+                $gid=trim($gid);
+                $sql1='SELECT ggr_login FROM conges_groupe_grd_resp WHERE ggr_gid='.\includes\SQL::quote($gid);
+                $ReqLog1 = \includes\SQL::query($sql1);
 
-				while ($resultat1 = $ReqLog1->fetch_array())
-				{
-					//attention à ne pas mettre 2 fois le meme resp dans le tableau
-					if (in_array($resultat1["ggr_login"], $tab_grd_resp)==FALSE)
-						$tab_grd_resp[]=$resultat1["ggr_login"];
-				}
-			}
-		}
-	}
+                while ($resultat1 = $ReqLog1->fetch_array())
+                {
+                    //attention à ne pas mettre 2 fois le meme resp dans le tableau
+                    if (in_array($resultat1["ggr_login"], $tab_grd_resp)==FALSE)
+                        $tab_grd_resp[]=$resultat1["ggr_login"];
+                }
+            }
+        }
+    }
 }
 
 
@@ -1777,14 +1779,14 @@ connecter alors qu'il n'a pas de compte dans
    False, sinon
 
 */
-	// connexion MySQL + selection de la database sur le serveur
+    // connexion MySQL + selection de la database sur le serveur
 
-	$req = 'SELECT COUNT(*) FROM conges_users WHERE u_login="'.\includes\SQL::quote($username).'";';
-	$res = \includes\SQL::query($req);
-	$cpt = $res->fetch_array();
-	$cpt = $cpt[0];
+    $req = 'SELECT COUNT(*) FROM conges_users WHERE u_login="'.\includes\SQL::quote($username).'";';
+    $res = \includes\SQL::query($req);
+    $cpt = $res->fetch_array();
+    $cpt = $cpt[0];
 
-	return ( $cpt != 0 );
+    return ( $cpt != 0 );
 }
 
 
@@ -1792,100 +1794,100 @@ connecter alors qu'il n'a pas de compte dans
 // renvoit TRUE si le login est responsable dans la table conges_users, FALSE sinon.
 function is_resp($login)
 {
-	static $sql_is_resp = array();
-	if (!isset($sql_is_resp[$login]))
-	{
-		// recup de qq infos sur le user
-		$select_info='SELECT u_is_resp FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'"';
-		$ReqLog_info = \includes\SQL::query($select_info);
-		$resultat_info = $ReqLog_info->fetch_array();
-		$sql_is_resp[$login]=$resultat_info["u_is_resp"];
-	}
+    static $sql_is_resp = array();
+    if (!isset($sql_is_resp[$login]))
+    {
+        // recup de qq infos sur le user
+        $select_info='SELECT u_is_resp FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'"';
+        $ReqLog_info = \includes\SQL::query($select_info);
+        $resultat_info = $ReqLog_info->fetch_array();
+        $sql_is_resp[$login]=$resultat_info["u_is_resp"];
+    }
 
-	return ($sql_is_resp[$login]=='Y');
+    return ($sql_is_resp[$login]=='Y');
 }
 
 // verifie si un user est HR ou pas
 // renvoit TRUE si le login est HR dans la table conges_users, FALSE sinon.
 function is_hr($login,  $DEBUG=FALSE)
 {
-	static $sql_is_hr = array();
-	if (!isset($sql_is_hr[$login]))
-	{
-		// recup de qq infos sur le user
-		$select_info='SELECT u_is_hr FROM conges_users WHERE u_login="'. \includes\SQL::quote($login).'";';
-		$ReqLog_info = \includes\SQL::query($select_info);
-		$resultat_info = $ReqLog_info->fetch_array();
-		$sql_is_hr[$login]=$resultat_info["u_is_hr"];
-	}
+    static $sql_is_hr = array();
+    if (!isset($sql_is_hr[$login]))
+    {
+        // recup de qq infos sur le user
+        $select_info='SELECT u_is_hr FROM conges_users WHERE u_login="'. \includes\SQL::quote($login).'";';
+        $ReqLog_info = \includes\SQL::query($select_info);
+        $resultat_info = $ReqLog_info->fetch_array();
+        $sql_is_hr[$login]=$resultat_info["u_is_hr"];
+    }
 
-	return ($sql_is_hr[$login]=='Y');
+    return ($sql_is_hr[$login]=='Y');
 }
 // verifie si un user est valide ou pas
 // renvoit TRUE si le login est enable dans la table conges_users, FALSE sinon.
 function is_active($login,  $DEBUG=FALSE)
 {
-	static $sql_is_active = array();
-	if (!isset($sql_is_active[$login]))
-	{
-		// recup de qq infos sur le user
-		$select_info='SELECT u_is_active FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'";';
-		$ReqLog_info = \includes\SQL::query($select_info);
-		$resultat_info = $ReqLog_info->fetch_array();
-		$sql_is_active[$login]=$resultat_info["u_is_active"];
-	}
+    static $sql_is_active = array();
+    if (!isset($sql_is_active[$login]))
+    {
+        // recup de qq infos sur le user
+        $select_info='SELECT u_is_active FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'";';
+        $ReqLog_info = \includes\SQL::query($select_info);
+        $resultat_info = $ReqLog_info->fetch_array();
+        $sql_is_active[$login]=$resultat_info["u_is_active"];
+    }
 
-	return ($sql_is_active[$login]=='Y');
+    return ($sql_is_active[$login]=='Y');
 }
 
 // verifie si un user est responsable d'un second user
 // renvoit TRUE si le $resp_login est responsable du $user_login, FALSE sinon.
 function is_resp_of_user($resp_login, $user_login,  $DEBUG=FALSE)
 {
-	return is_resp_direct_of_user($resp_login, $user_login,  $DEBUG=FALSE) || is_resp_group_of_user($resp_login, $user_login,  $DEBUG=FALSE) || is_gr_group_of_user($resp_login, $user_login,  $DEBUG=FALSE);
+    return is_resp_direct_of_user($resp_login, $user_login,  $DEBUG=FALSE) || is_resp_group_of_user($resp_login, $user_login,  $DEBUG=FALSE) || is_gr_group_of_user($resp_login, $user_login,  $DEBUG=FALSE);
 }
 
 
 function is_resp_direct_of_user($resp_login, $user_login,  $DEBUG=FALSE)
 {
 
-	$select_info='SELECT u_resp_login FROM conges_users WHERE u_login=\''.\includes\SQL::quote($user_login).'\';';
-	$ReqLog_info = \includes\SQL::query($select_info);
-	$resultat_info = $ReqLog_info->fetch_array();
-	$sql_resp_login=$resultat_info["u_resp_login"];
-	return ($resp_login==$sql_resp_login);
+    $select_info='SELECT u_resp_login FROM conges_users WHERE u_login=\''.\includes\SQL::quote($user_login).'\';';
+    $ReqLog_info = \includes\SQL::query($select_info);
+    $resultat_info = $ReqLog_info->fetch_array();
+    $sql_resp_login=$resultat_info["u_resp_login"];
+    return ($resp_login==$sql_resp_login);
 }
 
 
 function is_resp_group_of_user($resp_login, $user_login,  $DEBUG=FALSE)
 {
-	if ( $_SESSION['config']['gestion_groupes'] )
-	{
-		$ReqLog_info = \includes\SQL::query('SELECT count(*)
-				FROM `conges_groupe_users`
-				JOIN conges_groupe_resp ON gr_gid = gu_gid
-				WHERE gu_login = \''.\includes\SQL::quote($user_login).'\'
-				AND gr_login = \''.\includes\SQL::quote($resp_login).'\';');
-		$resultat_info = $ReqLog_info->fetch_array();
-		return ($resultat_info[0] != 0);
-	}
-	return false;
+    if ( $_SESSION['config']['gestion_groupes'] )
+    {
+        $ReqLog_info = \includes\SQL::query('SELECT count(*)
+                FROM `conges_groupe_users`
+                JOIN conges_groupe_resp ON gr_gid = gu_gid
+                WHERE gu_login = \''.\includes\SQL::quote($user_login).'\'
+                AND gr_login = \''.\includes\SQL::quote($resp_login).'\';');
+        $resultat_info = $ReqLog_info->fetch_array();
+        return ($resultat_info[0] != 0);
+    }
+    return false;
 }
 
 function is_gr_group_of_user($resp_login, $user_login,  $DEBUG=FALSE)
 {
-	if ( $_SESSION['config']['gestion_groupes'] && $_SESSION['config']['double_validation_conges'])
-	{
+    if ( $_SESSION['config']['gestion_groupes'] && $_SESSION['config']['double_validation_conges'])
+    {
 
-		$ReqLog_info = \includes\SQL::query('SELECT count(*)
-				FROM `conges_groupe_users`
-				JOIN conges_groupe_grd_resp ON ggr_gid = gu_gid
-				WHERE gu_login = \''.\includes\SQL::quote($user_login).'\'
-				AND ggr_login = \''.\includes\SQL::quote($resp_login).'\';');
-		$resultat_info = $ReqLog_info->fetch_array();
-		return ($resultat_info[0] != 0);
-	}
-	return false;
+        $ReqLog_info = \includes\SQL::query('SELECT count(*)
+                FROM `conges_groupe_users`
+                JOIN conges_groupe_grd_resp ON ggr_gid = gu_gid
+                WHERE gu_login = \''.\includes\SQL::quote($user_login).'\'
+                AND ggr_login = \''.\includes\SQL::quote($resp_login).'\';');
+        $resultat_info = $ReqLog_info->fetch_array();
+        return ($resultat_info[0] != 0);
+    }
+    return false;
 }
 
 
@@ -1894,17 +1896,17 @@ function is_gr_group_of_user($resp_login, $user_login,  $DEBUG=FALSE)
 // renvoit TRUE si le login est administrateur dans la table conges_users, FALSE sinon.
 function is_admin($login, $DEBUG=FALSE)
 {
-	static $sql_is_admin = array();
-	if (!isset($sql_is_admin[$login])) {
-		// recup de qq infos sur le user
-		$select_info='SELECT u_is_admin FROM conges_users WHERE u_login="'. \includes\SQL::quote($login).'";';
-		$ReqLog_info = \includes\SQL::query($select_info);
+    static $sql_is_admin = array();
+    if (!isset($sql_is_admin[$login])) {
+        // recup de qq infos sur le user
+        $select_info='SELECT u_is_admin FROM conges_users WHERE u_login="'. \includes\SQL::quote($login).'";';
+        $ReqLog_info = \includes\SQL::query($select_info);
 
-		$resultat_info = $ReqLog_info->fetch_array();
-		$sql_is_admin[$login]=$resultat_info["u_is_admin"];
-	}
+        $resultat_info = $ReqLog_info->fetch_array();
+        $sql_is_admin[$login]=$resultat_info["u_is_admin"];
+    }
 
-	return ($sql_is_admin[$login]=='Y');
+    return ($sql_is_admin[$login]=='Y');
 }
 
 
@@ -1914,199 +1916,198 @@ function is_admin($login, $DEBUG=FALSE)
 // retourne le num d'auto_incremente (p_num) ou 0 en cas l'erreur
 function insert_dans_periode($login, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin, $nb_jours, $commentaire, $id_type_abs, $etat, $id_fermeture, $DEBUG=FALSE)
 {
-	// Récupération du + grand p_num (+ grand numero identifiant de conges)
-	$sql1 = "SELECT max(p_num) FROM conges_periode" ;
-	$ReqLog1 = \includes\SQL::query($sql1);
-	if ( $num_new_demande = $ReqLog1->fetch_row() )
-		$num_new_demande = $num_new_demande[0] +1;
-	else
-		$num_new_demande = 1;
+    // Récupération du + grand p_num (+ grand numero identifiant de conges)
+    $sql1 = "SELECT max(p_num) FROM conges_periode" ;
+    $ReqLog1 = \includes\SQL::query($sql1);
+    if ( $num_new_demande = $ReqLog1->fetch_row() )
+        $num_new_demande = $num_new_demande[0] +1;
+    else
+        $num_new_demande = 1;
 
-	$sql2 = "INSERT INTO conges_periode SET p_login='$login',p_date_deb='$date_deb', p_demi_jour_deb='$demi_jour_deb',p_date_fin='$date_fin', p_demi_jour_fin='$demi_jour_fin', p_nb_jours='$nb_jours', p_commentaire='$commentaire', p_type='$id_type_abs', p_etat='$etat', ";
+    $sql2 = "INSERT INTO conges_periode SET p_login='$login',p_date_deb='$date_deb', p_demi_jour_deb='$demi_jour_deb',p_date_fin='$date_fin', p_demi_jour_fin='$demi_jour_fin', p_nb_jours='$nb_jours', p_commentaire='$commentaire', p_type='$id_type_abs', p_etat='$etat', ";
 
-	if($id_fermeture!=0)
-		$sql2 = $sql2." p_fermeture_id='$id_fermeture' ," ;
-	if($etat=="demande")
-		$sql2 = $sql2." p_date_demande=NOW() ," ;
-	else
-		$sql2 = $sql2." p_date_traitement=NOW() ," ;
+    if($id_fermeture!=0)
+        $sql2 = $sql2." p_fermeture_id='$id_fermeture' ," ;
+    if($etat=="demande")
+        $sql2 = $sql2." p_date_demande=NOW() ," ;
+    else
+        $sql2 = $sql2." p_date_traitement=NOW() ," ;
 
-	$sql2 = $sql2." p_num='$num_new_demande' " ;
-	$result = \includes\SQL::query($sql2);
+    $sql2 = $sql2." p_num='$num_new_demande' " ;
+    $result = \includes\SQL::query($sql2);
 
-	if($id_fermeture!=0)
-		$comment_log = "saisie de fermeture num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
-	elseif($etat=="demande")
-		$comment_log = "demande de conges num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
-	else
-		$comment_log = "saisie de conges num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
+    if($id_fermeture!=0)
+        $comment_log = "saisie de fermeture num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
+    elseif($etat=="demande")
+        $comment_log = "demande de conges num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
+    else
+        $comment_log = "saisie de conges num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
 
-	log_action($num_new_demande, $etat, $login, $comment_log, $DEBUG);
+    log_action($num_new_demande, $etat, $login, $comment_log, $DEBUG);
 
-	if($result)
-		return $num_new_demande;
-	else
-		return 0;
+    if($result)
+        return $num_new_demande;
+    else
+        return 0;
 }
 
 
 // remplit le tableau global des jours feries a partir de la database
 function init_tab_jours_feries()
 {
-	if (empty($_SESSION['tab_j_feries']))
-	{
-		$_SESSION['tab_j_feries']=array();
+    if (empty($_SESSION['tab_j_feries']))
+    {
+        $_SESSION['tab_j_feries']=array();
 
-		$sql_select='SELECT jf_date FROM conges_jours_feries;';
-		$res_select = \includes\SQL::query($sql_select);
+        $sql_select='SELECT jf_date FROM conges_jours_feries;';
+        $res_select = \includes\SQL::query($sql_select);
 
-		while( $row = $res_select->fetch_array())
-		{
-			$_SESSION['tab_j_feries'][]=$row['jf_date'];
-		}
-	}
+        while( $row = $res_select->fetch_array())
+        {
+            $_SESSION['tab_j_feries'][]=$row['jf_date'];
+        }
+    }
 }
 
 // renvoit TRUE si le jour est chomé (férié), sinon FALSE (verifie dans le tableau global $_SESSION["tab_j_feries"]
 function est_chome($timestamp)
 {
-	$j_date=date("Y-m-d", $timestamp);
-	if(isset($_SESSION["tab_j_feries"]))
-		return in_array($j_date, $_SESSION["tab_j_feries"]);
-	else
-		return FALSE;
+    $j_date=date("Y-m-d", $timestamp);
+    if(isset($_SESSION["tab_j_feries"]))
+        return in_array($j_date, $_SESSION["tab_j_feries"]);
+    else
+        return FALSE;
 }
-
 
 // initialise le tableau des variables de config (renvoit un tableau)
 function init_config_tab()
 {
-	static $userlogin = null;
-	static $result = null;
-	if ($result === null || $userlogin != $_SESSION['userlogin'])
-	{
+    static $userlogin = null;
+    static $result = null;
+    if ($result === null || $userlogin != $_SESSION['userlogin'])
+    {
 
-		include_once ROOT_PATH .'version.php';
-		include_once CONFIG_PATH .'dbconnect.php';
-		$tab = array();
+        include_once ROOT_PATH .'version.php';
+        include_once CONFIG_PATH .'dbconnect.php';
+        $tab = array();
 
-		/******************************************/
-		//  recup des variables de version.php
-		if(isset($config_php_conges_version)) $tab['php_conges_version'] = $config_php_conges_version ;
-		if(isset($config_url_site_web_php_conges)) $tab['url_site_web_php_conges'] = $config_url_site_web_php_conges ;
+        /******************************************/
+        //  recup des variables de version.php
+        if(isset($config_php_conges_version)) $tab['php_conges_version'] = $config_php_conges_version ;
+        if(isset($config_url_site_web_php_conges)) $tab['url_site_web_php_conges'] = $config_url_site_web_php_conges ;
 
-		/******************************************/
-		//  recup des variables de la table conges_appli
-		$sql_appli = "SELECT appli_variable, appli_valeur FROM conges_appli;";
-		$req_appli = \includes\SQL::query($sql_appli) ;
+        /******************************************/
+        //  recup des variables de la table conges_appli
+        $sql_appli = "SELECT appli_variable, appli_valeur FROM conges_appli;";
+        $req_appli = \includes\SQL::query($sql_appli) ;
 
-		while ($data_appli = $req_appli->fetch_array())
-		{
-			$key	= $data_appli[0];
-			$value	= $data_appli[1];
-			$tab[$key]	= $value;
-		}
+        while ($data_appli = $req_appli->fetch_array())
+        {
+            $key    = $data_appli[0];
+            $value    = $data_appli[1];
+            $tab[$key]    = $value;
+        }
 
-		/******************************************/
-		//  recup des variables de la table conges_config
+        /******************************************/
+        //  recup des variables de la table conges_config
 
-		$sql_config = "SELECT conf_nom, conf_valeur, conf_type FROM conges_config;";
-		$req_config = \includes\SQL::query($sql_config) ;
+        $sql_config = "SELECT conf_nom, conf_valeur, conf_type FROM conges_config;";
+        $req_config = \includes\SQL::query($sql_config) ;
 
-		while ($data = $req_config->fetch_array())
-		{
-			$key	= $data[0];
-			$value	= $data[1];
-			$type	= $data[2];
+        while ($data = $req_config->fetch_array())
+        {
+            $key    = $data[0];
+            $value    = $data[1];
+            $type    = $data[2];
 
-			if($value == "FALSE")
-				$value = false;
-			elseif($value == "TRUE")
-				$value = true;
-			elseif($type == "path")
-				$value =  ROOT_PATH ."/".$value ;
+            if($value == "FALSE")
+                $value = false;
+            elseif($value == "TRUE")
+                $value = true;
+            elseif($type == "path")
+                $value =  ROOT_PATH ."/".$value ;
 
-			$tab[$key] = $value;
-		}
+            $tab[$key] = $value;
+        }
 
 
-		/******************************************/
-		//  recup des mails dans  la table conges_mail
-		$sql_mail = "SELECT mail_nom, mail_subject, mail_body FROM conges_mail;";
-		$req_mail = \includes\SQL::query($sql_mail) ;
+        /******************************************/
+        //  recup des mails dans  la table conges_mail
+        $sql_mail = "SELECT mail_nom, mail_subject, mail_body FROM conges_mail;";
+        $req_mail = \includes\SQL::query($sql_mail) ;
 
-		while ($data_mail = $req_mail->fetch_array())
-		{
-			$mail_nom	= $data_mail[0];
-			$key1	= $mail_nom."_sujet";
-			$key2	= $mail_nom."_contenu";
-			$sujet	= $data_mail[1];
-			$corps	= $data_mail[2];
-			$tab[$key1] = $sujet ;
-			$tab[$key2] = $corps ;
-		}
+        while ($data_mail = $req_mail->fetch_array())
+        {
+            $mail_nom    = $data_mail[0];
+            $key1    = $mail_nom."_sujet";
+            $key2    = $mail_nom."_contenu";
+            $sujet    = $data_mail[1];
+            $corps    = $data_mail[2];
+            $tab[$key1] = $sujet ;
+            $tab[$key2] = $corps ;
+        }
 
-		/******************************************/
-		//  config_ldap.php
-		if (file_exists(CONFIG_PATH .'config_ldap.php'))
-		{
-			include_once CONFIG_PATH .'config_ldap.php';
-			if(isset($config_ldap_protocol_version))
-				$tab['ldap_protocol_version'] = $config_ldap_protocol_version ;
-			else
-				$tab['ldap_protocol_version'] = 0;
+        /******************************************/
+        //  config_ldap.php
+        if (file_exists(CONFIG_PATH .'config_ldap.php'))
+        {
+            include_once CONFIG_PATH .'config_ldap.php';
+            if(isset($config_ldap_protocol_version))
+                $tab['ldap_protocol_version'] = $config_ldap_protocol_version ;
+            else
+                $tab['ldap_protocol_version'] = 0;
 
-			if(isset($config_ldap_server))	$tab['ldap_server']	= $config_ldap_server ;
-			if(isset($config_ldap_bupsvr))	$tab['ldap_bupsvr']	= $config_ldap_bupsvr ;
-			if(isset($config_basedn))	$tab['basedn']		= $config_basedn ;
-			if(isset($config_ldap_user))	$tab['ldap_user']	= $config_ldap_user ;
-			if(isset($config_ldap_pass))	$tab['ldap_pass']	= $config_ldap_pass ;
-			if(isset($config_searchdn))	$tab['searchdn']	= $config_searchdn ;
-			if(isset($config_ldap_prenom))	$tab['ldap_prenom']	= $config_ldap_prenom ;
-			if(isset($config_ldap_nom))	$tab['ldap_nom']	= $config_ldap_nom ;
-			if(isset($config_ldap_mail))	$tab['ldap_mail']	= $config_ldap_mail ;
-			if(isset($config_ldap_login))	$tab['ldap_login']	= $config_ldap_login ;
-			if(isset($config_ldap_nomaff))	$tab['ldap_nomaff']	= $config_ldap_nomaff ;
-			if(isset($config_ldap_filtre))	$tab['ldap_filtre']	= $config_ldap_filtre ;
-			if(isset($config_ldap_filrech))	$tab['ldap_filrech']	= $config_ldap_filrech ;
-			if(isset($config_ldap_filtre_complet)) $tab['ldap_filtre_complet']  = $config_ldap_filtre_complet ;
-		}
+            if(isset($config_ldap_server))    $tab['ldap_server']    = $config_ldap_server ;
+            if(isset($config_ldap_bupsvr))    $tab['ldap_bupsvr']    = $config_ldap_bupsvr ;
+            if(isset($config_basedn))    $tab['basedn']        = $config_basedn ;
+            if(isset($config_ldap_user))    $tab['ldap_user']    = $config_ldap_user ;
+            if(isset($config_ldap_pass))    $tab['ldap_pass']    = $config_ldap_pass ;
+            if(isset($config_searchdn))    $tab['searchdn']    = $config_searchdn ;
+            if(isset($config_ldap_prenom))    $tab['ldap_prenom']    = $config_ldap_prenom ;
+            if(isset($config_ldap_nom))    $tab['ldap_nom']    = $config_ldap_nom ;
+            if(isset($config_ldap_mail))    $tab['ldap_mail']    = $config_ldap_mail ;
+            if(isset($config_ldap_login))    $tab['ldap_login']    = $config_ldap_login ;
+            if(isset($config_ldap_nomaff))    $tab['ldap_nomaff']    = $config_ldap_nomaff ;
+            if(isset($config_ldap_filtre))    $tab['ldap_filtre']    = $config_ldap_filtre ;
+            if(isset($config_ldap_filrech))    $tab['ldap_filrech']    = $config_ldap_filrech ;
+            if(isset($config_ldap_filtre_complet)) $tab['ldap_filtre_complet']  = $config_ldap_filtre_complet ;
+        }
 
-		/******************************************/
-		//  config_CAS.php
-		if (file_exists(CONFIG_PATH .'config_CAS.php'))
-		{
-			include_once CONFIG_PATH .'config_CAS.php';
-			if(isset($config_CAS_host))	$tab['CAS_host']	= $config_CAS_host ;
-			if(isset($config_CAS_portNumber)) $tab['CAS_portNumber'] = $config_CAS_portNumber ;
-			if(isset($config_CAS_URI))	$tab['CAS_URI']		= $config_CAS_URI ;
-			if(isset($config_CAS_CACERT))	$tab['CAS_CACERT']		= $config_CAS_CACERT ;
-		}
+        /******************************************/
+        //  config_CAS.php
+        if (file_exists(CONFIG_PATH .'config_CAS.php'))
+        {
+            include_once CONFIG_PATH .'config_CAS.php';
+            if(isset($config_CAS_host))    $tab['CAS_host']    = $config_CAS_host ;
+            if(isset($config_CAS_portNumber)) $tab['CAS_portNumber'] = $config_CAS_portNumber ;
+            if(isset($config_CAS_URI))    $tab['CAS_URI']        = $config_CAS_URI ;
+            if(isset($config_CAS_CACERT))    $tab['CAS_CACERT']        = $config_CAS_CACERT ;
+        }
 
-		/******************************************/
-		//  recup de qq infos sur le user
-		if(isset($_SESSION['userlogin']))
-		{
-			$sql_user = "SELECT u_nom, u_prenom, u_is_resp, u_is_admin, u_is_hr, u_is_active FROM conges_users WHERE u_login='".$_SESSION['userlogin']."' ";
-			$req_user = \includes\SQL::query($sql_user) ;
+        /******************************************/
+        //  recup de qq infos sur le user
+        if(isset($_SESSION['userlogin']))
+        {
+            $sql_user = "SELECT u_nom, u_prenom, u_is_resp, u_is_admin, u_is_hr, u_is_active FROM conges_users WHERE u_login='".$_SESSION['userlogin']."' ";
+            $req_user = \includes\SQL::query($sql_user) ;
 
-			if($data_user = $req_user->fetch_array())
-			{
-				$_SESSION['u_nom']	= $data_user[0] ;
-				$_SESSION['u_prenom']	= $data_user[1] ;
-				$_SESSION['is_resp']	= $data_user[2] ;
-				$_SESSION['is_admin']	= $data_user[3] ;
-				$_SESSION['is_hr']	= $data_user[4] ;
-				$_SESSION['is_active']	= $data_user[5] ;
-			}
-		}
+            if($data_user = $req_user->fetch_array())
+            {
+                $_SESSION['u_nom']    = $data_user[0] ;
+                $_SESSION['u_prenom']    = $data_user[1] ;
+                $_SESSION['is_resp']    = $data_user[2] ;
+                $_SESSION['is_admin']    = $data_user[3] ;
+                $_SESSION['is_hr']    = $data_user[4] ;
+                $_SESSION['is_active']    = $data_user[5] ;
+            }
+        }
 
-		/******************************************/
-		$result = $tab;
-		if (isset($_SESSION['userlogin']))
-			$userlogin = $_SESSION['userlogin'];
-	}
-	return $result;
+        /******************************************/
+        $result = $tab;
+        if (isset($_SESSION['userlogin']))
+            $userlogin = $_SESSION['userlogin'];
+    }
+    return $result;
 }
 
 
@@ -2125,387 +2126,390 @@ function getpost_variable($variable, $default="")
 function get_user_see_all($login)
 {
 
-	$request = 'SELECT u_see_all FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'";';
-	$data = \includes\SQL::query($request);
+    $request = 'SELECT u_see_all FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'";';
+    $data = \includes\SQL::query($request);
 
-	if($l = $data->fetch_array())
-	{
-		$see_all = $l['u_see_all'];
-		return ($see_all == 'Y');
-	}
-	else
-		return FALSE;
+    if($l = $data->fetch_array())
+    {
+        $see_all = $l['u_see_all'];
+        return ($see_all == 'Y');
+    }
+    else
+        return FALSE;
 }
 
 
 // recup dans un tableau des types de conges
 function recup_tableau_types_conges()
 {
-	$result = array();
-	$request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'conges\';';
-	$data   = \includes\SQL::query($request);
+    $result = array();
+    $request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'conges\';';
+    $data   = \includes\SQL::query($request);
 
-	while ($l = $data->fetch_array())
-	{
-		$id = $l['ta_id'];
-		$result[$id] = $l['ta_libelle'];
-	}
-	return $result;
+    while ($l = $data->fetch_array())
+    {
+        $id = $l['ta_id'];
+        $result[$id] = $l['ta_libelle'];
+    }
+    return $result;
 }
 
 // recup dans un tableau des types d'absence
 function recup_tableau_types_absence()
 {
-	$result = array();
-	$request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'absences\';';
-	$data   = \includes\SQL::query($request);
+    $result = array();
+    $request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'absences\';';
+    $data   = \includes\SQL::query($request);
 
-	while ($l = $data->fetch_array())
-	{
-		$id = $l['ta_id'];
-		$result[$id] = $l['ta_libelle'];
-	}
-	return $result;
+    while ($l = $data->fetch_array())
+    {
+        $id = $l['ta_id'];
+        $result[$id] = $l['ta_libelle'];
+    }
+    return $result;
 }
 
 // recup dans un tableau des types de conges exceptionnels
 function recup_tableau_types_conges_exceptionnels()
 {
-	$result = array();
-	$request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'conges_exceptionnels\';';
-	$data   = \includes\SQL::query($request);
+    $result = array();
+    $request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'conges_exceptionnels\';';
+    $data   = \includes\SQL::query($request);
 
-	while ($l = $data->fetch_array())
-	{
-		$id = $l['ta_id'];
-		$result[$id] = $l['ta_libelle'];
-	}
-	return $result;
+    while ($l = $data->fetch_array())
+    {
+        $id = $l['ta_id'];
+        $result[$id] = $l['ta_libelle'];
+    }
+    return $result;
 }
 
 // recup dans un tableau de tableau les infos des types de conges et absences
 function recup_tableau_tout_types_abs( )
 {
-	$result = array();
-	if ( $_SESSION['config']['gestion_conges_exceptionnels'] ) // on prend tout les types de conges
-		$request = 'SELECT ta_id, ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence;';
-	else // on prend tout les types de conges SAUF les conges exceptionnels
-		$request = 'SELECT ta_id, ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\';';
+    $result = array();
+    if ( $_SESSION['config']['gestion_conges_exceptionnels'] ) // on prend tout les types de conges
+        $request = 'SELECT ta_id, ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence;';
+    else // on prend tout les types de conges SAUF les conges exceptionnels
+        $request = 'SELECT ta_id, ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\';';
 
-	$data = \includes\SQL::query($request);
+    $data = \includes\SQL::query($request);
 
-	while ($resultat_cong = $data->fetch_array())
-	{
-		$id = $resultat_cong['ta_id'];
-		$result[$id] = array('type' =>  $resultat_cong['ta_type'],'libelle' => $resultat_cong['ta_libelle'],'short_libelle' =>  $resultat_cong['ta_short_libelle'],);
-	}
-	return $result;
+    while ($resultat_cong = $data->fetch_array())
+    {
+        $id = $resultat_cong['ta_id'];
+        $result[$id] = array('type' =>  $resultat_cong['ta_type'],'libelle' => $resultat_cong['ta_libelle'],'short_libelle' =>  $resultat_cong['ta_short_libelle'],);
+    }
+    return $result;
 }
 
 // recup dans un tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
 function recup_tableau_conges_for_user($login, $hide_conges_exceptionnels)
 {
-	// on pourrait tout faire en un seule select, mais cela bug si on change la prise en charge des conges exceptionnels en cours d'utilisation ...
+    // on pourrait tout faire en un seule select, mais cela bug si on change la prise en charge des conges exceptionnels en cours d'utilisation ...
 
-	if ($_SESSION['config']['gestion_conges_exceptionnels'] && ! $hide_conges_exceptionnels) // on prend tout les types de conges
-		$request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "'.\includes\SQL::quote($login).'" ORDER BY su_abs_id ASC;';
-	else // on prend tout les types de conges SAUF les conges exceptionnels
-		$request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "'.\includes\SQL::quote($login).'" ORDER BY su_abs_id ASC;';
+    if ($_SESSION['config']['gestion_conges_exceptionnels'] && ! $hide_conges_exceptionnels) // on prend tout les types de conges
+        $request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "'.\includes\SQL::quote($login).'" ORDER BY su_abs_id ASC;';
+    else // on prend tout les types de conges SAUF les conges exceptionnels
+        $request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "'.\includes\SQL::quote($login).'" ORDER BY su_abs_id ASC;';
 
-	$data   = \includes\SQL::query($request);
+    $data   = \includes\SQL::query($request);
 
-	$result = array();
+    $result = array();
 
-	while ($l = $data->fetch_array())
-	{
-		$sql_id = $l['ta_libelle'];
-		$result[$sql_id] = array('nb_an' => affiche_decimal($l['su_nb_an']),'solde' => affiche_decimal($l['su_solde']),'reliquat' => affiche_decimal($l['su_reliquat']),);
-	}
+    while ($l = $data->fetch_array())
+    {
+        $sql_id = $l['ta_libelle'];
+        $result[$sql_id] = array('nb_an' => affiche_decimal($l['su_nb_an']),'solde' => affiche_decimal($l['su_solde']),'reliquat' => affiche_decimal($l['su_reliquat']),);
+    }
 
-	return $result;
+    return $result;
 }
 
 // recup dans un tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
 function recup_tableau_conges_for_users( $hide_conges_exceptionnels, $logins = false)
 {
-	// on pourrait tout faire en un seule select, mais cela bug si on change la prise en charge des conges exceptionnels en cours d'utilisation ...
+    // on pourrait tout faire en un seule select, mais cela bug si on change la prise en charge des conges exceptionnels en cours d'utilisation ...
 
-	if ($logins === false)
-		$logins = '';
-	else
-		$logins = ' AND su_login IN ( \''.implode('\', \'',$logins).'\') ';
+    if ($logins === false)
+        $logins = '';
+    else
+        $logins = ' AND su_login IN ( \''.implode('\', \'',$logins).'\') ';
 
-	if ($_SESSION['config']['gestion_conges_exceptionnels'] && ! $hide_conges_exceptionnels) // on prend tout les types de conges
-		$request = 'SELECT su_login, ta_libelle,  su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id '.$logins.' ORDER BY ta_type , su_abs_id ASC';
-	else // on prend tout les types de conges SAUF les conges exceptionnels
-		$request = 'SELECT su_login, ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id '.$logins.' ORDER BY su_abs_id ASC';
+    if ($_SESSION['config']['gestion_conges_exceptionnels'] && ! $hide_conges_exceptionnels) // on prend tout les types de conges
+        $request = 'SELECT su_login, ta_libelle,  su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id '.$logins.' ORDER BY ta_type , su_abs_id ASC';
+    else // on prend tout les types de conges SAUF les conges exceptionnels
+        $request = 'SELECT su_login, ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id '.$logins.' ORDER BY su_abs_id ASC';
 
-	$data = \includes\SQL::query($request);
+    $data = \includes\SQL::query($request);
 
-	$result=array();
-	while ($l = $data->fetch_array())
-	{
-		$tab=array();
-		$tab['nb_an'] = affiche_decimal($l['su_nb_an']);
-		$tab['solde'] = affiche_decimal($l['su_solde']);
-		$tab['reliquat'] = affiche_decimal($l['su_reliquat']);
-		$result[ $l['su_login'] ][ $l['ta_libelle'] ]   = $tab;
-	}
-	return $result;
+    $result=array();
+    while ($l = $data->fetch_array())
+    {
+        $tab=array();
+        $tab['nb_an'] = affiche_decimal($l['su_nb_an']);
+        $tab['solde'] = affiche_decimal($l['su_solde']);
+        $tab['reliquat'] = affiche_decimal($l['su_reliquat']);
+        $result[ $l['su_login'] ][ $l['ta_libelle'] ]   = $tab;
+    }
+    return $result;
 }
 
 // affichage du tableau récapitulatif des solde de congés d'un user
 function affiche_tableau_bilan_conges_user($login, $DEBUG=FALSE)
 {
-	$request = 'SELECT u_quotite FROM conges_users where u_login = "'. \includes\SQL::quote($login).'";';
-	$ReqLog = \includes\SQL::query($request) ;
-	$resultat = $ReqLog->fetch_array();
-	$sql_quotite=$resultat['u_quotite'];
+    $request = 'SELECT u_quotite FROM conges_users where u_login = "'. \includes\SQL::quote($login).'";';
+    $ReqLog = \includes\SQL::query($request) ;
+    $resultat = $ReqLog->fetch_array();
+    $sql_quotite=$resultat['u_quotite'];
+    $return = '';
 
-	// recup dans un tableau de tableaux les nb et soldes de conges d'un user
-	$tab_cong_user = recup_tableau_conges_for_user($login, true ,$DEBUG);
+    // recup dans un tableau de tableaux les nb et soldes de conges d'un user
+    $tab_cong_user = recup_tableau_conges_for_user($login, true ,$DEBUG);
 
-	// recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-	if ($_SESSION['config']['gestion_conges_exceptionnels'])
-		$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels($DEBUG);
+    // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
+    if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+        $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels($DEBUG);
+    }
 
-	echo "<table class=\"table table-hover table-responsive table-condensed table-bordered\">\n";
-	echo '<thead>';
-	echo '<tr><td></td><td colspan="' . (count($tab_cong_user) * 2 ).'">SOLDES</td></tr>';
-	echo '<tr>';
-	echo '<th class="titre">'. _('divers_quotite') .'</th>';
+    $return .= '<table class="table table-hover table-responsive table-condensed table-bordered">';
+    $return .= '<thead>';
+    $return .= '<tr><td></td><td colspan="' . (count($tab_cong_user) * 2 ) . '">SOLDES</td></tr>';
+    $return .= '<tr>';
+    $return .= '<th class="titre">'. _('divers_quotite') .'</th>';
 
-	foreach($tab_cong_user as $id => $val)
-	{
-		if ($_SESSION['config']['gestion_conges_exceptionnels'] && in_array($id,$tab_type_conges_exceptionnels))
-			echo '<th class="solde">'.$id.'</th>';
-		else
-			echo '<th class="annuel">'.$id.' / '. _('divers_an_maj') .'</th><th class="solde">'.$id.'</th>';
-	}
-	echo '</tr>';
-	echo '</thead>';
-	echo '<tbody>';
-	echo '<tr>';
-	echo '<td class="quotite">'.$sql_quotite.'%</td>';
-	foreach($tab_cong_user as $id => $val)
-	{
-		if ($_SESSION['config']['gestion_conges_exceptionnels']  && in_array($id,$tab_type_conges_exceptionnels))
-			echo '<td class="solde">'.$val['solde'].( $val['reliquat'] > 0 ? ' ('. _('dont_reliquat').' '.$val['reliquat'].')': '') .'</td>';
-		else
-			echo '<td class="annuel">'.$val['nb_an'].'</td><td class="solde">'.$val['solde'].( $val['reliquat'] > 0 ?' ('. _('dont_reliquat').' '.$val['reliquat'].')':'').'</td>';
-	}
-	echo '</tr>';
-	echo '</tbody>';
-	echo '</table>';
+    foreach($tab_cong_user as $id => $val) {
+        if ($_SESSION['config']['gestion_conges_exceptionnels'] && in_array($id,$tab_type_conges_exceptionnels)) {
+            $return .= '<th class="solde">' . $id . '</th>';
+        } else {
+            $return .= '<th class="annuel">' . $id . ' / ' . _('divers_an_maj') . '</th><th class="solde">' . $id . '</th>';
+        }
+    }
+    $return .= '</tr>';
+    $return .= '</thead>';
+    $return .= '<tbody>';
+    $return .= '<tr>';
+    $return .= '<td class="quotite">' . $sql_quotite . '%</td>';
+    foreach($tab_cong_user as $id => $val) {
+        if ($_SESSION['config']['gestion_conges_exceptionnels']  && in_array($id,$tab_type_conges_exceptionnels)) {
+            $return .= '<td class="solde">' . $val['solde'] . ($val['reliquat'] > 0 ? ' (' . _('dont_reliquat') . ' ' . $val['reliquat'] . ')' : '') . '</td>';
+        } else {
+            $return .= '<td class="annuel">' . $val['nb_an'] . '</td><td class="solde">' . $val['solde'] . ($val['reliquat'] > 0 ? ' (' . _('dont_reliquat') . ' ' . $val['reliquat'] . ')' : '') . '</td>';
+        }
+    }
+    $return .= '</tr>';
+    $return .= '</tbody>';
+    $return .= '</table>';
+    return $return;
 }
 
 // renvoit un tableau de tableau contenant les informations du user
 // renvoit FALSE si erreur
 function recup_infos_du_user($login, $list_groups_double_valid, $DEBUG=FALSE)
 {
-	$tab=array();
-	$sql1 = 'SELECT u_login, u_nom, u_prenom, u_is_resp, u_resp_login, u_is_admin, u_is_hr, u_is_active, u_see_all, u_passwd, u_quotite, u_email, u_num_exercice FROM conges_users ' .
-			'WHERE u_login="'.\includes\SQL::quote($login).'";';
-	$ReqLog = \includes\SQL::query($sql1) ;
+    $tab=array();
+    $sql1 = 'SELECT u_login, u_nom, u_prenom, u_is_resp, u_resp_login, u_is_admin, u_is_hr, u_is_active, u_see_all, u_passwd, u_quotite, u_email, u_num_exercice FROM conges_users ' .
+            'WHERE u_login="'.\includes\SQL::quote($login).'";';
+    $ReqLog = \includes\SQL::query($sql1) ;
 
-	if($resultat = $ReqLog->fetch_array())
-	{
-		$tab_user=array();
-		$tab_user['login']	= $resultat['u_login'];;
-		$tab_user['nom']	= $resultat['u_nom'];
-		$tab_user['prenom']	= $resultat['u_prenom'];
-		$tab_user['is_resp']	= $resultat['u_is_resp'];
-		$tab_user['resp_login']	= $resultat['u_resp_login'];
-		$tab_user['is_admin']	= $resultat['u_is_admin'];
-		$tab_user['is_hr']	= $resultat['u_is_hr'];
-		$tab_user['is_active']	= $resultat['u_is_active'];
-		$tab_user['see_all']	= $resultat['u_see_all'];
-		$tab_user['passwd']	= $resultat['u_passwd'];
-		$tab_user['quotite']	= $resultat['u_quotite'];
-		$tab_user['email']	= $resultat['u_email'];
-		$tab_user['num_exercice'] = $resultat['u_num_exercice'];
-		$tab_user['conges']	= recup_tableau_conges_for_user($login, false, $DEBUG);
+    if($resultat = $ReqLog->fetch_array())
+    {
+        $tab_user=array();
+        $tab_user['login']    = $resultat['u_login'];;
+        $tab_user['nom']    = $resultat['u_nom'];
+        $tab_user['prenom']    = $resultat['u_prenom'];
+        $tab_user['is_resp']    = $resultat['u_is_resp'];
+        $tab_user['resp_login']    = $resultat['u_resp_login'];
+        $tab_user['is_admin']    = $resultat['u_is_admin'];
+        $tab_user['is_hr']    = $resultat['u_is_hr'];
+        $tab_user['is_active']    = $resultat['u_is_active'];
+        $tab_user['see_all']    = $resultat['u_see_all'];
+        $tab_user['passwd']    = $resultat['u_passwd'];
+        $tab_user['quotite']    = $resultat['u_quotite'];
+        $tab_user['email']    = $resultat['u_email'];
+        $tab_user['num_exercice'] = $resultat['u_num_exercice'];
+        $tab_user['conges']    = recup_tableau_conges_for_user($login, false, $DEBUG);
 
-		$tab_user['double_valid'] = "N";
+        $tab_user['double_valid'] = "N";
 
-		// on regarde ici si le user est dans un groupe qui fait l'objet d'une double validation
-		if($_SESSION['config']['double_validation_conges'])
-		{
-			if($list_groups_double_valid!="") // si $resp_login est responsable d'au moins un groupe a double validation
-			{
-				$sql1='SELECT gu_login FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($login).'" AND gu_gid IN ('.$list_groups_double_valid.') ORDER BY gu_gid, gu_login;';
-				$ReqLog1 = \includes\SQL::query($sql1);
+        // on regarde ici si le user est dans un groupe qui fait l'objet d'une double validation
+        if($_SESSION['config']['double_validation_conges'])
+        {
+            if($list_groups_double_valid!="") // si $resp_login est responsable d'au moins un groupe a double validation
+            {
+                $sql1='SELECT gu_login FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($login).'" AND gu_gid IN ('.$list_groups_double_valid.') ORDER BY gu_gid, gu_login;';
+                $ReqLog1 = \includes\SQL::query($sql1);
 
-				if($ReqLog1->num_rows  !=0)
-					$tab_user['double_valid'] = 'Y';
-			}
-		}
-		return $tab_user ;
-	}
-	else
-		return FALSE;
+                if($ReqLog1->num_rows  !=0)
+                    $tab_user['double_valid'] = 'Y';
+            }
+        }
+        return $tab_user ;
+    }
+    else
+        return FALSE;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users
 function recup_infos_all_users($DEBUG=FALSE)
 {
-	$tab=array();
-	$list_groupes_double_validation=get_list_groupes_double_valid($DEBUG);
-	$sql1 = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
-	$ReqLog = \includes\SQL::query($sql1);
+    $tab=array();
+    $list_groupes_double_validation=get_list_groupes_double_valid($DEBUG);
+    $sql1 = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
+    $ReqLog = \includes\SQL::query($sql1);
 
-	while ($resultat =$ReqLog->fetch_array())
-	{
-		$tab_user=array();
-		$sql_login=$resultat["u_login"];
+    while ($resultat =$ReqLog->fetch_array())
+    {
+        $tab_user=array();
+        $sql_login=$resultat["u_login"];
 
-		$tab[$sql_login] = recup_infos_du_user($sql_login, $list_groupes_double_validation, $DEBUG);
-	}
-	return $tab ;
+        $tab[$sql_login] = recup_infos_du_user($sql_login, $list_groupes_double_validation, $DEBUG);
+    }
+    return $tab ;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users d'un groupe donné
 function recup_infos_all_users_du_groupe($group_id, $DEBUG=FALSE)
 {
-	$tab=array();
-	// recup de la liste de tous les users du groupe ...
-	$list_all_users_du_groupe = get_list_users_du_groupe($group_id, $DEBUG);
-	if( $DEBUG ) { echo "list_all_users_du_groupe :<br>\n"; print_r($list_all_users_du_groupe); echo "<br><br>\n";}
+    $tab=array();
+    // recup de la liste de tous les users du groupe ...
+    $list_all_users_du_groupe = get_list_users_du_groupe($group_id, $DEBUG);
+    if( $DEBUG ) { echo "list_all_users_du_groupe :<br>\n"; print_r($list_all_users_du_groupe); echo "<br><br>\n";}
 
-	$list_groupes_double_validation=get_list_groupes_double_valid($DEBUG);
-	if( $DEBUG ) { echo "list_groupes_double_validation :<br>\n"; print_r($list_groupes_double_validation); echo "<br><br>\n";}
+    $list_groupes_double_validation=get_list_groupes_double_valid($DEBUG);
+    if( $DEBUG ) { echo "list_groupes_double_validation :<br>\n"; print_r($list_groupes_double_validation); echo "<br><br>\n";}
 
-	if(strlen($list_all_users_du_groupe)!=0)
-	{
-		$tab_users_du_groupe=explode(",", $list_all_users_du_groupe);
-		foreach($tab_users_du_groupe as $current_login)
-		{
-			$current_login = trim($current_login);
-			$current_login = trim($current_login, "\'");  // on enleve les quotes qui ont été ajouté lors de la creation de la liste
-			$tab[$current_login] = recup_infos_du_user($current_login, $list_groupes_double_validation, $DEBUG);
-		}
-	}
-	return $tab ;
+    if(strlen($list_all_users_du_groupe)!=0)
+    {
+        $tab_users_du_groupe=explode(",", $list_all_users_du_groupe);
+        foreach($tab_users_du_groupe as $current_login)
+        {
+            $current_login = trim($current_login);
+            $current_login = trim($current_login, "\'");  // on enleve les quotes qui ont été ajouté lors de la creation de la liste
+            $tab[$current_login] = recup_infos_du_user($current_login, $list_groupes_double_validation, $DEBUG);
+        }
+    }
+    return $tab ;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users dont $login est responsable
 function recup_infos_all_users_du_resp($login, $DEBUG=FALSE)
 {
-	$tab=array();
+    $tab=array();
 
-	// recup de la liste de tous les users du resp ...
-	$list_all_users_du_resp = get_list_all_users_du_resp($login, $DEBUG);
-	if( $DEBUG ) { echo "list_all_users_du_resp :<br>\n"; print_r($list_all_users_du_resp); echo "<br><br>\n";}
+    // recup de la liste de tous les users du resp ...
+    $list_all_users_du_resp = get_list_all_users_du_resp($login, $DEBUG);
+    if( $DEBUG ) { echo "list_all_users_du_resp :<br>\n"; print_r($list_all_users_du_resp); echo "<br><br>\n";}
 
-	// recup de la liste des groupes à double validation, dont $login est responsable
-	// (servira à dire pour chaque user s'il est dans un de ces groupe ou non , donc s'il fait l'objet d'une double valid ou non )
-	$list_groups_double_valid_du_resp=get_list_groupes_double_valid_du_resp($login, $DEBUG);
-	if( $DEBUG ) { echo "list_groups_double_valid :<br>\n"; print_r($list_groups_double_valid_du_resp); echo "<br><br>\n";}
+    // recup de la liste des groupes à double validation, dont $login est responsable
+    // (servira à dire pour chaque user s'il est dans un de ces groupe ou non , donc s'il fait l'objet d'une double valid ou non )
+    $list_groups_double_valid_du_resp=get_list_groupes_double_valid_du_resp($login, $DEBUG);
+    if( $DEBUG ) { echo "list_groups_double_valid :<br>\n"; print_r($list_groups_double_valid_du_resp); echo "<br><br>\n";}
 
-	if(strlen($list_all_users_du_resp)!=0)
-	{
-		$tab_users_du_resp=explode(",", $list_all_users_du_resp);
-		foreach($tab_users_du_resp as $current_login)
-		{
-			$current_login = trim($current_login);
-			$current_login = trim($current_login, "\'");  // on enleve les quotes qui ont été ajouté lors de la creation de la liste
+    if(strlen($list_all_users_du_resp)!=0)
+    {
+        $tab_users_du_resp=explode(",", $list_all_users_du_resp);
+        foreach($tab_users_du_resp as $current_login)
+        {
+            $current_login = trim($current_login);
+            $current_login = trim($current_login, "\'");  // on enleve les quotes qui ont été ajouté lors de la creation de la liste
 
-			$tab[$current_login] = recup_infos_du_user($current_login, $list_groups_double_valid_du_resp, $DEBUG);
-		}
-	}
+            $tab[$current_login] = recup_infos_du_user($current_login, $list_groups_double_valid_du_resp, $DEBUG);
+        }
+    }
 
-	return $tab ;
+    return $tab ;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users dont $login est GRAND responsable
 function recup_infos_all_users_du_grand_resp($login, $DEBUG=FALSE)
 {
-	$tab=array();
-	$list_groups_double_valid=get_list_groupes_double_valid_du_grand_resp($login, $DEBUG);
-	if( $DEBUG ) { echo "list_groups_double_valid :<br>\n"; print_r($list_groups_double_valid); echo "<br><br>\n";}
+    $tab=array();
+    $list_groups_double_valid=get_list_groupes_double_valid_du_grand_resp($login, $DEBUG);
+    if( $DEBUG ) { echo "list_groups_double_valid :<br>\n"; print_r($list_groups_double_valid); echo "<br><br>\n";}
 
-	if($list_groups_double_valid!="")
-	{
-		// recup de la liste des users des groupes de la liste $list_groups_double_valid
-		$sql_users = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users, conges_users WHERE gu_gid IN ('.\includes\SQL::quote($list_groups_double_valid).') AND gu_login=u_login ORDER BY u_nom;';
-		$ReqLog_users = \includes\SQL::query($sql_users) ;
-		$list_all_users_dbl_valid="";
-		while ($resultat_users =$ReqLog_users->fetch_array())
-		{
-			$current_login=$resultat_users["gu_login"];
-			if($list_all_users_dbl_valid=="")
-				$list_all_users_dbl_valid="'$current_login'";
-			else
-				$list_all_users_dbl_valid=$list_all_users_dbl_valid.", '$current_login'";
-		}
+    if($list_groups_double_valid!="")
+    {
+        // recup de la liste des users des groupes de la liste $list_groups_double_valid
+        $sql_users = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users, conges_users WHERE gu_gid IN ('.\includes\SQL::quote($list_groups_double_valid).') AND gu_login=u_login ORDER BY u_nom;';
+        $ReqLog_users = \includes\SQL::query($sql_users) ;
+        $list_all_users_dbl_valid="";
+        while ($resultat_users =$ReqLog_users->fetch_array())
+        {
+            $current_login=$resultat_users["gu_login"];
+            if($list_all_users_dbl_valid=="")
+                $list_all_users_dbl_valid="'$current_login'";
+            else
+                $list_all_users_dbl_valid=$list_all_users_dbl_valid.", '$current_login'";
+        }
 
-		if($list_all_users_dbl_valid!="")
-		{
-			$tab_users_du_resp=explode(",", $list_all_users_dbl_valid);
-			foreach($tab_users_du_resp as $current_login)
-			{
-				$current_login = trim($current_login);
-				$current_login = trim($current_login, "\'");  // on enleve les qote qui on été ajouté lors de la creation de la liste
-				$tab[$current_login] = recup_infos_du_user($current_login, $list_groups_double_valid, $DEBUG);
-			}
-		}
-	}
-	return $tab ;
+        if($list_all_users_dbl_valid!="")
+        {
+            $tab_users_du_resp=explode(",", $list_all_users_dbl_valid);
+            foreach($tab_users_du_resp as $current_login)
+            {
+                $current_login = trim($current_login);
+                $current_login = trim($current_login, "\'");  // on enleve les qote qui on été ajouté lors de la creation de la liste
+                $tab[$current_login] = recup_infos_du_user($current_login, $list_groups_double_valid, $DEBUG);
+            }
+        }
+    }
+    return $tab ;
 }
 
 // execute sequentiellement les requètes d'un fichier .sql
 function execute_sql_file($file, $DEBUG=FALSE)
 {
-	// lecture du fichier SQL
-	// et execution de chaque ligne ....
-	$lines = file ($file);
-	$sql_requete="";
-	foreach ($lines as $line_num => $line)
-	{
-		$line=trim($line);
-		if( (substr($line, 0, 1)!="#") && ($line!="") )  //on ne prend pas les lignes de commentaire
-		{
-			$sql_requete = $sql_requete.$line ;
-			if(substr($sql_requete, -1, 1)==";") // alors la requete est finie !
-			{
-				if( $DEBUG )
-					echo "$sql_requete<br>\n";
-				$result = \includes\SQL::query($sql_requete);
-				$sql_requete="";
-			}
-		}
-	}
-	return TRUE;
+    // lecture du fichier SQL
+    // et execution de chaque ligne ....
+    $lines = file ($file);
+    $sql_requete="";
+    foreach ($lines as $line_num => $line)
+    {
+        $line=trim($line);
+        if( (substr($line, 0, 1)!="#") && ($line!="") )  //on ne prend pas les lignes de commentaire
+        {
+            $sql_requete = $sql_requete.$line ;
+            if(substr($sql_requete, -1, 1)==";") // alors la requete est finie !
+            {
+                if( $DEBUG )
+                    echo "$sql_requete<br>\n";
+                $result = \includes\SQL::query($sql_requete);
+                $sql_requete="";
+            }
+        }
+    }
+    return TRUE;
 }
 
 // verif des droits du user à afficher la page qu'il demande (pour éviter les hacks par bricolage d'URL)
 // verif_droits_user($session, "is_admin", $DEBUG);
 function verif_droits_user($session, $niveau_droits, $DEBUG=FALSE)
 {
-	if( $DEBUG ) { print_r($_SESSION); echo "<br><br>\n"; }
+    if( $DEBUG ) { print_r($_SESSION); echo "<br><br>\n"; }
 
-	$niveau_droits = strtolower($niveau_droits);
+    $niveau_droits = strtolower($niveau_droits);
 
-	// verif si $_SESSION['is_admin'] ou $_SESSION['is_resp'] ou $_SESSION['is_hr'] =="N" ou $_SESSION['is_active'] =="N"
-	if($_SESSION[$niveau_droits]=="N")
-	{
-		// on recupere les variable utiles pour le suite :
-		$url_accueil_conges = $_SESSION['config']['URL_ACCUEIL_CONGES'] ;
-		$lang_divers_acces_page_interdit =  _('divers_acces_page_interdit') ;
-		$lang_divers_user_disconnected	=  _('divers_user_disconnected') ;
-		$lang_divers_veuillez		=  _('divers_veuillez') ;
-		$lang_divers_vous_authentifier	=  _('divers_vous_authentifier') ;
+    // verif si $_SESSION['is_admin'] ou $_SESSION['is_resp'] ou $_SESSION['is_hr'] =="N" ou $_SESSION['is_active'] =="N"
+    if($_SESSION[$niveau_droits]=="N")
+    {
+        // on recupere les variable utiles pour le suite :
+        $url_accueil_conges = $_SESSION['config']['URL_ACCUEIL_CONGES'] ;
+        $lang_divers_acces_page_interdit =  _('divers_acces_page_interdit') ;
+        $lang_divers_user_disconnected    =  _('divers_user_disconnected') ;
+        $lang_divers_veuillez        =  _('divers_veuillez') ;
+        $lang_divers_vous_authentifier    =  _('divers_vous_authentifier') ;
 
-		// on delete la session et on renvoit sur l'authentification (page d'accueil)
-		session_delete($session);
+        // on delete la session et on renvoit sur l'authentification (page d'accueil)
+        session_delete($session);
 
-		// message d'erreur !
-		echo "<center>\n";
-		echo "<font color=\"red\">$lang_divers_acces_page_interdit</font><br>$lang_divers_user_disconnected<br>\n";
-		echo "$lang_divers_veuillez <a href='$url_accueil_conges/index.php' target='_top'> $lang_divers_vous_authentifier .</a>\n";
-		echo "</center>\n";
-		exit;
-	}
+        // message d'erreur !
+        echo "<center>\n";
+        echo "<font color=\"red\">$lang_divers_acces_page_interdit</font><br>$lang_divers_user_disconnected<br>\n";
+        echo "$lang_divers_veuillez <a href='$url_accueil_conges/index.php' target='_top'> $lang_divers_vous_authentifier .</a>\n";
+        echo "</center>\n";
+        exit;
+    }
 }
 
 
@@ -2513,24 +2517,24 @@ function verif_droits_user($session, $niveau_droits, $DEBUG=FALSE)
 function affiche_select_from_lang_directory( $select_name, $default )
 {
     $return = '';
-	if(empty($select_name)){
+    if(empty($select_name)){
         $select_name = 'lang';
     }
-	if(empty($default)){
+    if(empty($default)){
         $default = 'fr_FR';
     }
-	$return .= '<select id="' . $select_name . '" name="' . $select_name . '" class="form-control">';
-	$langs = glob( LOCALE_PATH .'*' );
-	$return .= 'langs = ' . var_export( $langs, true );
-	foreach($langs as $lang ) {
-		$lang = basename($lang);
-		if( $lang == $default ) {
-			$return .= '<option value="' . $lang . '" selected >' . $lang . '</option>';
+    $return .= '<select id="' . $select_name . '" name="' . $select_name . '" class="form-control">';
+    $langs = glob( LOCALE_PATH .'*' );
+    $return .= 'langs = ' . var_export( $langs, true );
+    foreach($langs as $lang ) {
+        $lang = basename($lang);
+        if( $lang == $default ) {
+            $return .= '<option value="' . $lang . '" selected >' . $lang . '</option>';
         } else {
-			$return .= '<option value="' . $lang . '">' . $lang . '</option>';
+            $return .= '<option value="' . $lang . '">' . $lang . '</option>';
         }
-	}
-	$return .= '</select>';
+    }
+    $return .= '</select>';
     return $return;
 }
 
@@ -2538,173 +2542,173 @@ function affiche_select_from_lang_directory( $select_name, $default )
 // retourne TRUE ou FALSE
 function log_action($num_periode, $etat_periode, $login_pour, $comment, $DEBUG=FALSE)
 {
-	if(isset($_SESSION['userlogin']))
-		$user = $_SESSION['userlogin'] ;
-	else
-		$user = "inconnu";
+    if(isset($_SESSION['userlogin']))
+        $user = $_SESSION['userlogin'] ;
+    else
+        $user = "inconnu";
 
-	$sql1 = 'INSERT INTO conges_logs SET log_p_num="'.\includes\SQL::quote($num_periode).'",log_user_login_par="'.\includes\SQL::quote($user).'",log_user_login_pour="'.\includes\SQL::quote($login_pour).'",log_etat="'.\includes\SQL::quote($etat_periode).'",log_comment="'.\includes\SQL::quote($comment).'",log_date=NOW()';
-	$result = \includes\SQL::query($sql1);
+    $sql1 = 'INSERT INTO conges_logs SET log_p_num="'.\includes\SQL::quote($num_periode).'",log_user_login_par="'.\includes\SQL::quote($user).'",log_user_login_pour="'.\includes\SQL::quote($login_pour).'",log_etat="'.\includes\SQL::quote($etat_periode).'",log_comment="'.\includes\SQL::quote($comment).'",log_date=NOW()';
+    $result = \includes\SQL::query($sql1);
 
-	return $result;
+    return $result;
 }
 
 // remplit le tableau global des jours feries a partir de la database
 function init_tab_jours_fermeture($user,  $DEBUG=FALSE)
 {
-	$_SESSION["tab_j_fermeture"]=array();
-	$sql_select='SELECT DISTINCT jf_date FROM conges_jours_fermeture, conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($user).'" AND gu_gid=jf_gid';
-	$res_select = \includes\SQL::query($sql_select);
+    $_SESSION["tab_j_fermeture"]=array();
+    $sql_select='SELECT DISTINCT jf_date FROM conges_jours_fermeture, conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($user).'" AND gu_gid=jf_gid';
+    $res_select = \includes\SQL::query($sql_select);
 
-	while( $row = $res_select->fetch_array())
-		$_SESSION["tab_j_fermeture"][]=$row["jf_date"];
+    while( $row = $res_select->fetch_array())
+        $_SESSION["tab_j_fermeture"][]=$row["jf_date"];
 }
 
 // renvoit TRUE si le jour est fermé (fermeture), sinon FALSE (verifie dans le tableau global $_SESSION["tab_j_fermeture"]
 function est_ferme($timestamp)
 {
-	$j_date=date("Y-m-d", $timestamp);
-	if(isset($_SESSION["tab_j_fermeture"]))
-		return in_array($j_date, $_SESSION["tab_j_fermeture"]);
-	else
-		return FALSE;
+    $j_date=date("Y-m-d", $timestamp);
+    if(isset($_SESSION["tab_j_fermeture"]))
+        return in_array($j_date, $_SESSION["tab_j_fermeture"]);
+    else
+        return FALSE;
 }
 
 // renvoit le "su_reliquat" pour un user et un type de conges donné
 function get_reliquat_user_conges($login, $type_abs,  $DEBUG=FALSE)
 {
-	$select_info='SELECT su_reliquat FROM conges_solde_user WHERE su_login="'.\includes\SQL::quote($login).'" AND su_abs_id="'.\includes\SQL::quote($type_abs).'"';
-	$ReqLog_info = \includes\SQL::query($select_info);
-	$resultat_info = $ReqLog_info->fetch_array();
-	$sql_reliquat=$resultat_info["su_reliquat"];
+    $select_info='SELECT su_reliquat FROM conges_solde_user WHERE su_login="'.\includes\SQL::quote($login).'" AND su_abs_id="'.\includes\SQL::quote($type_abs).'"';
+    $ReqLog_info = \includes\SQL::query($select_info);
+    $resultat_info = $ReqLog_info->fetch_array();
+    $sql_reliquat=$resultat_info["su_reliquat"];
 
-	return $sql_reliquat;
+    return $sql_reliquat;
 }
 
 /*  si date_fin_conges < date_limite_reliquat => alors on décompte dans reliquats
-	si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
-	si gonges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
-	calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
-	d'apres la date limite et ne pas le décompter des reliquats !!!
+    si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
+    si gonges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
+    calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
+    d'apres la date limite et ne pas le décompter des reliquats !!!
 */
 function soustrait_solde_et_reliquat_user($user_login, $num_current_periode, $user_nb_jours_pris, $type_abs, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin,  $DEBUG=FALSE)
 {
 
-$user_nb_jours_pris = number_format($user_nb_jours_pris, 1, '.', '');
+    $user_nb_jours_pris = number_format($user_nb_jours_pris, 1, '.', '');
 
-	//si on autorise les reliquats
-	if($_SESSION['config']['autorise_reliquats_exercice'])
-	{
-		//recup du reliquat du user pour ce type d'absence
-		$reliquat=get_reliquat_user_conges($user_login, $type_abs,  $DEBUG);
-		//echo "reliquat = $reliquat<br>\n";
-		// s'il y a une date limite d'utilisationdes reliquats (au format jj-mm)
-		if($_SESSION['config']['jour_mois_limite_reliquats']!=0)
-		{
-			//si date_fin_conges < date_limite_reliquat => alors on décompte dans reliquats
-			if($date_fin < $_SESSION['config']['date_limite_reliquats'])
-			{
-				if($reliquat>$user_nb_jours_pris)
-					$new_reliquat = $reliquat-$user_nb_jours_pris;
-				else
-					$new_reliquat = 0;
-			}
-			//si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
-			elseif($date_deb >= $_SESSION['config']['date_limite_reliquats'])
-			{
-				$new_reliquat = $reliquat;
-			}
-			//si conges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
-			//calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
-			//d'apres la data limite et ne pas le décompter des reliquats !!!
-			else
-			{
-				include_once 'fonctions_calcul.php' ;
-				$comment="calcul reliquat -> date limite" ;
-				$nb_reliquats_a_deduire = compter($user_login, $num_current_periode, $date_deb, $_SESSION['config']['date_limite_reliquats'], $demi_jour_deb, "pm", $comment ,  $DEBUG);
+    //si on autorise les reliquats
+    if($_SESSION['config']['autorise_reliquats_exercice'])
+    {
+        //recup du reliquat du user pour ce type d'absence
+        $reliquat=get_reliquat_user_conges($user_login, $type_abs,  $DEBUG);
+        //echo "reliquat = $reliquat<br>\n";
+        // s'il y a une date limite d'utilisationdes reliquats (au format jj-mm)
+        if($_SESSION['config']['jour_mois_limite_reliquats']!=0)
+        {
+            //si date_fin_conges < date_limite_reliquat => alors on décompte dans reliquats
+            if($date_fin < $_SESSION['config']['date_limite_reliquats'])
+            {
+                if($reliquat>$user_nb_jours_pris)
+                    $new_reliquat = $reliquat-$user_nb_jours_pris;
+                else
+                    $new_reliquat = 0;
+            }
+            //si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
+            elseif($date_deb >= $_SESSION['config']['date_limite_reliquats'])
+            {
+                $new_reliquat = $reliquat;
+            }
+            //si conges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
+            //calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
+            //d'apres la data limite et ne pas le décompter des reliquats !!!
+            else
+            {
+                include_once 'fonctions_calcul.php' ;
+                $comment="calcul reliquat -> date limite" ;
+                $nb_reliquats_a_deduire = compter($user_login, $num_current_periode, $date_deb, $_SESSION['config']['date_limite_reliquats'], $demi_jour_deb, "pm", $comment ,  $DEBUG);
 
-				if($reliquat > $nb_reliquats_a_deduire)
-					$new_reliquat = $reliquat - $nb_reliquats_a_deduire;
-				else
-					$new_reliquat = 0;
-			}
-		}
-		// s'il n'y a pas de date limite d'utilisation des reliquats
-		else
-		{
-			if($reliquat>$user_nb_jours_pris)
-				$new_reliquat = $reliquat-$user_nb_jours_pris;
-			else
-				$new_reliquat = 0;
-		}
-		$user_nb_jours_pris = str_replace(',', '.', $user_nb_jours_pris);
-		$new_reliquat = str_replace(',', '.', $new_reliquat);
-		$sql2 = 'UPDATE conges_solde_user SET su_solde=su_solde-'.\includes\SQL::quote($user_nb_jours_pris).', su_reliquat='.\includes\SQL::quote($new_reliquat).' WHERE su_login="'.\includes\SQL::quote($user_login).'"  AND su_abs_id='.\includes\SQL::quote($type_abs).' ';
-	}
-	else
-	{
-		$user_nb_jours_pris = str_replace(',', '.', $user_nb_jours_pris);
-		$new_reliquat = str_replace(',', '.', $new_reliquat);
-		$sql2 = 'UPDATE conges_solde_user SET su_solde=su_solde-'.\includes\SQL::quote($user_nb_jours_pris).' WHERE su_login=\''.\includes\SQL::quote($user_login).'\'  AND su_abs_id=\''.$type_abs.'\' ';
-	}
-	$ReqLog2 = \includes\SQL::query($sql2) ;
+                if($reliquat > $nb_reliquats_a_deduire)
+                    $new_reliquat = $reliquat - $nb_reliquats_a_deduire;
+                else
+                    $new_reliquat = 0;
+            }
+        }
+        // s'il n'y a pas de date limite d'utilisation des reliquats
+        else
+        {
+            if($reliquat>$user_nb_jours_pris)
+                $new_reliquat = $reliquat-$user_nb_jours_pris;
+            else
+                $new_reliquat = 0;
+        }
+        $user_nb_jours_pris = str_replace(',', '.', $user_nb_jours_pris);
+        $new_reliquat = str_replace(',', '.', $new_reliquat);
+        $sql2 = 'UPDATE conges_solde_user SET su_solde=su_solde-'.\includes\SQL::quote($user_nb_jours_pris).', su_reliquat='.\includes\SQL::quote($new_reliquat).' WHERE su_login="'.\includes\SQL::quote($user_login).'"  AND su_abs_id='.\includes\SQL::quote($type_abs).' ';
+    }
+    else
+    {
+        $user_nb_jours_pris = str_replace(',', '.', $user_nb_jours_pris);
+        $new_reliquat = str_replace(',', '.', $new_reliquat);
+        $sql2 = 'UPDATE conges_solde_user SET su_solde=su_solde-'.\includes\SQL::quote($user_nb_jours_pris).' WHERE su_login=\''.\includes\SQL::quote($user_login).'\'  AND su_abs_id=\''.$type_abs.'\' ';
+    }
+    $ReqLog2 = \includes\SQL::query($sql2) ;
 }
 
 // recup de la liste des users des groupes dont $resp_login est responsable mais ne remonte pas les autres responsables
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_users_des_groupes_du_resp_sauf_resp($resp_login, $DEBUG=FALSE)
 {
-	$list_users_des_groupes_du_resp_sauf_resp="";
-	$list_groups=get_list_groupes_du_resp($resp_login, $DEBUG);
-	if($list_groups!="") // si $resp_login est responsable d'au moins un groupe
-	{
-		$sql1="SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ($list_groups) AND gu_login NOT IN (SELECT gr_login FROM conges_groupe_resp WHERE gr_gid IN ($list_groups)) ORDER BY gu_login ";
-		$ReqLog1 = \includes\SQL::query($sql1);
+    $list_users_des_groupes_du_resp_sauf_resp="";
+    $list_groups=get_list_groupes_du_resp($resp_login, $DEBUG);
+    if($list_groups!="") // si $resp_login est responsable d'au moins un groupe
+    {
+        $sql1="SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ($list_groups) AND gu_login NOT IN (SELECT gr_login FROM conges_groupe_resp WHERE gr_gid IN ($list_groups)) ORDER BY gu_login ";
+        $ReqLog1 = \includes\SQL::query($sql1);
 
-		while ($resultat1 = $ReqLog1->fetch_array())
-		{
-			$current_login=$resultat1["gu_login"];
-			if($list_users_des_groupes_du_resp_sauf_resp=="")
-				$list_users_des_groupes_du_resp_sauf_resp="'$current_login'";
-			else
-				$list_users_des_groupes_du_resp_sauf_resp=$list_users_des_groupes_du_resp_sauf_resp.", '$current_login'";
-		}
-	}
-	if( $DEBUG ) { echo "list_users_des_groupes_du_resp_sauf_resp= $list_users_des_groupes_du_resp_sauf_resp<br>\n" ;}
+        while ($resultat1 = $ReqLog1->fetch_array())
+        {
+            $current_login=$resultat1["gu_login"];
+            if($list_users_des_groupes_du_resp_sauf_resp=="")
+                $list_users_des_groupes_du_resp_sauf_resp="'$current_login'";
+            else
+                $list_users_des_groupes_du_resp_sauf_resp=$list_users_des_groupes_du_resp_sauf_resp.", '$current_login'";
+        }
+    }
+    if( $DEBUG ) { echo "list_users_des_groupes_du_resp_sauf_resp= $list_users_des_groupes_du_resp_sauf_resp<br>\n" ;}
 
-	return $list_users_des_groupes_du_resp_sauf_resp;
+    return $list_users_des_groupes_du_resp_sauf_resp;
 }
 
 /*--------- ajout fonction probesys -------------------*/
 //date au format d/m/Y -> Y-m-d
 function convert_date($date){
-	$date_component = explode('/', $date);
-	$date_component = array_reverse($date_component);
+    $date_component = explode('/', $date);
+    $date_component = array_reverse($date_component);
 
-	return implode('-', $date_component);
+    return implode('-', $date_component);
 }
 
 //date au format d/m/Y -> d-m-Y
 function revert_date($date){
-	$date_component = explode('-', $date);
+    $date_component = explode('-', $date);
 
-	return implode('/', $date_component);
+    return implode('/', $date_component);
 }
 
 //date au format d/m/Y
 function get_nb_jour($date_deb, $date_fin, $demi_jour_deb, $demi_jour_fin){
-	$date_deb = new DateTime($date_deb); //inclusive
-	$date_fin = new DateTime($date_fin); //exclusive
-	$diff = $date_deb->diff($date_fin);
-	$diff = $diff->format("%a");
+    $date_deb = new DateTime($date_deb); //inclusive
+    $date_fin = new DateTime($date_fin); //exclusive
+    $diff = $date_deb->diff($date_fin);
+    $diff = $diff->format("%a");
 
-	if($demi_jour_deb == 'am' && $demi_jour_fin =='pm') {
-		$diff = $diff + 1;
-	}
+    if($demi_jour_deb == 'am' && $demi_jour_fin =='pm') {
+        $diff = $diff + 1;
+    }
 
-	if($demi_jour_deb == $demi_jour_fin) {
-		$diff = $diff + 0.5;
-	}
+    if($demi_jour_deb == $demi_jour_fin) {
+        $diff = $diff + 0.5;
+    }
 
-	return $diff;
+    return $diff;
 }

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -2459,37 +2459,40 @@ class Fonctions
     {
         $jour_today=date("j");
         $jour_today_name=date("D");
+        $return = '';
 
         $first_jour_mois_timestamp=mktime (0,0,0,$mois,1,$year);
         $mois_name=date_fr("F", $first_jour_mois_timestamp);
         $first_jour_mois_rang=date("w", $first_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        if($first_jour_mois_rang==0)
+        if($first_jour_mois_rang==0) {
             $first_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        }
 
-        echo "<table>\n";
+        $return .= '<table>';
         /* affichage  2 premieres lignes */
-        echo "    <thead>\n";
-        echo "    <tr><th colspan=7 class=\"titre\"> $mois_name $year </th></tr>\n" ;
-        echo "    <tr>\n";
-        echo "        <th class=\"cal-saisie2\">". _('lundi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('mardi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('mercredi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('jeudi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('vendredi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('samedi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('dimanche_1c') ."</th>\n";
-        echo "    </tr>\n" ;
-        echo "    </thead>\n" ;
+        $return .= '<thead>';
+        $return .= '<tr><th colspan=7 class="titre">' . $mois_name . ' ' . $year . '</th></tr>';
+        $return .= '<tr>';
+        $return .= '<th class="cal-saisie2">' . _('lundi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('mardi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('mercredi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('jeudi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('vendredi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('samedi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('dimanche_1c') . '</th>';
+        $return .= '</tr>' ;
+        $return .= '</thead>';
 
         /* affichage ligne 1 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         // affichage des cellules vides jusqu'au 1 du mois ...
         for($i=1; $i<$first_jour_mois_rang; $i++) {
-            if( (($i==6)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==7)&&($_SESSION['config']['dimanche_travail']==FALSE)) )
+            if( (($i==6)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==7)&&($_SESSION['config']['dimanche_travail']==FALSE)) ) {
                 $bgcolor=$_SESSION['config']['week_end_bgcolor'];
-            else
+            } else {
                 $bgcolor=$_SESSION['config']['semaine_bgcolor'];
-            echo "<td class=\"month-out cal-saisie2\">&nbsp;</td>";
+            }
+            $return .= '<td class="month-out cal-saisie2">&nbsp;</td>';
         }
         // affichage des cellules du 1 du mois à la fin de la ligne ...
         for($i=$first_jour_mois_rang; $i<8; $i++) {
@@ -2499,103 +2502,110 @@ class Fonctions
             $j_day=date("d", $j_timestamp);
             $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year))
+            if(in_array ("$j_date", $tab_year)) {
                 $td_second_class="fermeture";
+            }
 
-            echo "<td  class=\"cal-saisie $td_second_class\">$j_day</td>";
+            $return .= '<td  class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 2 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=8-$first_jour_mois_rang+1; $i<15-$first_jour_mois_rang+1; $i++) {
             $j_timestamp=mktime (0,0,0,$mois,$i,$year);
             $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
             $j_date=date("Y-m-d", $j_timestamp);
             $j_day=date("d", $j_timestamp);
 
-            if(in_array ("$j_date", $tab_year))
+            if(in_array ("$j_date", $tab_year)) {
                 $td_second_class="fermeture";
+            }
 
-            echo "<td  class=\"cal-saisie $td_second_class\">$j_day</td>";
+            $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 3 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=15-$first_jour_mois_rang+1; $i<22-$first_jour_mois_rang+1; $i++) {
             $j_timestamp=mktime (0,0,0,$mois,$i,$year);
             $j_date=date("Y-m-d", $j_timestamp);
             $j_day=date("d", $j_timestamp);
             $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year))
+            if(in_array ("$j_date", $tab_year)) {
                 $td_second_class="fermeture";
+            }
 
-            echo "<td  class=\"cal-saisie $td_second_class\">$j_day</td>";
+            $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day .  '</td>';
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 4 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=22-$first_jour_mois_rang+1; $i<29-$first_jour_mois_rang+1; $i++) {
             $j_timestamp=mktime (0,0,0,$mois,$i,$year);
             $j_date=date("Y-m-d", $j_timestamp);
             $j_day=date("d", $j_timestamp);
             $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year))
+            if(in_array ("$j_date", $tab_year)) {
                 $td_second_class="fermeture";
+            }
 
-            echo "<td  class=\"cal-saisie $td_second_class\">$j_day</td>";
+            $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 5 du mois (peut etre la derniere ligne) */
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=29-$first_jour_mois_rang+1; $i<36-$first_jour_mois_rang+1 && checkdate($mois, $i, $year); $i++) {
             $j_timestamp=mktime (0,0,0,$mois,$i,$year);
             $j_date=date("Y-m-d", $j_timestamp);
             $j_day=date("d", $j_timestamp);
             $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year))
+            if(in_array ("$j_date", $tab_year)) {
                 $td_second_class="fermeture";
+            }
 
-            echo "<td  class=\"cal-saisie $td_second_class\">$j_day</td>";
+            $return .= '<td  class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
         for($i; $i<36-$first_jour_mois_rang+1; $i++) {
-            if( (($i==35-$first_jour_mois_rang)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==36-$first_jour_mois_rang)&&($_SESSION['config']['dimanche_travail']==FALSE)) )
+            if( (($i==35-$first_jour_mois_rang)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==36-$first_jour_mois_rang)&&($_SESSION['config']['dimanche_travail']==FALSE)) ) {
                 $bgcolor=$_SESSION['config']['week_end_bgcolor'];
-            else
+            } else {
                 $bgcolor=$_SESSION['config']['semaine_bgcolor'];
-            echo "<td class=\"cal-saisie2 month-out\">&nbsp;</td>";
+            }
+            $return .= '<td class="cal-saisie2 month-out">&nbsp;</td>';
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 6 du mois (derniere ligne)*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=36-$first_jour_mois_rang+1; checkdate($mois, $i, $year); $i++) {
             $j_timestamp=mktime (0,0,0,$mois,$i,$year);
             $j_date=date("Y-m-d", $j_timestamp);
             $j_day=date("d", $j_timestamp);
             $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year))
+            if(in_array ("$j_date", $tab_year)) {
                 $td_second_class="fermeture";
+            }
 
-            echo "<td  class=\"cal-saisie $td_second_class\">$j_day</td>";
+            $return .= '<td  class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
         for($i; $i<43-$first_jour_mois_rang+1; $i++) {
-            if( (($i==42-$first_jour_mois_rang)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==43-$first_jour_mois_rang)&&($_SESSION['config']['dimanche_travail']==FALSE)))
+            if( (($i==42-$first_jour_mois_rang)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==43-$first_jour_mois_rang)&&($_SESSION['config']['dimanche_travail']==FALSE))) {
                 $bgcolor=$_SESSION['config']['week_end_bgcolor'];
-            else
+            } else {
                 $bgcolor=$_SESSION['config']['semaine_bgcolor'];
-            echo "<td class=\"month-out cal-saisie2\">&nbsp;</td>";
+            }
+            $return .= '<td class="month-out cal-saisie2">&nbsp;</td>';
         }
-        echo "</tr>\n";
-
-        echo "</table>\n";
+        $return .= '</tr></table>';
+        return $return;
     }
 
     //calendrier des fermeture
@@ -2604,18 +2614,20 @@ class Fonctions
         // on construit le tableau de l'année considérée
         $tab_year=array();
         \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id,  $DEBUG);
+        $return = '';
 
-        echo "<div class=\"calendar calendar-year\">\n";
+        $return .= '<div class="calendar calendar-year">';
         $months = array('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12');
 
         foreach ($months as $month) {
-            echo "<div class=\"month\">\n";
-            echo "<div class=\"wrapper\">\n";
-            echo \hr\Fonctions::affiche_calendrier_fermeture_mois($year, $month, $tab_year);
-            echo "</div>\n";
-            echo "</div>";
+            $return .= '<div class="month">';
+            $return .= '<div class="wrapper">';
+            $return .= \hr\Fonctions::affiche_calendrier_fermeture_mois($year, $month, $tab_year);
+            $return .= '</div>';
+            $return .= '</div>';
         }
-        echo "</div>";
+        $return .= '</div>';
+        return $return;
     }
 
     //insertion des nouvelles dates de fermeture
@@ -2676,22 +2688,27 @@ class Fonctions
 
     public static function commit_annul_fermeture($fermeture_id, $groupe_id,  $DEBUG=FALSE)
     {
-
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
-        if( $DEBUG ) { echo "fermeture_id = $fermeture_id <br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'fermeture_id = ' . $fermeture_id . '<br>';
+        }
 
 
         /*****************************/
         // on construit le tableau des users affectés par les fermetures saisies :
-        if($groupe_id==0)  // fermeture pour tous !
+        if($groupe_id==0) { // fermeture pour tous !
             $list_users = get_list_all_users( $DEBUG);
-        else
+        } else {
             $list_users = get_list_users_du_groupe($groupe_id,  $DEBUG);
+        }
 
         $tab_users = explode(",", $list_users);
-        if( $DEBUG ) { echo "tab_users =<br>\n"; print_r($tab_users) ; echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_users =<br>' . var_export($tab_users, true) . '<br>';
+        }
 
         /***********************************************/
         /** suppression des jours de fermetures   **/
@@ -2721,54 +2738,61 @@ class Fonctions
 
             // mise à jour du solde de jours de conges pour l'utilisateur $current_login
             if ($sql_nb_jours_a_crediter != 0) {
-                    $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde + '.\includes\SQL::quote($sql_nb_jours_a_crediter).' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id = '.\includes\SQL::quote($sql_type_abs) ;
-                    $ReqLog = \includes\SQL::query($sql1);
+                $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde + '.\includes\SQL::quote($sql_nb_jours_a_crediter).' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id = '.\includes\SQL::quote($sql_type_abs) ;
+                $ReqLog = \includes\SQL::query($sql1);
             }
         }
 
-        echo '<div class="wrapper">';
-        if($result)
-            echo "<br>". _('form_modif_ok') ."<br><br>\n";
-        else
-            echo "<br>". _('form_modif_not_ok') ." !<br><br>\n";
+        $return .= '<div class="wrapper">';
+        if($result) {
+            $return .= '<br>' . _('form_modif_ok') . '<br><br>';
+        } else {
+            $return .= '<br>' . _('form_modif_not_ok') . ' !<br><br>';
+        }
 
         // on enregistre cette action dan les logs
-        if($groupe_id==0)  // fermeture pour tous !
+        if($groupe_id==0) { // fermeture pour tous !
             $comment_log = "annulation fermeture $fermeture_id (pour tous) " ;
-        else
+        } else {
             $comment_log = "annulation fermeture $fermeture_id (pour le groupe $groupe_id)" ;
+        }
         log_action(0, "", "", $comment_log,  $DEBUG);
 
-        echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-        echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-        echo "</form>\n";
-        echo '</div>';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('form_ok') . '">';
+        $return .= '</form>';
+        $return .= '</div>';
+        return $return;
     }
 
     public static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges, $DEBUG=FALSE)
     {
-
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
-
+        $return = '';
 
         // on transforme les formats des dates
         $tab_date_debut=explode("/",$new_date_debut);   // date au format d/m/Y
         $date_debut=$tab_date_debut[2]."-".$tab_date_debut[1]."-".$tab_date_debut[0];
         $tab_date_fin=explode("/",$new_date_fin);   // date au format d/m/Y
         $date_fin=$tab_date_fin[2]."-".$tab_date_fin[1]."-".$tab_date_fin[0];
-        if( $DEBUG ) { echo "date_debut = $date_debut  // date_fin = $date_fin<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'date_debut = ' . $date_debut . '// date_fin = ' . $date_fin . '<br>';
+        }
 
 
         /*****************************/
         // on construit le tableau des users affectés par les fermetures saisies :
-        if($groupe_id==0)  // fermeture pour tous !
+        if($groupe_id==0) { // fermeture pour tous !
             $list_users = get_list_all_users( $DEBUG);
-        else
+        } else {
             $list_users = get_list_users_du_groupe($groupe_id,  $DEBUG);
+        }
 
         $tab_users = explode(",", $list_users);
-        if( $DEBUG ) { echo "tab_users =<br>\n"; print_r($tab_users) ; echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_users =<br>' . var_export($tab_users, true) . '<br>';
+        }
 
         //******************************
         // !!!!
@@ -2784,7 +2808,9 @@ class Fonctions
         for($current_date=$date_debut; $current_date <= $date_fin; $current_date=jour_suivant($current_date)) {
             $tab_fermeture[] = $current_date;
         }
-        if( $DEBUG ) { echo "tab_fermeture =<br>\n"; print_r($tab_fermeture) ; echo "<br>\n"; }
+        if( $DEBUG ) {
+            echo "tab_fermeture =<br>\n"; print_r($tab_fermeture) ; echo "<br>\n";
+        }
         // on insere les nouvelles dates saisies dans conges_jours_fermeture
         $result = \hr\Fonctions::insert_year_fermeture($new_fermeture_id, $tab_fermeture, $groupe_id,  $DEBUG);
 
@@ -2807,7 +2833,9 @@ class Fonctions
                 // $nb_jours = compter($current_login, $date_debut, $date_fin, $opt_debut, $opt_fin, $comment,  $DEBUG);
                 $nb_jours = compter($current_login, "", $date_debut, $date_fin, $opt_debut, $opt_fin, $comment, $DEBUG);
 
-                if ($DEBUG) echo "<br>user_login : " . $current_login . " nbjours : " . $nb_jours . "<br>\n";
+                if ($DEBUG) {
+                    $return .= '<br>user_login : ' . $current_login . ' nbjours : ' . $nb_jours . '<br>';
+                }
 
                 // on ne met à jour la table conges_periode .
                 $commentaire =  _('divers_fermeture') ;
@@ -2824,19 +2852,21 @@ class Fonctions
         // on recharge les jours fermés dans les variables de session
         init_tab_jours_fermeture($_SESSION['userlogin'],  $DEBUG);
 
-        echo '<div class="wrapper">';
+        $return .= '<div class="wrapper">';
 
-        if($result)
-            echo "<br>". _('form_modif_ok') ."<br><br>\n";
-        else
-            echo "<br>". _('form_modif_not_ok') ." !<br><br>\n";
+        if($result) {
+            $return .= '<br>' . _('form_modif_ok') . '<br><br>';
+        } else {
+            $return .= '<br>' . _('form_modif_not_ok') . ' !<br><br>';
+        }
 
         $comment_log = "saisie des jours de fermeture de $date_debut a $date_fin" ;
         log_action(0, "", "", $comment_log,  $DEBUG);
-        echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-        echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-        echo "</form>\n";
-        echo '</div>';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('form_ok') . '">';
+        $return .= '</form>';
+        $return .= '</div>';
+        return $return;
     }
 
     //function confirm_saisie_fermeture($tab_checkbox_j_ferme, $year_calendrier_saisie, $groupe_id, $DEBUG=FALSE)
@@ -2844,20 +2874,22 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
-        echo '<div class="wrapper">';
-        echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-        echo  _('divers_fermeture_du') ."  <b>$fermeture_date_debut</b> ". _('divers_au') ." <b>$fermeture_date_fin</b>. \n";
-        echo "<b>". _('admin_annul_fermeture_confirm') .".</b><br>\n";
-        echo "<input type=\"hidden\" name=\"fermeture_id\" value=\"$fermeture_id\">\n";
-        echo "<input type=\"hidden\" name=\"fermeture_date_debut\" value=\"$fermeture_date_debut\">\n";
-        echo "<input type=\"hidden\" name=\"fermeture_date_fin\" value=\"$fermeture_date_fin\">\n";
-        echo "<input type=\"hidden\" name=\"groupe_id\" value=\"$groupe_id\">\n";
-        echo "<input type=\"hidden\" name=\"choix_action\" value=\"commit_annul_fermeture\">\n";
-        echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_continuer') ."\">\n";
-        echo "<a class=\"btn\" href=\"$PHP_SELF?session=$session\">". _('form_cancel') ."</a>";
-        echo "</form>\n";
-        echo "</div>\n";
+        $return .= '<div class="wrapper">';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= _('divers_fermeture_du') . '<b>' . $fermeture_date_debut . '</b>' . _('divers_au') . '<b>' . $fermeture_date_fin . '</b>.';
+        $return .= '<b>' . _('admin_annul_fermeture_confirm') . '</b>.<br>';
+        $return .= '<input type="hidden" name="fermeture_id" value="' . $fermeture_id . '">';
+        $return .= '<input type="hidden" name="fermeture_date_debut" value="' . $fermeture_date_debut . '">';
+        $return .= '<input type="hidden" name="fermeture_date_fin" value="' . $fermeture_date_fin . '">';
+        $return .= '<input type="hidden" name="groupe_id" value="' . $groupe_id . '">';
+        $return .= '<input type="hidden" name="choix_action" value="commit_annul_fermeture">';
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('form_continuer') . '">';
+        $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+        $return .= '</form>';
+        $return .= '</div>';
+        return $return;
     }
 
     // retourne un tableau des periodes de fermeture (pour un groupe donné (gid=0 pour tout le monde))
@@ -2885,21 +2917,25 @@ class Fonctions
     {
         $tab_conges=recup_tableau_types_conges( $DEBUG);
         $tab_conges_except=recup_tableau_types_conges_exceptionnels( $DEBUG);
+        $return = '';
 
         foreach($tab_conges as $id => $libelle) {
-            if($libelle == 1)
-                echo "<option value=\"$id\" selected>$libelle</option>\n";
-            else
-                echo "<option value=\"$id\">$libelle</option>\n";
+            if($libelle == 1) {
+                $return .= '<option value="' . $id . '" selected>' . $libelle . '</option>';
+            } else {
+                $return .= '<option value="' . $id  . '">' . $libelle . '</option>';
+            }
         }
         if(count($tab_conges_except)!=0) {
             foreach($tab_conges_except as $id => $libelle) {
-                if($libelle == 1)
-                    echo "<option value=\"$id\" selected>$libelle</option>\n";
-                else
-                    echo "<option value=\"$id\">$libelle</option>\n";
+                if($libelle == 1) {
+                    $return .= '<option value="' . $id . '" selected>' . $libelle . '</option>';
+                } else {
+                    $return .= '<option value="' . $id . '">' . $libelle . '</option>';
+                }
             }
         }
+        return $return;
     }
 
     //renvoi un tableau des jours de fermeture
@@ -2925,6 +2961,7 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         $tab_date_debut=explode("/",$new_date_debut);   // date au format d/m/Y
         $timestamp_date_debut = mktime(0,0,0, $tab_date_debut[1], $tab_date_debut[0], $tab_date_debut[2]) ;
@@ -2937,74 +2974,76 @@ class Fonctions
         // on construit le tableau de l'année considérée
         $tab_year=array();
         \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id,  $DEBUG);
-        if( $DEBUG ) { echo "tab_year = "; print_r($tab_year); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_year = ' . var_export($tab_year, true) . '<br>';
+        }
 
-        echo "<form id=\"form-fermeture\" class=\"form-inline\" role=\"form\" action=\"$PHP_SELF?session=$session&year=$year\" method=\"POST\">\n";
-          echo "<div class=\"form-group\">\n";
-        echo "<label for=\"new_date_debut\">" . _('divers_date_debut') . "</label><input type=\"text\" class=\"form-control date\" name=\"new_date_debut\" value=\"$new_date_debut\">\n";
-          echo "</div>";
-          echo "<div class=\"form-group\">\n";
-          echo "<label for=\"new date_fin\">" . _('divers_date_fin') . "</label><input type=\"text\" class=\"form-control date\" name=\"new_date_fin\" value=\"$new_date_fin\">\n";
-          echo "</div>";
-          echo "<div class=\"form-group\">\n";
-        echo "<label for=\"id_type_conges\">" . _('admin_jours_fermeture_affect_type_conges') . "</label>\n";
-        echo "<select name=\"id_type_conges\" class=\"form-control\">\n";
-           echo \hr\Fonctions::affiche_select_conges_id($DEBUG);
-           echo "</select>\n";
-           echo "</div>\n";
-           echo "<hr/>\n";
-         echo "<input type=\"hidden\" name=\"groupe_id\" value=\"$groupe_id\">\n";
-        echo "<input type=\"hidden\" name=\"choix_action\" value=\"commit_new_fermeture\">\n";
-        echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_submit') ."\">\n";
-        echo "</form>\n";
+        $return .= '<form id="form-fermeture" class="form-inline" role="form" action="' . $PHP_SELF . '?session=' . $session . '&year=' . $year . '" method="POST">';
+        $return .= '<div class="form-group">';
+        $return .= '<label for="new_date_debut">' . _('divers_date_debut') . '</label><input type="text" class="form-control date" name="new_date_debut" value="' . $new_date_debut . '">';
+        $return .= '</div>';
+        $return .= '<div class="form-group">';
+        $return .= '<label for="new date_fin">' . _('divers_date_fin') . '</label><input type="text" class="form-control date" name="new_date_fin" value="' . $new_date_fin . '">';
+        $return .= '</div>';
+        $return .= '<div class="form-group">';
+        $return .= '<label for="id_type_conges">' . _('admin_jours_fermeture_affect_type_conges') . '</label>';
+        $return .= '<select name="id_type_conges" class="form-control">';
+        $return .= \hr\Fonctions::affiche_select_conges_id($DEBUG);
+        $return .= '</select>';
+        $return .= '</div>';
+        $return .= '<hr/>';
+        $return .= '<input type="hidden" name="groupe_id" value="' . $groupe_id . '">';
+        $return .= '<input type="hidden" name="choix_action" value="commit_new_fermeture">';
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
+        $return .= '</form>';
+        return $return;
     }
 
     public static function saisie_groupe_fermeture( $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
+        $return .= '<h3>fermeture pour tous ou pour un groupe ?</h3>';
+        $return .= '<div class="row">';
+        $return .= '<div class="col-md-6">';
+        /********************/
+        /* Choix Tous       */
+        /********************/
 
-        echo "<h3>fermeture pour tous ou pour un groupe ?</h3>\n";
-        echo '<div class="row">';
-            echo '<div class="col-md-6">';
-                /********************/
-                /* Choix Tous       */
-                /********************/
+        // AFFICHAGE TABLEAU
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<input type="hidden" name="groupe_id" value="0">';
+        $return .= '<input type="hidden" name="choix_action" value="saisie_dates">';
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('admin_jours_fermeture_fermeture_pour_tous') . ' !">';
+        $return .= '</form>';
+        $return .= '</div>';
+        $return .= '<div class="col-md-6">';
+        /********************/
+        /* Choix Groupe     */
+        /********************/
+        // Récuperation des informations :
+        $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename"  ;
 
-                // AFFICHAGE TABLEAU
-                echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n" ;
-                    echo "<input type=\"hidden\" name=\"groupe_id\" value=\"0\">\n";
-                    echo "<input type=\"hidden\" name=\"choix_action\" value=\"saisie_dates\">\n";
-                    echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('admin_jours_fermeture_fermeture_pour_tous') ." !\">  \n";
-                echo "</form>\n" ;
-            echo '</div>';
-            echo '<div class="col-md-6">';
-                /********************/
-                /* Choix Groupe     */
-                /********************/
-                // Récuperation des informations :
-                $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename"  ;
+        // AFFICHAGE TABLEAU
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" class="form-inline" method="POST">';
+        $return .= '<div class="form-group" style="margin-right: 10px;">';
+        $ReqLog_gr = \includes\SQL::query($sql_gr);
+        $return .= '<select class="form-control" name="groupe_id">';
+        while ($resultat_gr = $ReqLog_gr->fetch_array()) {
+            $sql_gid=$resultat_gr["g_gid"] ;
+            $sql_group=$resultat_gr["g_groupename"] ;
+            $sql_comment=$resultat_gr["g_comment"] ;
 
-                // AFFICHAGE TABLEAU
-
-                echo "<form action=\"$PHP_SELF?session=$session\" class=\"form-inline\" method=\"POST\">\n" ;
-                    echo '<div class="form-group" style="margin-right: 10px;">';
-                        $ReqLog_gr = \includes\SQL::query($sql_gr);
-                        echo "<select  class=\"form-control\" name=\"groupe_id\">";
-                        while ($resultat_gr = $ReqLog_gr->fetch_array()) {
-                            $sql_gid=$resultat_gr["g_gid"] ;
-                            $sql_group=$resultat_gr["g_groupename"] ;
-                            $sql_comment=$resultat_gr["g_comment"] ;
-
-                            echo "<option value=\"$sql_gid\">$sql_group";
-                        }
-                        echo "</select>";
-                        echo "<input type=\"hidden\" name=\"choix_action\" value=\"saisie_dates\">\n";
-                    echo '</div>';
-                    echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('admin_jours_fermeture_fermeture_par_groupe') ."\">  \n";
-                echo "</form>\n" ;
-            echo '</div>';
+            $return .= '<option value="' . $sql_gid . '">' . $sql_group;
+        }
+        $return .= '</select>';
+        $return .= '<input type="hidden" name="choix_action" value="saisie_dates">';
+        $return .= '</div>';
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('admin_jours_fermeture_fermeture_par_groupe') . '">';
+        $return .= '</form>';
+        $return .= '</div>';
 
         /************************************************/
         // HISTORIQUE DES FERMETURES
@@ -3012,12 +3051,12 @@ class Fonctions
         $tab_periodes_fermeture = array();
         \hr\Fonctions::get_tableau_periodes_fermeture($tab_periodes_fermeture, $DEBUG);
         if(count($tab_periodes_fermeture)!=0) {
-            echo "<table class=\"table\">\n";
-            echo "<thead>\n";
-            echo "<tr>\n";
-            echo "<th colspan=\"2\">Fermetures</th>\n";
-            echo "</tr>\n";
-            echo "</thead>\n";
+            $return .= '<table class="table">';
+            $return .= '<thead>';
+            $return .= '<tr>';
+            $return .= '<th colspan="2">Fermetures</th>';
+            $return .= '</tr>';
+            $return .= '</thead>';
             foreach($tab_periodes_fermeture as $tab_periode) {
                 $date_affiche_1=eng_date_to_fr($tab_periode['date_deb']);
                 $date_affiche_2=eng_date_to_fr($tab_periode['date_fin']);
@@ -3025,27 +3064,27 @@ class Fonctions
                 $groupe_id =($tab_periode['groupe_id']);
                 $groupe_name =($tab_periode['groupe_name']);
 
-                if($groupe_id==0)
+                if($groupe_id==0) {
                     $groupe_name = 'Tous';
-                else
+                } else {
                     $groupe_name = $groupe_name;
+                }
 
-                echo "<tr>\n";
-                echo "<td>\n";
-                echo  _('divers_du') ." <b>$date_affiche_1</b> ". _('divers_au') ." <b>$date_affiche_2</b>  (id $fermeture_id)</b>  ".$groupe_name."\n";
-                echo "</td>\n";
-                echo "<td>\n";
-                echo "<a href=\"$PHP_SELF?session=$session&choix_action=annul_fermeture&fermeture_id=$fermeture_id&groupe_id=$groupe_id&fermeture_date_debut=$date_affiche_1&fermeture_date_fin=$date_affiche_2\">". _('admin_annuler_fermeture') ."</a>\n";
-                echo "</td>\n";
-                echo "</tr>\n";
+                $return .= '<tr>';
+                $return .= '<td>';
+                $return .= _('divers_du') . ' <b>'. $date_affiche_1 . '</b> ' . _('divers_au') . ' <b>' . $date_affiche_2 . '</b>  (id ' . $fermeture_id . ')</b> ' . $groupe_name;
+                $return .= '</td>';
+                $return .= '<td>';
+                $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&choix_action=annul_fermeture&fermeture_id=' . $fermeture_id . '&groupe_id=' . $groupe_id . '&fermeture_date_debut=' . $date_affiche_1 . '&fermeture_date_fin=' . $date_affiche_2 . '">' . _('admin_annuler_fermeture') . '</a>';
+                $return .= '</td>';
+                $return .= '</tr>';
             }
-            echo "</table>\n";
+            $return .= '</table>';
         }
-
-
-        echo '</div>';
-        echo "<hr>\n" ;
-        echo "<a class=\"btn\" href=\"/admin/admin_index.php?session=$session\">". _('form_cancel') ."</a>\n";
+        $return .= '</div>';
+        $return .= '<hr>';
+        $return .= '<a class="btn" href="/admin/admin_index.php?session=' . $session . '">' . _('form_cancel') . '</a>';
+        return $return;
     }
 
     /**
@@ -3062,6 +3101,7 @@ class Fonctions
     {
         // verif des droits du user à afficher la page
         verif_droits_user($session, "is_hr", $DEBUG);
+        $return = '';
 
         /*** initialisation des variables ***/
         /*************************************/
@@ -3069,40 +3109,49 @@ class Fonctions
         // SERVER
         $PHP_SELF=$_SERVER['PHP_SELF'];
         // GET / POST
-        $choix_action                 = getpost_variable('choix_action');
-        $year                        = getpost_variable('year', 0);
-        $groupe_id                    = getpost_variable('groupe_id');
-        $id_type_conges                = getpost_variable('id_type_conges');
-        $new_date_debut                = getpost_variable('new_date_debut'); // valeur par dédaut = aujourd'hui
-        $new_date_fin                  = getpost_variable('new_date_fin');   // valeur par dédaut = aujourd'hui
-        $fermeture_id                  = getpost_variable('fermeture_id', 0);
-        $fermeture_date_debut        = getpost_variable('fermeture_date_debut');
-        $fermeture_date_fin            = getpost_variable('fermeture_date_fin');
-        $code_erreur                = getpost_variable('code_erreur', 0);
+        $choix_action         = getpost_variable('choix_action');
+        $year                 = getpost_variable('year', 0);
+        $groupe_id            = getpost_variable('groupe_id');
+        $id_type_conges       = getpost_variable('id_type_conges');
+        $new_date_debut       = getpost_variable('new_date_debut'); // valeur par dédaut = aujourd'hui
+        $new_date_fin         = getpost_variable('new_date_fin');   // valeur par dédaut = aujourd'hui
+        $fermeture_id         = getpost_variable('fermeture_id', 0);
+        $fermeture_date_debut = getpost_variable('fermeture_date_debut');
+        $fermeture_date_fin   = getpost_variable('fermeture_date_fin');
+        $code_erreur          = getpost_variable('code_erreur', 0);
 
-        // si les dates de début ou de fin ne sont pas passé par get/post alors date du jours.
+        // si les dates de début ou de fin ne sont pas passé par get/post alors date du jour.
         if($new_date_debut=="") {
-            if($year==0)
+            if($year==0) {
                 $new_date_debut=date("d/m/Y") ;
-            else
+            } else {
                 $new_date_debut=date("d/m/Y", mktime(0,0,0, date("m"), date("d"), $year) ) ;
+            }
         }
         if($new_date_fin=="") {
-            if($year==0)
+            if($year==0) {
                 $new_date_fin=date("d/m/Y") ;
-            else
+            } else {
                 $new_date_fin=date("d/m/Y", mktime(0,0,0, date("m"), date("d"), $year) ) ;
+            }
         }
 
-        if($year ==0)
+        if($year ==0) {
             $year= date("Y");
+        }
 
         /*************************************/
 
         //debugage
-        if( $DEBUG ) { echo "choix_action = $choix_action // year = $year // groupe_id = $groupe_id<br>\n"; }
-        if( $DEBUG ) { echo "new_date_debut = $new_date_debut // new_date_fin = $new_date_fin<br>\n"; }
-        if( $DEBUG ) { echo "fermeture_id = $fermeture_id // fermeture_date_debut = $fermeture_date_debut // fermeture_date_fin = $fermeture_date_fin<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'choix_action = ' . $choix_action . '// year = ' . $year . ' // groupe_id = ' . $groupe_id . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'new_date_debut = ' . $new_date_debut . '// new_date_fin = ' . $new_date_fin . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'fermeture_id = ' . $fermeture_id . '// fermeture_date_debut = ' . $fermeture_date_debut . '// fermeture_date_fin = ' . $fermeture_date_fin . '<br>';
+        }
 
         /***********************************/
         /*  VERIF DES DATES RECUES   */
@@ -3114,7 +3163,9 @@ class Fonctions
         $date_fin_yyyy_mm_dd = $tab_date_fin[2]."-".$tab_date_fin[1]."-".$tab_date_fin[0] ;
         $timestamp_today = mktime(0,0,0, date("m"), date("d"), date("Y")) ;
 
-        if( $DEBUG ) { echo "timestamp_date_debut = $timestamp_date_debut // timestamp_date_fin = $timestamp_date_fin // timestamp_today = $timestamp_today<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'timestamp_date_debut = ' . $timestamp_date_debut . ' // timestamp_date_fin = ' . $timestamp_date_fin . '// timestamp_today = ' . $timestamp_today . '<br>';
+        }
 
         /*********************************/
         /*   COMPOSITION DES ONGLETS...  */
@@ -3122,24 +3173,27 @@ class Fonctions
 
         $onglet = getpost_variable('onglet');
 
-        if(!$onglet)
+        if(!$onglet) {
             $onglet = 'saisie';
+        }
 
         $onglets = array();
-        $onglets['saisie'] = _('admin_jours_fermeture_titre') . " " . "<span class=\"current-year\">$year</span>";
+        $onglets['saisie']   = _('admin_jours_fermeture_titre') . " " . "<span class=\"current-year\">$year</span>";
         $onglets['calendar'] = 'Calendrier des fermetures' . " " . "<span class=\"current-year\">$year</span>";
         $onglets['year_nav'] = NULL;
 
         //initialisation de l'action par défaut : saisie_dates pour tous, saisie_groupe en cas de gestion et fermeture par groupe autorisée
         if($choix_action=="") {
             // si pas de gestion par groupe
-            if($_SESSION['config']['gestion_groupes']==FALSE)
-                 $choix_action="saisie_dates";
+            if($_SESSION['config']['gestion_groupes'] == FALSE) {
+                $choix_action="saisie_dates";
+            }
             // si gestion par groupe et fermeture_par_groupe
-            elseif(($_SESSION['config']['fermeture_par_groupe']) && ($groupe_id=="") )
-                 $choix_action="saisie_groupe";
-            else
-                 $choix_action="saisie_dates";
+            elseif(($_SESSION['config']['fermeture_par_groupe']) && ($groupe_id=="") ) {
+                $choix_action="saisie_groupe";
+            } else {
+                $choix_action="saisie_dates";
+            }
         }
 
         /*********************************/
@@ -3156,25 +3210,24 @@ class Fonctions
         /*********************************/
         /*   AFFICHAGE DES ONGLETS...  */
         /*********************************/
-        echo '<div id="onglet_menu">';
+        $return .= '<div id="onglet_menu">';
         foreach($onglets as $key => $title) {
-            if($key == 'year_nav')
-            {
+            if($key == 'year_nav') {
                 // navigation
                 $prev_link = "$PHP_SELF?session=$session&onglet=$onglet&year=". ($year - 1) . "&groupe_id=$groupe_id";
                 $next_link = "$PHP_SELF?session=$session&onglet=$onglet&year=". ($year + 1) . "&groupe_id=$groupe_id";
-                echo "<div class=\"onglet calendar-nav\">\n";
-                echo "<ul>\n";
-                echo "<li><a href=\"$prev_link\" class=\"calendar-prev\"><i class=\"fa fa-chevron-left\"></i><span>année précédente</span></a></li>\n";
-                echo "<li class=\"current-year\">$year</li>\n";
-                echo "<li><a href=\"$next_link\" class=\"calendar-next\"><i class=\"fa fa-chevron-right\"></i><span>année suivante</span></a></li>\n";
-                echo "</ul>\n";
-                echo "</div>\n";
+                $return .= '<div class="onglet calendar-nav">';
+                $return .= '<ul>';
+                $return .= '<li><a href="' . $prev_link . '" class="calendar-prev"><i class="fa fa-chevron-left"></i><span>année précédente</span></a></li>';
+                $return .= '<li class="current-year">' . $year . '</li>';
+                $return .= '<li><a href="' . $next_link . '" class="calendar-next"><i class="fa fa-chevron-right"></i><span>année suivante</span></a></li>';
+                $return .= '</ul>';
+                $return .= '</div>';
             } else {
-                echo '<div class="onglet '.($onglet == $key ? ' active': '').'" ><a href="' . $PHP_SELF . '?session=' . $session . "&year=$year&onglet=" . $key . '">' . $title . '</a></div>';
+                $return .= '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" ><a href="' . $PHP_SELF . '?session=' . $session . '&year=' . $year . '&onglet=' . $key . '">' . $title . '</a></div>';
             }
         }
-        echo '</div>';
+        $return .= '</div>';
 
         // vérifie si les jours fériés sont saisie pour l'année en cours
         if( (verif_jours_feries_saisis($date_debut_yyyy_mm_dd, $DEBUG)==FALSE) && (verif_jours_feries_saisis($date_fin_yyyy_mm_dd, $DEBUG)==FALSE) ) {
@@ -3187,8 +3240,7 @@ class Fonctions
         //en cas de confirmation d'une fermeture :
         if($choix_action == "commit_new_fermeture") {
             // on verifie que $new_date_debut est anterieure a $new_date_fin
-            if($timestamp_date_debut > $timestamp_date_fin)
-            {
+            if($timestamp_date_debut > $timestamp_date_fin) {
                 $code_erreur=2 ;  // code erreur : $new_date_debut est posterieure a $new_date_fin
                 $choix_action="saisie_dates";
             }
@@ -3206,8 +3258,7 @@ class Fonctions
                 // fabrication et initialisation du tableau des demi-jours de la date_debut à la date_fin
                 $tab_periode_calcul = make_tab_demi_jours_periode($date_debut_yyyy_mm_dd, $date_fin_yyyy_mm_dd, "am", "pm", $DEBUG);
                 // on verifie si la periode saisie ne chevauche pas une periode existante
-                if(\hr\Fonctions::verif_periode_chevauche_periode_groupe($date_debut_yyyy_mm_dd, $date_fin_yyyy_mm_dd, '', $tab_periode_calcul, $groupe_id, $DEBUG) )
-                {
+                if(\hr\Fonctions::verif_periode_chevauche_periode_groupe($date_debut_yyyy_mm_dd, $date_fin_yyyy_mm_dd, '', $tab_periode_calcul, $groupe_id, $DEBUG) ) {
                     $code_erreur=5 ;  // code erreur : fermeture chevauche une periode deja saisie
                     $choix_action="saisie_dates";
                 }
@@ -3215,54 +3266,59 @@ class Fonctions
         }
 
         if($onglet == 'calendar') {
-
             // les jours fériés de l'annee de la periode saisie ne sont pas enregistrés
-            if($code_erreur==1)
-                echo "<div class=\"alert alert-danger\">" . _('admin_jours_fermeture_annee_non_saisie') . "</div>\n";
+            if($code_erreur==1) {
+                $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_annee_non_saisie') . '</div>';
+            }
 
                    /************************************************/
             // CALENDRIER DES FERMETURES
-            \hr\Fonctions::affiche_calendrier_fermeture($year, $DEBUG);
+            $return .= \hr\Fonctions::affiche_calendrier_fermeture($year, $DEBUG);
         } elseif($choix_action=="saisie_dates") {
-            if($groupe_id=="") // choix du groupe n'a pas été fait ($_SESSION['config']['fermeture_par_groupe']==FALSE)
+            if($groupe_id=="") { // choix du groupe n'a pas été fait ($_SESSION['config']['fermeture_par_groupe']==FALSE)
                 $groupe_id=0;
+            }
 
             // $new_date_debut est anterieure a $new_date_fin
-            if($code_erreur==2)
-                echo "<div class=\"alert alert-danger\">" . _('admin_jours_fermeture_dates_incompatibles') . "</div>\n";
+            if($code_erreur==2) {
+                $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_dates_incompatibles') . '</div>';
+            }
 
             // ce ne sont des dates passées
-            if($code_erreur==3)
-                echo "<div class=\"alert alert-danger\">" . _('admin_jours_fermeture_date_passee_error') . "</div>\n";
+            if($code_erreur==3) {
+                $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_date_passee_error') . '</div>';
+            }
 
             // fermeture le jour même impossible
-            if($code_erreur==4)
-                echo "<div class=\"alert alert-danger\">" . _('admin_jours_fermeture_fermeture_aujourd_hui') . "</div>\n";
+            if($code_erreur==4) {
+                $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_fermeture_aujourd_hui') . '</div>';
+            }
 
             // la periode saisie chevauche une periode existante
-            if($code_erreur==5)
-                echo "<div class=\"alert alert-danger\">" . _('admin_jours_fermeture_chevauche_periode') . "</div>\n";
+            if($code_erreur==5) {
+                $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_chevauche_periode') . '</div>';
+            }
 
-            echo "<div class=\"wrapper\">";
-            echo '<a href="' . ROOT_PATH . "hr/hr_index.php?session=$session\" class=\"admin-back\"><i class=\"fa fa-arrow-circle-o-left\"></i>Retour mode rh</a>\n";
-            if($onglet == 'saisie')
-                    \hr\Fonctions::saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur, $DEBUG);
+            $return .= '<div class="wrapper">';
+            $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session=' . $session . '" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
+            if($onglet == 'saisie') {
+                $return .= \hr\Fonctions::saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur, $DEBUG);
+            }
         } elseif($choix_action=="saisie_groupe") {
-            echo '<div class="wrapper">';
-            echo '<a href="' . ROOT_PATH . "hr/hr_index.php?session=$session\" class=\"admin-back\"><i class=\"fa fa-arrow-circle-o-left\"></i>Retour mode rh</a>\n";
-                   \hr\Fonctions::saisie_groupe_fermeture($DEBUG);
-                echo '</div>';
+            $return .= '<div class="wrapper">';
+            $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session=' . $session . '" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
+            $return .= \hr\Fonctions::saisie_groupe_fermeture($DEBUG);
+            $return .= '</div>';
         } elseif($choix_action=="commit_new_fermeture") {
-            echo $title;
-            \hr\Fonctions::commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges, $DEBUG);
+            $return .= $title;
+            $return .= \hr\Fonctions::commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges, $DEBUG);
         } elseif($choix_action=="annul_fermeture") {
-            echo $title;
-            \hr\Fonctions::confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin, $DEBUG);
+            $return .= $title;
+            $return .= \hr\Fonctions::confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin, $DEBUG);
         } elseif($choix_action=="commit_annul_fermeture") {
-            echo $title;
-            \hr\Fonctions::commit_annul_fermeture($fermeture_id, $groupe_id, $DEBUG);
+            $return .= $title;
+            $return .= \hr\Fonctions::commit_annul_fermeture($fermeture_id, $groupe_id, $DEBUG);
         }
-
-        bottom();
+        return $return;
     }
 }

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -1187,7 +1187,6 @@ class Fonctions
         // recup de la liste des users d'un groupe donné
         $list_users = get_list_users_du_groupe($choix_groupe, $DEBUG);
 
-
         foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
             if($nb_jours!=0) {
                 $comment = $tab_new_comment_all[$id_conges];
@@ -1199,14 +1198,15 @@ class Fonctions
                     $current_login  =$resultat1["u_login"];
                     $current_quotite=$resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                         $nb_conges=$nb_jours;
-                    else
+                    } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
                         $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                    }
 
                     $valid=verif_saisie_decimal($nb_conges, $DEBUG);
-                    if($valid){
+                    if($valid) {
                         // 1 : on update conges_solde_user
                         $req_update = 'UPDATE conges_solde_user SET su_solde = su_solde+ '.intval($nb_conges).'
                                 WHERE  su_login = "'. \includes\SQL::quote($current_login).'" AND su_abs_id = '.intval($id_conges).';';
@@ -1223,10 +1223,11 @@ class Fonctions
                 }
 
                 $group_name = get_group_name_from_id($choix_groupe, $DEBUG);
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
-                else
+                } else {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
+                }
                 log_action(0, "ajout", "groupe", $comment_log, $DEBUG);
             }
         }
@@ -1236,15 +1237,17 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $list_users_du_resp = get_list_all_users_du_hr($_SESSION['userlogin'], $DEBUG);
-        if( $DEBUG ) { echo "list_all_users_du_hr = $list_users_du_resp<br>\n";}
-
-        if( $DEBUG ) { echo "tab_new_nb_conges_all = <br>"; print_r($tab_new_nb_conges_all); echo "<br>\n" ;}
-        if( $DEBUG ) { echo "tab_calcul_proportionnel = <br>"; print_r($tab_calcul_proportionnel); echo "<br>\n" ;}
+        if( $DEBUG ) {
+            $return .= 'list_all_users_du_hr = ' . $list_users_du_resp . '<br>';
+            $return .= 'tab_new_nb_conges_all = <br>' . var_export($tab_new_nb_conges_all, true) . '<br>';
+            $return .= 'tab_calcul_proportionnel = <br>' . var_export($tab_calcul_proportionnel, true) . '<br>';
+        }
 
         foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
             if($nb_jours!=0) {
@@ -1257,12 +1260,13 @@ class Fonctions
                     $current_login  =$resultat1["u_login"];
                     $current_quotite=$resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                         $nb_conges=$nb_jours;
-                    else
+                    } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
                         $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
-                       $valid=verif_saisie_decimal($nb_conges, $DEBUG);
+                    }
+                    $valid=verif_saisie_decimal($nb_conges, $DEBUG);
                     if($valid) {
                         // 1 : update de la table conges_solde_user
                         $req_update = 'UPDATE conges_solde_user SET su_solde = su_solde + '.floatval($nb_conges).'
@@ -1276,13 +1280,15 @@ class Fonctions
                     }
                 }
 
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
-                else
+                } else {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
+                }
                 log_action(0, "ajout", "tous", $comment_log, $DEBUG);
             }
         }
+        return $return;
     }
 
 
@@ -1318,6 +1324,7 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs */
@@ -1327,118 +1334,122 @@ class Fonctions
 
         if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
-            echo "<h2>". _('resp_ajout_conges_ajout_groupe') ."</h2>\n";
-            echo "<form action=\"$PHP_SELF?session=$session&onglet=ajout_conges\" method=\"POST\"> \n";
-            echo "    <fieldset class=\"cal_saisie\">\n";
-            echo "<div class=\"table-responsive\"><table class=\"table table-hover table-condensed table-striped\">\n";
-            echo "    <tr>\n";
-            echo "        <td class=\"big\">". _('resp_ajout_conges_choix_groupe') ." : </td>\n";
-                // création du select pour le choix du groupe
-                $text_choix_group="<select name=\"choix_groupe\" >";
-                $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
-                $ReqLog_group = \includes\SQL::query($sql_group) ;
+            $return .= '<h2>' . _('resp_ajout_conges_ajout_groupe') . '</h2>';
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+            $return .= '<fieldset class="cal_saisie">';
+            $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
+            $return .= '<tr>';
+            $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') . ' : </td>';
+            // création du select pour le choix du groupe
+            $text_choix_group="<select name=\"choix_groupe\" >";
+            $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
+            $ReqLog_group = \includes\SQL::query($sql_group) ;
 
-                while ($resultat_group = $ReqLog_group->fetch_array()) {
-                    $current_group_id=$resultat_group["g_gid"];
-                    $current_group_name=$resultat_group["g_groupename"];
-                    $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
-                }
-                $text_choix_group=$text_choix_group."</select>" ;
-
-            echo "        <td colspan=\"3\">$text_choix_group</td>\n";
-            echo "    </tr>\n";
-        echo "<tr>\n";
-        echo "<th colspan=\"2\">" . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . "</th>\n";
-        echo "<th>" ._('resp_ajout_conges_calcul_prop') . "</th>\n";
-        echo "<th>" . _('divers_comment_maj_1') . "</th>\n";
-        echo "</tr>\n";
-            foreach($tab_type_conges as $id_conges => $libelle) {
-                echo "    <tr>\n";
-                echo "        <td><strong>$libelle<strong></td>\n";
-                echo "        <td><input class=\"form-control\" type=\"text\" name=\"tab_new_nb_conges_all[$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\"></td>\n";
-                echo "        <td>". _('resp_ajout_conges_oui') ." <input type=\"checkbox\" name=\"tab_calcul_proportionnel[$id_conges]\" value=\"TRUE\" checked></td>\n";
-                echo "        <td><input class=\"form-control\" type=\"text\" name=\"tab_new_comment_all[$id_conges]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-                echo "    </tr>\n";
+            while ($resultat_group = $ReqLog_group->fetch_array()) {
+                $current_group_id=$resultat_group["g_gid"];
+                $current_group_name=$resultat_group["g_groupename"];
+                $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
             }
-            echo "    </table></div>\n";
-            echo "<p>" . _('resp_ajout_conges_calcul_prop_arondi') . "! </p>\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_valid_groupe') ."\">\n";
-            echo "    </fieldset>\n";
-            echo "<input type=\"hidden\" name=\"ajout_groupe\" value=\"TRUE\">\n";
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "</form> \n";
+            $text_choix_group=$text_choix_group."</select>" ;
+
+            $return .= '<td colspan="3">' . $text_choix_group . '</td>';
+            $return .= '</tr>';
+            $return .= '<tr>';
+            $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
+            $return .= '<th>' ._('resp_ajout_conges_calcul_prop') . '</th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+            $return .= '</tr>';
+            foreach($tab_type_conges as $id_conges => $libelle) {
+                $return .= '<tr>';
+                $return .= '<td><strong>' . $libelle . '<strong></td>';
+                $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
+                $return .= '<td>' . _('resp_ajout_conges_oui') . '<input type="checkbox" name="tab_calcul_proportionnel[' . $id_conges . ']" value="TRUE" checked></td>';
+                $return .= '<td><input class="form-control" type="text" name="tab_new_comment_all[' . $id_conges . ']" size="30" maxlength="200" value=""></td>';
+                $return .= '</tr>';
+            }
+            $return .= '</table></div>';
+            $return .= '<p>' . _('resp_ajout_conges_calcul_prop_arondi') . '! </p>';
+            $return .= '<input class="btn" type="submit" value="' . _('form_valid_groupe') . '">';
+            $return .= '</fieldset>';
+            $return .= '<input type="hidden" name="ajout_groupe" value="TRUE">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '</form>';
         }
+        return $return;
     }
 
     public static function affichage_saisie_globale_pour_tous($tab_type_conges, $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /************************************************************/
         /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
-        echo "<h2>". _('resp_ajout_conges_ajout_all') ."</h2>\n";
-        echo "<form action=\"$PHP_SELF?session=$session&onglet=ajout_conges\" method=\"POST\"> \n";
-        echo "    <fieldset class=\"cal_saisie\">\n";
-        echo "<div class=\"table-responsive\"><table class=\"table table-hover table-condensed table-striped\">\n";
-        echo "<thead>\n";
-        echo "<tr>\n";
-        echo "<th colspan=\"2\">" . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . "</th>\n";
-        echo "<th>" ._('resp_ajout_conges_calcul_prop') . "</th>\n";
-        echo "<th>" . _('divers_comment_maj_1') . "</th>\n";
-        echo "</tr>\n";
-        echo "</thead>\n";
+        $return .= '<h2>' . _('resp_ajout_conges_ajout_all') . '</h2>';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+        $return .= '<fieldset class="cal_saisie">';
+        $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
+        $return .= '<thead>';
+        $return .= '<tr>';
+        $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
+        $return .= '<th>' . _('resp_ajout_conges_calcul_prop') . '</th>';
+        $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+        $return .= '</tr>';
+        $return .= '</thead>';
         foreach($tab_type_conges as $id_conges => $libelle) {
-            echo "    <tr>\n";
-            echo "        <td><strong>$libelle<strong></td>\n";
-            echo "        <td><input class=\"form-control\" type=\"text\" name=\"tab_new_nb_conges_all[$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\"></td>\n";
-            echo "        <td>". _('resp_ajout_conges_oui') ." <input type=\"checkbox\" name=\"tab_calcul_proportionnel[$id_conges]\" value=\"TRUE\" checked></td>\n";
-            echo "        <td><input class=\"form-control\" type=\"text\" name=\"tab_new_comment_all[$id_conges]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-            echo "    </tr>\n";
+            $return .= '<tr>';
+            $return .= '<td><strong>' . $libelle . '<strong></td>';
+            $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
+            $return .= '<td>' . _('resp_ajout_conges_oui') . '<input type="checkbox" name="tab_calcul_proportionnel[' . $id_conges . ']" value="TRUE" checked></td>';
+            $return .= '<td><input class="form-control" type="text" name="tab_new_comment_all[' . $id_conges . ']" size="30" maxlength="200" value=""></td>';
+            $return .= '</tr>';
         }
-        echo "</table></div>\n";
+        $return .= '</table></div>';
         // texte sur l'arrondi du calcul proportionnel
-        echo "<p>" . _('resp_ajout_conges_calcul_prop_arondi') . "!</p>\n";
+        $return .= '<p>' . _('resp_ajout_conges_calcul_prop_arondi') . '!</p>';
         // bouton valider
-        echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_valid_global') ."\">\n";
-        echo "</fieldset>\n";
-        echo "<input type=\"hidden\" name=\"ajout_global\" value=\"TRUE\">\n";
-        echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-        echo "</form> \n";
+        $return .= '<input class="btn" type="submit" value="' . _('form_valid_global') . '">';
+        $return .= '</fieldset>';
+        $return .= '<input type="hidden" name="ajout_global" value="TRUE">';
+        $return .= '<input type="hidden" name="session" value="' . $session . '">';
+        $return .= '</form>';
+        return $return;
     }
 
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp, $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /************************************************************/
         /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
-        echo "<h2>Ajout par utilisateur</h2>\n";
-        echo " <form action=\"$PHP_SELF?session=$session&onglet=ajout_conges\" method=\"POST\"> \n";
+        $return .= '<h2>Ajout par utilisateur</h2>';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
 
         if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             // AFFICHAGE TITRES TABLEAU
-            echo "<div class=\"table-responsive\"><table class=\"table table-hover table-condensed table-striped\">\n";
-            echo '<thead>';
-                echo '<tr align="center">';
-                    echo '<th>'. _('divers_nom_maj_1') .'</th>';
-                    echo '<th>'. _('divers_prenom_maj_1') .'</th>';
-                    echo '<th>'. _('divers_quotite_maj_1') .'</th>';
-                    foreach($tab_type_conges as $id_conges => $libelle) {
-                        echo "<th>$libelle<br><i>(". _('divers_solde') .")</i></th>\n";
-                        echo "<th>$libelle<br>". _('resp_ajout_conges_nb_jours_ajout') .'</th>' ;
-                    }
-                    if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                        foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
-                            echo "<th>$libelle<br><i>(". _('divers_solde') .")</i></th>\n";
-                            echo "<th>$libelle<br>". _('resp_ajout_conges_nb_jours_ajout') .'</th>' ;
-                        }
-                    }
-                    echo '<th>'. _('divers_comment_maj_1') ."<br></th>\n" ;
-                echo"</tr>\n";
-            echo '</thead>';
-            echo '<tbody>';
+            $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
+            $return .= '<thead>';
+            $return .= '<tr align="center">';
+            $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
+            foreach($tab_type_conges as $id_conges => $libelle) {
+                $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
+                $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
+            }
+            if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                    $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
+                    $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
+                }
+            }
+            $return .= '<th>'. _('divers_comment_maj_1') . '<br></th>';
+            $return .= '</tr>';
+            $return .= '</thead>';
+            $return .= '<tbody>';
 
             // AFFICHAGE LIGNES TABLEAU
             $cpt_lignes=0 ;
@@ -1447,87 +1458,97 @@ class Fonctions
             $i = true;
             // affichage des users dont on est responsable :
             foreach($tab_all_users_du_hr as $current_login => $tab_current_user) {
-                echo '<tr class="'.($i?'i':'p').'">';
+                $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
                 $tab_conges=$tab_current_user['conges'];
 
                 /** sur la ligne ,   **/
-                echo '<td>'.$tab_current_user['nom'].'</td>';
-                echo '<td>'.$tab_current_user['prenom'].'</td>';
-                echo '<td>'.$tab_current_user['quotite']."%</td>\n";
+                $return .= '<td>' . $tab_current_user['nom'] . '</td>';
+                $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
+                $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
                 foreach($tab_type_conges as $id_conges => $libelle) {
                     /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
                     $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
-                    echo '<td>'.$tab_conges[$libelle]['nb_an']." <i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
-                    echo "<td align=\"center\" class=\"histo\">$champ_saisie_conges</td>\n" ;
+                    $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
+                    $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                 }
                 if ($_SESSION['config']['gestion_conges_exceptionnels']) {
                     foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                         /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
                         $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
-                        echo "<td><i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
-                        echo "<td align=\"center\" class=\"histo\">$champ_saisie_conges</td>\n" ;
+                        $return .= '<td><i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
+                        $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                     }
                 }
-                echo "<td align=\"center\" class=\"histo\"><input class=\"form-control\" type=\"text\" name=\"tab_commentaire_saisie[$current_login]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-                echo '</tr>';
+                $return .= '<td align="center" class="histo"><input class="form-control" type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="30" maxlength="200" value=""></td>';
+                $return .= '</tr>';
                 $cpt_lignes++ ;
                 $i = !$i;
             }
 
-            echo '</tbody>';
-            echo '</table>';
+            $return .= '</tbody>';
+            $return .= '</table>';
 
-            echo "<input type=\"hidden\" name=\"ajout_conges\" value=\"TRUE\">\n";
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_submit') ."\">\n";
-            echo " </form> \n";
+            $return .= '<input type="hidden" name="ajout_conges" value="TRUE">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
+            $return .= ' </form>';
         }
+
+        return $return;
     }
 
     public static function saisie_ajout( $tab_type_conges, $DEBUG)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         // recup du tableau des types de conges (seulement les congesexceptionnels )
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-          $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
-          if( $DEBUG ) { echo "tab_type_conges_exceptionnels = "; print_r($tab_type_conges_exceptionnels); echo "<br><br>\n";}
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
+            if( $DEBUG ) {
+                $return .= 'tab_type_conges_exceptionnels = ' . var_export($tab_type_conges_exceptionnels, true) . '<br><br>';
+            }
+        } else {
+            $tab_type_conges_exceptionnels = array();
         }
-        else
-          $tab_type_conges_exceptionnels = array();
 
         // recup de la liste de TOUS les users pour le RH
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $tab_all_users_du_hr=recup_infos_all_users_du_hr($_SESSION['userlogin']);
         $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( $DEBUG ) { echo "tab_all_users_du_hr =<br>\n"; print_r($tab_all_users_du_hr); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_all_users_du_grand_resp =<br>\n"; print_r($tab_all_users_du_grand_resp); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_hr =<br>' . var_export($tab_all_users_du_hr, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_grand_resp =<br>' . var_export($tab_all_users_du_grand_resp, true) . '<br>';
+        }
 
         if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
-            \hr\Fonctions::affichage_saisie_globale_pour_tous($tab_type_conges, $DEBUG);
-            echo "<br>\n";
+            $return .= \hr\Fonctions::affichage_saisie_globale_pour_tous($tab_type_conges, $DEBUG);
+            $return .= '<br>';
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes'] )
-                \hr\Fonctions::affichage_saisie_globale_groupe($tab_type_conges, $DEBUG);
-            echo "<br>\n";
+            if( $_SESSION['config']['gestion_groupes'] ) {
+                $return .= \hr\Fonctions::affichage_saisie_globale_groupe($tab_type_conges, $DEBUG);
+            }
+            $return .= '<br>';
 
             /************************************************************/
             /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
-            \hr\Fonctions::affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp, $DEBUG);
-            echo "<br>\n";
+            $return .= \hr\Fonctions::affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp, $DEBUG);
+            $return .= '<br>';
 
+        } else {
+            $return .= _('resp_etat_aucun_user') . '<br>';
         }
-        else
-            echo  _('resp_etat_aucun_user') ."<br>\n";
-
+        return $return;
     }
 
     /**
@@ -1544,13 +1565,14 @@ class Fonctions
     public static function pageAjoutCongesModule($tab_type_cong, $session, $DEBUG = false)
     {
         //var pour resp_ajout_conges_all.php
-        $ajout_conges            = getpost_variable('ajout_conges');
-        $ajout_global            = getpost_variable('ajout_global');
-        $ajout_groupe            = getpost_variable('ajout_groupe');
-        $choix_groupe            = getpost_variable('choix_groupe');
+        $ajout_conges = getpost_variable('ajout_conges');
+        $ajout_global = getpost_variable('ajout_global');
+        $ajout_groupe = getpost_variable('ajout_groupe');
+        $choix_groupe = getpost_variable('choix_groupe');
+        $return = '';
 
         // titre
-        echo '<h1>'. _('resp_ajout_conges_titre') ."</h1>\n\n";
+        $return .= '<h1>'. _('resp_ajout_conges_titre') . '</h1>';
 
         if( $ajout_conges == "TRUE" ) {
             $tab_champ_saisie            = getpost_variable('tab_champ_saisie');
@@ -1565,7 +1587,7 @@ class Fonctions
             $tab_calcul_proportionnel    = getpost_variable('tab_calcul_proportionnel');
             $tab_new_comment_all         = getpost_variable('tab_new_comment_all');
 
-            \hr\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all, $DEBUG);
+            $return .= \hr\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all, $DEBUG);
             redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
             exit;
         } elseif( $ajout_groupe == "TRUE" ) {
@@ -1579,8 +1601,10 @@ class Fonctions
             redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
             exit;
         } else {
-            \hr\Fonctions::saisie_ajout($tab_type_cong,$DEBUG);
+            $return .= \hr\Fonctions::saisie_ajout($tab_type_cong,$DEBUG);
         }
+
+        return $return;
     }
 
     //fonction de recherche des jours fériés de l'année demandée

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -1676,12 +1676,16 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
-        if( $DEBUG ) { echo "tab_checkbox_j_chome : <br>\n"; print_r($tab_checkbox_j_chome); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_checkbox_j_chome : <br>' . var_export($tab_checkbox_j_chome, true) . '<br>';
+        }
 
         // si l'année est déja renseignée dans la database, on efface ttes les dates de l'année
-        if(\hr\Fonctions::verif_year_deja_saisie($tab_checkbox_j_chome, $DEBUG))
+        if(\hr\Fonctions::verif_year_deja_saisie($tab_checkbox_j_chome, $DEBUG)) {
             $result = \hr\Fonctions::delete_year($tab_checkbox_j_chome, $DEBUG);
+        }
 
 
         // on insert les nouvelles dates saisies
@@ -1690,15 +1694,17 @@ class Fonctions
         // on recharge les jours feries dans les variables de session
         init_tab_jours_feries($DEBUG);
 
-        if($result)
-            echo "<div class=\"alert alert-success\">" . _('form_modif_ok') . "</div>\n";
-        else
-            echo "<div class=\"alert alert-danger\">". _('form_modif_not_ok') . "</div>\n";
+        if($result) {
+            $return .= '<div class="alert alert-success">' . _('form_modif_ok') . '</div>';
+        } else {
+            $return .= '<div class="alert alert-danger">' . _('form_modif_not_ok') . '</div>';
+        }
 
         $date_1=key($tab_checkbox_j_chome);
         $tab_date = explode('-', $date_1);
         $comment_log = "saisie des jours chomés pour ".$tab_date[0] ;
         log_action(0, "", "", $comment_log, $DEBUG);
+        return $return;
     }
 
     public static function confirm_saisie($tab_checkbox_j_chome, $DEBUG=FALSE)
@@ -1756,131 +1762,141 @@ class Fonctions
     {
         $jour_today=date("j");
         $jour_today_name=date("D");
+        $return = '';
 
         $first_jour_mois_timestamp=mktime (0,0,0,$mois,1,$year);
         $mois_name=date_fr("F", $first_jour_mois_timestamp);
         $first_jour_mois_rang=date("w", $first_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        if($first_jour_mois_rang==0)
+        if($first_jour_mois_rang==0) {
             $first_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        }
 
-
-        echo "<table>\n";
+        $return .= '<table>';
         /* affichage  2 premieres lignes */
-        echo "<thead>\n";
-        echo "    <tr align=\"center\" bgcolor=\"".$_SESSION['config']['light_grey_bgcolor']."\"><th colspan=7 class=\"titre\"> $mois_name $year </th></tr>\n" ;
-        echo "    <tr>\n";
-        echo "        <th class=\"cal-saisie2\">". _('lundi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('mardi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('mercredi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('jeudi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2\">". _('vendredi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2 weekend\">". _('samedi_1c') ."</th>\n";
-        echo "        <th class=\"cal-saisie2 weekend\">". _('dimanche_1c') ."</th>\n";
-        echo "    </tr>\n" ;
-        echo "</thead>\n";
+        $return .= '<thead>';
+        $return .= '<tr align="center" bgcolor="' .  $_SESSION['config']['light_grey_bgcolor'] . '"><th colspan=7 class="titre">' . $mois_name . ' ' . $year . '</th></tr>';
+        $return .= '<tr>';
+        $return .= '<th class="cal-saisie2">' . _('lundi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('mardi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('mercredi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('jeudi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2">' . _('vendredi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2 weekend">' . _('samedi_1c') . '</th>';
+        $return .= '<th class="cal-saisie2 weekend">' . _('dimanche_1c') . '</th>';
+        $return .= '</tr>';
+        $return .= '</thead>';
 
         /* affichage ligne 1 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         // affichage des cellules vides jusqu'au 1 du mois ...
         for($i=1; $i<$first_jour_mois_rang; $i++) {
-            echo \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
         }
         // affichage des cellules cochables du 1 du mois à la fin de la ligne ...
         for($i=$first_jour_mois_rang; $i<8; $i++) {
             $j=$i-$first_jour_mois_rang+1;
-            echo \hr\Fonctions::affiche_jour_checkbox($mois,$j,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$j,$year,$tab_year);
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 2 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=8-$first_jour_mois_rang+1; $i<15-$first_jour_mois_rang+1; $i++) {
-            echo \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 3 du mois*/
-        echo "<tr>\n";
-        for($i=15-$first_jour_mois_rang+1; $i<22-$first_jour_mois_rang+1; $i++){
-            echo \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+        $return .= '<tr>';
+        for($i=15-$first_jour_mois_rang+1; $i<22-$first_jour_mois_rang+1; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 4 du mois*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=22-$first_jour_mois_rang+1; $i<29-$first_jour_mois_rang+1; $i++) {
-            echo \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 5 du mois (peut etre la derniere ligne) */
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=29-$first_jour_mois_rang+1; $i<36-$first_jour_mois_rang+1 && checkdate($mois, $i, $year); $i++) {
-            echo \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
         }
 
         for($i; $i<36-$first_jour_mois_rang+1; $i++) {
-            echo \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
         }
-        echo "</tr>\n";
+        $return .= '</tr>';
 
         /* affichage ligne 6 du mois (derniere ligne)*/
-        echo "<tr>\n";
+        $return .= '<tr>';
         for($i=36-$first_jour_mois_rang+1; checkdate($mois, $i, $year); $i++) {
-            echo \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
         }
 
         for($i; $i<43-$first_jour_mois_rang+1; $i++) {
-            echo \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
+            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
         }
-        echo "</tr>\n";
+        $return .= '</tr></table>';
 
-        echo "</table>\n";
+        return $return;
     }
 
     public static function saisie($year_calendrier_saisie, $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         // si l'année n'est pas renseignée, on prend celle du jour
-        if($year_calendrier_saisie==0)
+        if($year_calendrier_saisie==0) {
             $year_calendrier_saisie = date("Y");
+        }
 
         // on construit le tableau des jours feries de l'année considérée
         $tab_year=array();
         \hr\Fonctions::get_tableau_jour_feries($year_calendrier_saisie, $tab_year,$DEBUG);
-        if( $DEBUG ) { echo "tab_year = "; print_r($tab_year); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_year = ' . var_export($tab_year, true) . '<br>';
+        }
 
         //calcul automatique des jours feries
         if($_SESSION['config']['calcul_auto_jours_feries_france']) {
             $tableau_jour_feries = \hr\Fonctions::fcListJourFeries($year_calendrier_saisie) ;
-            if( $DEBUG ) { echo "tableau_jour_feries = "; print_r($tableau_jour_feries); echo "<br>\n"; }
-            foreach ($tableau_jour_feries as $i => $value)
-            {
+            if( $DEBUG ) {
+                $return .= 'tableau_jour_feries = ' . var_export($tableau_jour_feries, true) . '<br>';
+            }
+            foreach ($tableau_jour_feries as $i => $value) {
                 if(!in_array ("$value", $tab_year))
-                    $tab_year[]=$value;
+                    $tab_year[] = $value;
             }
         }
-        if( $DEBUG ) { echo "tab_year = "; print_r($tab_year); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_year = ' . var_export($tab_year, true) . '<br>';
+        }
 
-        echo "<form action=\"$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=$year_calendrier_saisie\" method=\"POST\">\n" ;
-        echo "<div class=\"calendar\">\n";
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=jours_chomes&year_calendrier_saisie=' . $year_calendrier_saisie . '" method="POST">';
+        $return .= '<div class="calendar">';
         $months = array('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12');
 
         foreach ($months as $month) {
-            echo "<div class=\"month\">\n";
-            echo "<div class=\"wrapper\">\n";
-            echo \hr\Fonctions::affiche_calendrier_saisie_jours_chomes($year_calendrier_saisie, $month, $tab_year);
-            echo "</div>\n";
-            echo "</div>";
+            $return .= '<div class="month">';
+            $return .= '<div class="wrapper">';
+            $return .= \hr\Fonctions::affiche_calendrier_saisie_jours_chomes($year_calendrier_saisie, $month, $tab_year);
+            $return .= '</div>';
+            $return .= '</div>';
         }
-        echo "</div>";
-        echo "<div class=\"actions\">";
-        echo "<input type=\"hidden\" name=\"choix_action\" value=\"commit\">\n";
-        echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_submit') ."\">  \n";
-        echo "</div>";
-        echo "</form>\n" ;
+        $return .= '</div>';
+        $return .= '<div class="actions">';
+        $return .= '<input type="hidden" name="choix_action" value="commit">';
+        $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
+        $return .= '</div>';
+        $return .= '</form>';
+
+        return $return;
     }
 
     /**
@@ -1897,6 +1913,7 @@ class Fonctions
     {
         // verif des droits du user à afficher la page
         verif_droits_user($session, "is_hr", $DEBUG);
+        $return = '';
         /*** initialisation des variables ***/
         /*************************************/
         // recup des parametres reçus :
@@ -1908,33 +1925,38 @@ class Fonctions
         $tab_checkbox_j_chome        = getpost_variable('tab_checkbox_j_chome');
         /*************************************/
 
-        if( $DEBUG ) { echo "choix_action = $choix_action # year_calendrier_saisie = $year_calendrier_saisie<br>\n"; print_r($year_calendrier_saisie) ; echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'choix_action = ' . $choix_action . ' # year_calendrier_saisie = ' . $year_calendrier_saisie . '<br>' . var_export($year_calendrier_saisie, true) . '<br>';
+        }
 
         // si l'année n'est pas renseignée, on prend celle du jour
-        if($year_calendrier_saisie==0)
+        if($year_calendrier_saisie==0) {
             $year_calendrier_saisie = date("Y");
+        }
 
         $add_css = '<style>#onglet_menu .onglet{ width: 50% ;}</style>';
 
         //    header_menu('hr', NULL, $add_css);
 
-        echo "<div class=\"pager\">\n";
-        echo "<div class=\"onglet calendar-nav\">\n";
+        $return .= '<div class="pager">';
+        $return .= '<div class="onglet calendar-nav">';
         // navigation
         $prev_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie - 1);
         $next_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie + 1);
-        echo "<ul>\n";
-        echo "<li><a href=\"$prev_link\" class=\"calendar-prev\"><i class=\"fa fa-chevron-left\"></i><span>année précédente</span></a></li>\n";
-        echo "<li class=\"current-year\">$year_calendrier_saisie</li>\n";
-        echo "<li><a href=\"$next_link\" class=\"calendar-next\"><i class=\"fa fa-chevron-right\"></i><span>année suivante</span></a></li>\n";
-        echo "</ul>\n";
-        echo "</div>\n";
-        echo "</div>\n";
-        if($choix_action=="commit")
-            \hr\Fonctions::commit_saisie($tab_checkbox_j_chome, $DEBUG);
-        echo "<div class=\"wrapper\">\n";
-        \hr\Fonctions::saisie($year_calendrier_saisie, $DEBUG);
-        echo "</div>\n";
+        $return .= '<ul>';
+        $return .= '<li><a href="' . $prev_link . '" class="calendar-prev"><i class="fa fa-chevron-left"></i><span>année précédente</span></a></li>';
+        $return .= '&nbsp;<li class="current-year">' . $year_calendrier_saisie . '</li>';
+        $return .= '&nbsp;<li><a href="' . $next_link . '" class="calendar-next"><i class="fa fa-chevron-right"></i><span>année suivante</span></a></li>';
+        $return .= '</ul>';
+        $return .= '</div>';
+        $return .= '</div>';
+        if($choix_action=="commit") {
+            $return .= \hr\Fonctions::commit_saisie($tab_checkbox_j_chome, $DEBUG);
+        }
+        $return .= '<div class="wrapper">';
+        $return .= \hr\Fonctions::saisie($year_calendrier_saisie, $DEBUG);
+        $return .= '</div>';
+        return $return;
     }
 
     // calcule de la date limite d'utilisation des reliquats (si on utilise une date limite et qu'elle n'est pas encore calculée) et stockage dans la table

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -47,36 +47,37 @@ class Fonctions
         // AFFICHAGE ETAT CONGES TOUS USERS
         /***********************************/
         // AFFICHAGE TABLEAU (premiere ligne)
-        echo '<h2>'. _('hr_traite_user_etat_conges') ."</H2>\n\n";
-        echo "<table cellpadding=\"2\" class=\"tablo\" width=\"80%\">\n";
-        echo '<thead>';
-        echo '<tr>';
-        echo '<th>'. _('divers_nom_maj') .'</th>';
-        echo '<th>'. _('divers_prenom_maj') .'</th>';
-        echo '<th>'. _('divers_quotite_maj_1') .'</th>' ;
+        $return = '';
+        $return .= '<h2>'. _('hr_traite_user_etat_conges') . '</H2>';
+        $return .= '<table cellpadding="2" class="tablo" width="80%">';
+        $return .= '<thead>';
+        $return .= '<tr>';
+        $return .= '<th>' . _('divers_nom_maj') . '</th>';
+        $return .= '<th>' . _('divers_prenom_maj') . '</th>';
+        $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
         $nb_colonnes = 3;
         foreach($tab_type_cong as $id_conges => $libelle) {
             // cas d'une absence ou d'un congé
-            echo "<th> $libelle"." / ". _('divers_an_maj') .'</th>';
-            echo '<th>'. _('divers_solde_maj') ." ".$libelle .'</th>';
+            $return .= '<th>' . $libelle . ' / ' . _('divers_an_maj') . '</th>';
+            $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
             $nb_colonnes += 2;
         }
         // conges exceptionnels
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
             foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
-                echo '<th>'. _('divers_solde_maj') ." $libelle</th>\n";
+                $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
                 $nb_colonnes += 1;
             }
         }
-        echo '<th></th>';
+        $return .= '<th></th>';
         $nb_colonnes += 1;
         if($_SESSION['config']['editions_papier']) {
-            echo '<th></th>';
+            $return .= '<th></th>';
             $nb_colonnes += 1;
         }
-        echo '</tr>';
-        echo '</thead>';
-        echo '<tbody>';
+        $return .= '</tr>';
+        $return .= '</thead>';
+        $return .= '<tbody>';
 
         /***********************************/
         // AFFICHAGE USERS
@@ -85,22 +86,26 @@ class Fonctions
 
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est responsable
         $tab_all_users=recup_infos_all_users_du_hr($_SESSION['userlogin'], $DEBUG);
-        if( $DEBUG ) {echo "tab_all_users :<br>\n";  print_r($tab_all_users); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users :<br>' . var_export($tab_all_users, true) . '<br>';
+        }
 
-        if(count($tab_all_users)==0) // si le tableau est vide (resp sans user !!) on affiche une alerte !
-            echo "<tr><td class=\"histo\" colspan=\"".$nb_colonnes."\">". _('resp_etat_aucun_user') ."</td></tr>\n" ;
-        else {
+        if(count($tab_all_users)==0) {
+            // si le tableau est vide (resp sans user !!) on affiche une alerte !
+            $return .= '<tr><td class="histo" colspan="' . $nb_colonnes . '">' .  _('resp_etat_aucun_user') . '</td></tr>';
+        } else {
             //$i = true;
             foreach($tab_all_users as $current_login => $tab_current_user) {
                 //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
                 $tab_conges=$tab_current_user['conges'];
                 $text_affich_user="<a href=\"hr_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\""._('resp_etat_users_afficher')."\"><i class=\"fa fa-eye\"></i></a>" ;
                 $text_edit_papier="<a href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
-                if($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE')
-                    { echo '<tr>'; }
-                else
-                    { echo '<tr class="hidden">'; }
-                echo '<td>'.$tab_current_user['nom']."</td><td>".$tab_current_user['prenom']."</td><td>".$tab_current_user['quotite']."%</td>";
+                if($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE') {
+                    $return .= '<tr>';
+                } else {
+                    $return .= '<tr class="hidden">';
+                }
+                $return .= '<td>' . $tab_current_user['nom'] . '</td><td>' . $tab_current_user['prenom'] . '</td><td>' . $tab_current_user['quotite'] . '%</td>';
                 foreach($tab_type_cong as $id_conges => $libelle) {
                     $nbAn = isset($tab_conges[$libelle]['nb_an'])
                         ? $tab_conges[$libelle]['nb_an']
@@ -108,8 +113,8 @@ class Fonctions
                     $solde = isset($tab_conges[$libelle]['solde'])
                         ? $tab_conges[$libelle]['solde']
                         : 0;
-                    echo '<td>'.$nbAn.'</td>';
-                    echo '<td>'. $solde .'</td>';
+                    $return .= '<td>'.$nbAn.'</td>';
+                    $return .= '<td>'. $solde .'</td>';
                 }
                 if ($_SESSION['config']['gestion_conges_exceptionnels']) {
                     foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle)
@@ -117,20 +122,22 @@ class Fonctions
                         $solde = isset($tab_conges[$libelle]['solde'])
                             ? $tab_conges[$libelle]['solde']
                             : 0;
-                        echo '<td>' . $solde .'</td>';
+                        $return .= '<td>' . $solde .'</td>';
                     }
                 }
-                echo "<td>$text_affich_user</td>\n";
-                if($_SESSION['config']['editions_papier'])
-                echo "<td>$text_edit_papier</td>";
-                echo '</tr>';
+                $return .= '<td>' . $text_affich_user . '</td>';
+                if($_SESSION['config']['editions_papier']) {
+                    $return .= '<td>' . $text_edit_papier . '</td>';
+                }
+
+                $return .= '</tr>';
                 //$i = !$i;
             }
         }
 
-        echo '</tbody>';
-        echo '</table>';
-        echo '<script>
+        $return .= '</tbody>';
+        $return .= '</table>';
+        $return .= '<script>
         $(document).ready(function()
             {
             $("tr:not(.hidden):odd").css("background-color", "#F4F4F4");
@@ -139,6 +146,7 @@ class Fonctions
                 });
             });
         </script>';
+        return $return;
     }
 
     public static function traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus, $DEBUG=FALSE)

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -153,6 +153,7 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         while($elem_tableau = each($tab_bt_radio)) {
             $champs             = explode("--", $elem_tableau['value']);
@@ -167,7 +168,7 @@ class Fonctions
 
             $numero             = $elem_tableau['key'];
             $numero_int         = (int) $numero;
-            echo "$numero---$user_login---$user_nb_jours_pris---$reponse<br>\n";
+            $return .= $numero . '---' . $user_login . '---' . $user_nb_jours_pris . '---' . $reponse . '<br>';
 
             /* Modification de la table conges_periode */
             if(strcmp($reponse, "OK")==0) {
@@ -206,24 +207,25 @@ class Fonctions
         }
 
         if( $DEBUG ) {
-            echo "<form action=\"$PHP_SELF?sesssion=$session&onglet=traitement_demande\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
+            $return .= '<form action="' . $PHP_SELF  . '?sesssion=' . $session . '&onglet=traitement_demande" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
         } else {
-            echo  _('form_modif_ok') ."<br><br> \n";
+            $return .= _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session&onglet=traitement_demandes\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '&onglet=traitement_demandes">';
         }
-                //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_refus_conges_alerte_user'])
-                    alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges", $DEBUG);
-
+        //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
+        if($_SESSION['config']['mail_refus_conges_alerte_user']) {
+            alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges", $DEBUG);
+        }
+        return $return;
     }
 
     public static function affiche_all_demandes_en_cours($tab_type_conges, $DEBUG=FALSE)
     {
-
+        $return = '';
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
         $count1=0;
@@ -233,8 +235,9 @@ class Fonctions
 
         // recup du tableau des types de conges (seulement les conges exceptionnels)
         $tab_type_conges_exceptionnels=array();
-        if ($_SESSION['config']['gestion_conges_exceptionnels'])
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
             $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels($DEBUG);
+        }
 
         /*********************************/
         // Récupération des informations
@@ -242,26 +245,26 @@ class Fonctions
 
         // Récup dans un tableau de tableau des informations de tous les users
         $tab_all_users=recup_infos_all_users($DEBUG);
-        if( $DEBUG ) { echo "tab_all_users :<br>\n"; print_r($tab_all_users); echo "<br><br>\n";}
+        if( $DEBUG ) {
+            $return .= 'tab_all_users :<br>' . var_export($tab_all_users, true) . '<br><br>';
+        }
 
         // si tableau des users du resp n'est pas vide
         if( count($tab_all_users)!=0 ) {
             // constitution de la liste (séparé par des virgules) des logins ...
             $list_users="";
             foreach($tab_all_users as $current_login => $tab_current_user) {
-                if($list_users=="")
+                if($list_users=="") {
                     $list_users= "'$current_login'" ;
-                else
+                } else {
                     $list_users=$list_users.", '$current_login'" ;
+                }
             }
         }
 
         /*********************************/
 
-
-
-
-        echo " <form action=\"$PHP_SELF?session=$session&onglet=traitement_demandes\" method=\"POST\"> \n" ;
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traitement_demandes" method="POST">';
 
         /*********************************/
         /* TABLEAU DES DEMANDES DES USERS*/
@@ -281,28 +284,28 @@ class Fonctions
             $count1 = $ReqLog1->num_rows;
             if($count1!=0) {
                 // AFFICHAGE TABLEAU DES DEMANDES EN COURS
-
-                echo "<h3>". _('resp_traite_demandes_titre_tableau_1') ."</h3>\n" ;
-                echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\">\n" ;
-                echo '<thead>' ;
-                echo '<tr>' ;
-                echo '<th>'. _('divers_nom_maj_1') ."<br>". _('divers_prenom_maj_1') .'</th>' ;
-                echo '<th>'. _('divers_quotite_maj_1') .'</th>' ;
-                echo "<th>". _('divers_type_maj_1') ."</th>\n" ;
-                echo '<th>'. _('divers_debut_maj_1') .'</th>' ;
-                echo '<th>'. _('divers_fin_maj_1') .'</th>' ;
-                echo '<th>'. _('divers_comment_maj_1') .'</th>' ;
-                echo '<th>'. _('resp_traite_demandes_nb_jours') .'</th>';
-                echo "<th>". _('divers_solde') ."</th>\n" ;
-                echo '<th>'. _('divers_accepter_maj_1') .'</th>' ;
-                echo '<th>'. _('divers_refuser_maj_1') .'</th>' ;
-                echo '<th>'. _('resp_traite_demandes_attente') .'</th>' ;
-                echo '<th>'. _('resp_traite_demandes_motif_refus') .'</th>' ;
-                if( $_SESSION['config']['affiche_date_traitement'] )
-                echo '<th>'. _('divers_date_traitement') .'</th>' ;
-                echo '</tr>';
-                echo '</thead>' ;
-                echo '<tbody>' ;
+                $return .= '<h3>' . _('resp_traite_demandes_titre_tableau_1') . '</h3>';
+                $return .= '<table cellpadding="2" class="table table-hover table-responsive table-condensed table-striped">';
+                $return .= '<thead>';
+                $return .= '<tr>';
+                $return .= '<th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_debut_maj_1') .'</th>';
+                $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+                $return .= '<th>' . _('resp_traite_demandes_nb_jours') . '</th>';
+                $return .= '<th>' . _('divers_solde') . '</th>';
+                $return .= '<th>'. _('divers_accepter_maj_1') .'</th>' ;
+                $return .= '<th>'. _('divers_refuser_maj_1') .'</th>' ;
+                $return .= '<th>' . _('resp_traite_demandes_attente') . '</th>';
+                $return .= '<th>'. _('resp_traite_demandes_motif_refus') . '</th>';
+                if( $_SESSION['config']['affiche_date_traitement'] ) {
+                    $return .= '<th>' . _('divers_date_traitement') . '</th>';
+                }
+                $return .= '</tr>';
+                $return .= '</thead>' ;
+                $return .= '<tbody>' ;
                 $i = true;
                 $tab_bt_radio=array();
                 while ($resultat1 = $ReqLog1->fetch_array()) {
@@ -325,15 +328,17 @@ class Fonctions
                     $sql_p_date_demande     = $resultat1["p_date_demande"];
                     $sql_p_date_traitement  = $resultat1["p_date_traitement"];
 
-                    if($sql_p_demi_jour_deb=="am")
+                    if($sql_p_demi_jour_deb=="am") {
                         $demi_j_deb="mat";
-                    else
+                    } else {
                         $demi_j_deb="aprm";
+                    }
 
-                    if($sql_p_demi_jour_fin=="am")
+                    if($sql_p_demi_jour_fin=="am") {
                         $demi_j_fin="mat";
-                    else
+                    } else {
                         $demi_j_fin="aprm";
+                    }
 
                     // on construit la chaine qui servira de valeur à passer dans les boutons-radio
                     $chaine_bouton_radio = "$sql_p_login--$sql_p_nb_jours--$sql_p_type--$sql_p_date_deb--$sql_p_demi_jour_deb--$sql_p_date_fin--$sql_p_demi_jour_fin";
@@ -342,12 +347,12 @@ class Fonctions
                     $boutonradio3="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--RIEN\" checked>";
                     $text_refus="<input class=\"form-control\" type=\"text\" name=\"tab_text_refus[$sql_p_num]\" size=\"20\" max=\"100\">";
 
-                    echo '<tr class="'.($i?'i':'p').'">';
-                    echo "<td><b>".$tab_all_users[$sql_p_login]['nom']."</b><br>".$tab_all_users[$sql_p_login]['prenom']."</td><td>".$tab_all_users[$sql_p_login]['quotite']."%</td>";
-                    echo "<td>".$tab_type_all_abs[$sql_p_type]['libelle']."</td>\n";
-                    echo "<td>$sql_p_date_deb_fr <span class=\"demi\">$demi_j_deb</span></td><td>$sql_p_date_fin_fr <span class=\"demi\">$demi_j_fin</span></td><td>$sql_p_commentaire</td><td><b>$sql_p_nb_jours</b></td>";
+                    $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+                    $return .= '<td><b>' . $tab_all_users[$sql_p_login]['nom'] . '</b><br>' . $tab_all_users[$sql_p_login]['prenom'] . '</td><td>' . $tab_all_users[$sql_p_login]['quotite'] . '%</td>';
+                    $return .= '<td>' . $tab_type_all_abs[$sql_p_type]['libelle'] . '</td>';
+                    $return .= '<td>' . $sql_p_date_deb_fr . '<span class="demi">' . $demi_j_deb . '</span></td><td>' . $sql_p_date_fin_fr . '<span class="demi">' . $demi_j_fin . '</span></td><td>' . $sql_p_commentaire . '</td><td><b>' . $sql_p_nb_jours . '</b></td>';
                     $tab_conges=$tab_all_users[$sql_p_login]['conges'];
-                    echo "<td>".$tab_conges[$tab_type_all_abs[$sql_p_type]['libelle']]['solde']."</td>";
+                    $return .= '<td>' . $tab_conges[$tab_type_all_abs[$sql_p_type]['libelle']]['solde'] . '</td>';
                     // foreach($tab_type_conges as $id_conges => $libelle)
                     // {
                     //     echo '<td>'.$tab_conges[$libelle]['solde'].'</td>';
@@ -359,30 +364,32 @@ class Fonctions
                     //         echo '<td>'.$tab_conges[$libelle]['solde'].'</td>';
                     //     }
                     // echo '<td>'.$tab_type_all_abs[$sql_p_type]['libelle'].'</td>';
-                    echo "<td>$boutonradio1</td><td>$boutonradio2</td><td>$boutonradio3</td><td>$text_refus</td>\n";
+                    $return .= '<td>' . $boutonradio1 . '</td><td>' . $boutonradio2 . '</td><td>' . $boutonradio3 . '</td><td>' . $text_refus . '</td>';
                     if($_SESSION['config']['affiche_date_traitement']) {
-                        if($sql_p_date_demande == NULL)
-                            echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : $sql_p_date_traitement</td>\n" ;
-                        else
-                            echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : pas traité</td>\n" ;
+                        if($sql_p_date_demande == NULL) {
+                            $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
+                        } else {
+                            $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
+                        }
                     }
-                    echo '</tr>' ;
+                    $return .= '</tr>' ;
                     $i = !$i;
                 } // while
-                echo '</tbody>' ;
-                echo '</table>' ;
+                $return .= '</tbody>' ;
+                $return .= '</table>' ;
             } //if($count1!=0)
         } //if( count($tab_all_users)!=0 )
 
-        echo "<br>\n";
+        $return .= '<br>';
 
-        if(($count1==0) && ($count2==0))
-            echo "<strong>". _('resp_traite_demandes_aucune_demande') ."</strong>\n";
-        else {
-            echo "<hr/>\n";
-            echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_submit') ."\">\n" ;
+        if(($count1==0) && ($count2==0)) {
+            $return .= '<strong>' . _('resp_traite_demandes_aucune_demande') . '</strong>';
+        } else {
+            $return .= '<hr/>';
+            $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
         }
-        echo " </form> \n" ;
+        $return .= '</form>';
+        return $return;
     }
 
     /**
@@ -399,23 +406,25 @@ class Fonctions
      */
     public static function pageTraitementDemandeModule(array $tab_type_cong, $onglet, $session, $DEBUG = false)
     {
-
+        $return = '';
 
         //var pour resp_traite_demande_all.php
         $tab_bt_radio   = getpost_variable('tab_bt_radio');
         $tab_text_refus = getpost_variable('tab_text_refus');
 
         // titre
-        echo '<h2>'. _('resp_traite_demandes_titre') .'</h2>';
+        $return .= '<h2>'. _('resp_traite_demandes_titre') .'</h2>';
 
         // si le tableau des bouton radio des demandes est vide , on affiche les demandes en cours
         if( $tab_bt_radio == '' ) {
-            \hr\Fonctions::affiche_all_demandes_en_cours($tab_type_cong, $DEBUG);
+            $return .= \hr\Fonctions::affiche_all_demandes_en_cours($tab_type_cong, $DEBUG);
         } else {
-            \hr\Fonctions::traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus, $DEBUG);
+            $return .= \hr\Fonctions::traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus, $DEBUG);
+            echo $return;
             redirect( ROOT_PATH .'hr/hr_index.php?session='.$session.'&onglet='.$onglet, false);
             exit;
         }
+        return $return;
     }
 
     public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id, $DEBUG=FALSE)

--- a/hr/hr_ajout_conges.php
+++ b/hr/hr_ajout_conges.php
@@ -25,4 +25,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 $DEBUG = false;
-\hr\Fonctions::pageAjoutCongesModule($tab_type_cong, $session, $DEBUG);
+echo \hr\Fonctions::pageAjoutCongesModule($tab_type_cong, $session, $DEBUG);

--- a/hr/hr_cloture_year.php
+++ b/hr/hr_cloture_year.php
@@ -24,4 +24,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-\hr\Fonctions::pageClotureYearModule($session, $DEBUG);
+echo \hr\Fonctions::pageClotureYearModule($session, $DEBUG);

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -3,20 +3,20 @@
 Libertempo : Gestion Interactive des Congés
 Copyright (C) 2015 (Wouldsmina)Copyright (C) 2015 (Prytoegrian)Copyright (C) 2005 (cedric chauvineau)
 
-Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les 
+Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
 termes de la Licence Publique Générale GNU publiée par la Free Software Foundation.
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE, 
-ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation 
+Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE,
+ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation
 dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pour plus de détails.
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps 
-que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation, 
+Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
+que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
 *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU General Public License as published by the Free Software Foundation; either 
+of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
@@ -42,75 +42,75 @@ $DEBUG = FALSE ;
 verif_droits_user($session, "is_hr", $DEBUG);
 
 
-	/*************************************/
-	// recup des parametres reçus :
-	// SERVER
-	$PHP_SELF=$_SERVER['PHP_SELF'];
-	// GET / POST
-	$onglet = getpost_variable('onglet', "page_principale");
-	
-	
-	/*********************************/
-	/*   COMPOSITION DES ONGLETS...  */
-	/*********************************/
+/*************************************/
+// recup des parametres reçus :
+// SERVER
+$PHP_SELF=$_SERVER['PHP_SELF'];
+// GET / POST
+$onglet = getpost_variable('onglet', "page_principale");
 
-	$onglets = array();
-	
-	
-	$onglets['page_principale'] = _('resp_menu_button_retour_main');
 
-	if( $_SESSION['config']['user_saisie_demande'] ) 
-		$onglets['traitement_demandes'] = _('resp_menu_button_traite_demande');
-		
-	// if( $_SESSION['config']['resp_ajoute_conges'] )
-		$onglets['ajout_conges'] = _('resp_ajout_conges_titre');
-		$onglets['jours_chomes'] = _('admin_button_jours_chomes_1');
-		
-	$onglets['cloture_year'] = _('resp_cloture_exercice_titre');
-	
-	if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('traite_user')))
-		$onglet = 'page_principale';
-	
-	/*********************************/
-	/*   COMPOSITION DU HEADER...    */
-	/*********************************/
-	
-	$add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
-   	header_menu('', 'Libertempo : '._('resp_menu_button_mode_hr'),$add_css);
-		
-	/*********************************/
-	/*   AFFICHAGE DES ONGLETS...  */
-	/*********************************/
-	
-	echo '<div id="onglet_menu">';
-	foreach($onglets as $key => $title) {
-		echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-			<a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
-		</div>';
-	}
-	echo '</div>';
-	
-	
-	/*********************************/
-	/*   AFFICHAGE DE L'ONGLET ...    */
-	/*********************************/
-	
-	
-	/** initialisation des tableaux des types de conges/absences  **/
-	// recup du tableau des types de conges (seulement les conges)
-	$tab_type_cong=recup_tableau_types_conges( $DEBUG);
+/*********************************/
+/*   COMPOSITION DES ONGLETS...  */
+/*********************************/
 
-	// recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-//	if ($_SESSION['config']['gestion_conges_exceptionnels']) 
-		$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
-	
-	echo '<div class="'.$onglet.' main-content">';
-		include_once ROOT_PATH . 'hr/hr_'.$onglet.'.php';
-	echo '</div>';
-	
-	/*********************************/
-	/*   AFFICHAGE DU BOTTOM ...   */
-	/*********************************/
-	
-	bottom();
-	exit;
+$onglets = array();
+
+
+$onglets['page_principale'] = _('resp_menu_button_retour_main');
+
+if( $_SESSION['config']['user_saisie_demande'] )
+    $onglets['traitement_demandes'] = _('resp_menu_button_traite_demande');
+
+// if( $_SESSION['config']['resp_ajoute_conges'] )
+    $onglets['ajout_conges'] = _('resp_ajout_conges_titre');
+    $onglets['jours_chomes'] = _('admin_button_jours_chomes_1');
+
+$onglets['cloture_year'] = _('resp_cloture_exercice_titre');
+
+if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('traite_user')))
+    $onglet = 'page_principale';
+
+/*********************************/
+/*   COMPOSITION DU HEADER...    */
+/*********************************/
+
+$add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
+header_menu('', 'Libertempo : '._('resp_menu_button_mode_hr'),$add_css);
+
+/*********************************/
+/*   AFFICHAGE DES ONGLETS...  */
+/*********************************/
+
+echo '<div id="onglet_menu">';
+foreach($onglets as $key => $title) {
+    echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
+        <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+    </div>';
+}
+echo '</div>';
+
+
+/*********************************/
+/*   AFFICHAGE DE L'ONGLET ...    */
+/*********************************/
+
+
+/** initialisation des tableaux des types de conges/absences  **/
+// recup du tableau des types de conges (seulement les conges)
+$tab_type_cong=recup_tableau_types_conges( $DEBUG);
+
+// recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
+//    if ($_SESSION['config']['gestion_conges_exceptionnels'])
+$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
+
+echo '<div class="'.$onglet.' main-content">';
+    include_once ROOT_PATH . 'hr/hr_'.$onglet.'.php';
+echo '</div>';
+
+/*********************************/
+/*   AFFICHAGE DU BOTTOM ...   */
+/*********************************/
+
+bottom();
+exit;

--- a/hr/hr_jours_chomes.php
+++ b/hr/hr_jours_chomes.php
@@ -28,7 +28,7 @@ defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 
 if (file_exists(CONFIG_PATH .'config_ldap.php'))
-	include CONFIG_PATH .'config_ldap.php';
+    include CONFIG_PATH .'config_ldap.php';
 
 $DEBUG=FALSE;
-\hr\Fonctions::pageJoursChomesModule($session, $DEBUG);
+echo \hr\Fonctions::pageJoursChomesModule($session, $DEBUG);

--- a/hr/hr_jours_fermeture.php
+++ b/hr/hr_jours_fermeture.php
@@ -29,8 +29,9 @@ require_once ROOT_PATH . 'define.php';
 
 $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
 
-if (file_exists(CONFIG_PATH .'config_ldap.php'))
-	include_once CONFIG_PATH .'config_ldap.php';
+if (file_exists(CONFIG_PATH .'config_ldap.php')) {
+    include_once CONFIG_PATH .'config_ldap.php';
+}
 
 
 include_once ROOT_PATH .'fonctions_conges.php' ;
@@ -40,4 +41,5 @@ include_once ROOT_PATH .'fonctions_calcul.php';
 
 
 $DEBUG=FALSE;
-\hr\Fonctions::pageJoursFermetureModule($session, $DEBUG);
+echo \hr\Fonctions::pageJoursFermetureModule($session, $DEBUG);
+bottom();

--- a/hr/hr_page_principale.php
+++ b/hr/hr_page_principale.php
@@ -25,4 +25,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 $DEBUG = false;
-\hr\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session, $DEBUG);
+echo \hr\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session, $DEBUG);

--- a/hr/hr_traite_user.php
+++ b/hr/hr_traite_user.php
@@ -25,4 +25,5 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 $DEBUG = false;
-\hr\Fonctions::pageTraiteUserModule($onglet, $DEBUG);
+include_once ROOT_PATH .'fonctions_javascript.php' ;
+echo \hr\Fonctions::pageTraiteUserModule($onglet, $DEBUG);

--- a/hr/hr_traitement_demandes.php
+++ b/hr/hr_traitement_demandes.php
@@ -25,4 +25,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 $DEBUG = false;
-\hr\Fonctions::pageTraitementDemandeModule($tab_type_cong, $onglet, $session, $DEBUG);
+echo \hr\Fonctions::pageTraitementDemandeModule($tab_type_cong, $onglet, $session, $DEBUG);

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -1944,7 +1944,7 @@ class Fonctions
         /********************/
         // AFFICHAGE TABLEAU
         // affichage du tableau récapitulatif des solde de congés d'un user
-        affiche_tableau_bilan_conges_user($user_login);
+        echo affiche_tableau_bilan_conges_user($user_login);
         echo "<hr/>\n";
 
         /*************************/
@@ -1969,7 +1969,7 @@ class Fonctions
 
             //affiche le formulaire de saisie d'une nouvelle demande de conges ou d'un  nouveau conges
             $onglet = "traite_user";
-            saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet);
+            echo saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet);
 
             echo "<hr/>\n";
         }

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -5,20 +5,20 @@ Copyright (C) 2015 (Wouldsmina)
 Copyright (C) 2015 (Prytoegrian)
 Copyright (C) 2005 (cedric chauvineau)
 
-Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les 
+Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
 termes de la Licence Publique Générale GNU publiée par la Free Software Foundation.
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE, 
-ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation 
+Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE,
+ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation
 dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pour plus de détails.
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps 
-que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation, 
+Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
+que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
 *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU General Public License as published by the Free Software Foundation; either 
+of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
@@ -78,7 +78,7 @@ class Fonctions
     {
         //conversion des dates
         $new_debut = convert_date($new_debut);
-        $new_fin = convert_date($new_fin);   
+        $new_fin = convert_date($new_fin);
 
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
@@ -149,7 +149,7 @@ class Fonctions
 
         $new_demande_conges = getpost_variable('new_demande_conges', 0);
 
-        if( $new_demande_conges == 1 && $_SESSION['config']['user_saisie_demande'] ) 
+        if( $new_demande_conges == 1 && $_SESSION['config']['user_saisie_demande'] )
         {
             $new_debut	    = getpost_variable('new_debut');
             $new_demi_jour_deb  = getpost_variable('new_demi_jour_deb');
@@ -160,7 +160,7 @@ class Fonctions
 
             $user_login	    = $_SESSION['userlogin'];
 
-            if( $_SESSION['config']['disable_saise_champ_nb_jours_pris'] ) 
+            if( $_SESSION['config']['disable_saise_champ_nb_jours_pris'] )
                 $new_nb_jours = compter($user_login, '', $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $new_comment,  $DEBUG);
             else
                 $new_nb_jours = getpost_variable('new_nb_jours') ;
@@ -184,7 +184,7 @@ class Fonctions
             // saisie_nouveau_conges($_SESSION['userlogin'], $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet, $DEBUG);
 
             //affiche le formulaire de saisie d'une nouvelle demande de conges
-            saisie_nouveau_conges2($_SESSION['userlogin'], $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet, $DEBUG);
+            echo saisie_nouveau_conges2($_SESSION['userlogin'], $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet, $DEBUG);
         }
     }
 
@@ -352,7 +352,7 @@ class Fonctions
 
         //conversion des dates
         $new_debut = convert_date($new_debut);
-        $new_fin = convert_date($new_fin); 
+        $new_fin = convert_date($new_fin);
 
         if ($_SESSION['config']['disable_saise_champ_nb_jours_pris'])
             $new_nb_jours = compter($user_login, $p_num_to_update, $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $new_comment,  $DEBUG);
@@ -548,7 +548,7 @@ class Fonctions
         log_action(0, '', $_SESSION['userlogin'], $comment_log,  $DEBUG);
 
     }
-    
+
     /**
      * Encapsule le comportement du module de modification de mot de passe
      *
@@ -612,7 +612,7 @@ class Fonctions
             echo '</form>';
         }
     }
-    
+
     /**
      * Encapsule le comportement du module de demande en cours
      *
@@ -682,9 +682,9 @@ class Fonctions
                 $sql_p_demi_jour_deb		= $resultat3["p_demi_jour_deb"];
                 $sql_p_demi_jour_fin		= $resultat3["p_demi_jour_fin"];
 
-                if($sql_p_demi_jour_deb=="am") 
-                    $demi_j_deb="mat";  
-                else 
+                if($sql_p_demi_jour_deb=="am")
+                    $demi_j_deb="mat";
+                else
                     $demi_j_deb="aprm";
 
                 if($sql_p_demi_jour_fin=="am")
@@ -787,7 +787,7 @@ class Fonctions
             if ($i < 0 || $i > $nb_jours_mois || $td_second_class == 'weekend') {
                 echo '<td class="'.$td_second_class.'">-</td>';
             }
-            else {	
+            else {
                 $val_matin='';
                 $val_aprem='';
                 recup_infos_artt_du_jour($user_login, $j_timestamp, $val_matin, $val_aprem,  $DEBUG);
@@ -854,7 +854,7 @@ class Fonctions
             if ($i < 0 || $i > $nb_jours_mois || $td_second_class == 'weekend') {
                 echo '<td class="'.$td_second_class.'">-</td>';
             }
-            else {	
+            else {
                 $val_matin='';
                 $val_aprem='';
                 recup_infos_artt_du_jour($user_login, $j_timestamp, $val_matin, $val_aprem,  $DEBUG);
@@ -1273,7 +1273,7 @@ class Fonctions
 
         echo '</form>' ;
     }
-    
+
     /**
      * Encapsule le comportement du module d'échange d'absence
      *

--- a/utilisateur/user_index.php
+++ b/utilisateur/user_index.php
@@ -44,44 +44,44 @@ if($_SESSION['config']['where_to_find_user_email']=="ldap"){ include CONFIG_PATH
 	$PHP_SELF=$_SERVER['PHP_SELF'];
 	// GET / POST
 	$onglet = getpost_variable('onglet');
-	
-	
+
+
 	/*********************************/
 	/*   COMPOSITION DES ONGLETS...  */
 	/*********************************/
 
 	$onglets = array();
-	
+
 	if( $_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission'] )
 		$onglets['nouvelle_absence'] = _('divers_nouvelle_absence');
 
 	if( $_SESSION['config']['user_echange_rtt'] )
 		$onglets['echange_jour_absence'] = _('user_onglet_echange_abs');
-		
+
 	if( $_SESSION['config']['user_saisie_demande'] )
 		$onglets['demandes_en_cours'] = _('user_onglet_demandes');
-	
+
 	$onglets['historique_conges'] = _('user_onglet_historique_conges');
 	$onglets['historique_autres_absences'] = _('user_onglet_historique_abs');
 
 	if( $_SESSION['config']['auth'] && $_SESSION['config']['user_ch_passwd'] )
 		$onglets['changer_mot_de_passe'] = _('user_onglet_change_passwd');
-	
+
 	if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('modif_demande','suppr_demande')))
 		$onglet = 'nouvelle_absence';
-	
+
 	/*********************************/
 	/*   COMPOSITION DU HEADER...    */
 	/*********************************/
-	
+
 	$add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
 	header_menu('','Libertempo : '._('user'),$add_css);
-	
-	
+
+
 	/*********************************/
 	/*   AFFICHAGE DES ONGLETS...  */
 	/*********************************/
-	
+
 	echo '<div id="onglet_menu">';
 	foreach($onglets as $key => $title) {
 		echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
@@ -90,27 +90,27 @@ if($_SESSION['config']['where_to_find_user_email']=="ldap"){ include CONFIG_PATH
 	}
 	echo '</div>';
 
-	
+
 	/*********************************/
 	/*   AFFICHAGE DU RECAP ...    */
 	/*********************************/
 
 	echo "<div class=\"wrapper\">\n";
 	echo '<h3>'._('tableau_recap').'</h3>';
-	affiche_tableau_bilan_conges_user( $_SESSION['userlogin'] );
+	echo affiche_tableau_bilan_conges_user( $_SESSION['userlogin'] );
 	echo "<hr/>\n";
 	echo "</div>\n";
 
 	/*********************************/
 	/*   AFFICHAGE DE L'ONGLET ...    */
 	/*********************************/
-	
+
 	echo '<div class="'.$onglet.' wrapper">';
 		include ROOT_PATH . 'utilisateur/user_'.$onglet.'.php';
 	echo '</div>';
-	
+
 	/*********************************/
 	/*   AFFICHAGE DU BOTTOM ...   */
 	/*********************************/
-	
+
 	bottom();


### PR DESCRIPTION
Suite de #76 pour #63 

Il n'y a quasiment plus d'affichage direct dans toutes les pages relatives au haut responsable. À la place, on stocke dans une variable. Ça nous permettra à terme de gérer la notion de template de vues.
Comme pour la précédente PR, github n'aime pas le diff de `hr/Fonctions.php` je ne sais pas pourquoi. Il s'agit essentiellement de remplacer les echo par du stockage, rien d'extraordinaire.