### PR TITLE
Séparation affichage / logique dans les modules responsable et calendrier

### DIFF
--- a/calendrier.php
+++ b/calendrier.php
@@ -31,4 +31,7 @@ $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session']
 include_once ROOT_PATH .'fonctions_conges.php';
 include_once INCLUDE_PATH .'fonction.php';
 $DEBUG = false;
-\calendrier\Fonctions::calendrierModule($session, $DEBUG);
+$add_css = NULL;
+header_menu('', 'Libertempo : '._('calendrier_titre'), $add_css);
+echo \calendrier\Fonctions::calendrierModule($session, $DEBUG);
+bottom();

--- a/calendrier/Fonctions.php
+++ b/calendrier/Fonctions.php
@@ -36,154 +36,137 @@ class Fonctions
     // renvoit un tableau de tableau
     public static function recup_tableau_des_users_a_afficher($select_groupe,  $DEBUG=FALSE)
     {
+        // si acces sans authentification est permis : alors droit de voir tout le monde
+        // sinon, on verifie si le user a le droite de voir tout le monde
+        if( ($_SESSION['config']['consult_calendrier_sans_auth']) && (!isset($_SESSION['userlogin'])) ) {
+            //si gestion des groupes et un groupe a ete selectionne
+            if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
+                $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                $sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
 
-    	// si acces sans authentification est permis : alors droit de voir tout le monde
-    	// sinon, on verifie si le user a le droite de voir tout le monde
-    	if( ($_SESSION['config']['consult_calendrier_sans_auth']) && (!isset($_SESSION['userlogin'])) )
-    	{
-    		//si gestion des groupes et un groupe a ete selectionne
-    		if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) )
-    		{
-    			$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    			$sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
+                //recup de la liste des users des groupes dont le user est membre
+                $list_users=get_list_users_du_groupe($select_groupe,  $DEBUG);
+                if($list_users!="")  //si la liste n'est pas vide ( serait le cas si groupe vide)
+                    $sql1 = $sql1." AND u_login IN ($list_users) ORDER BY u_nom, u_prenom ";
+            } else // affiche tous les users
+            {
+                $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                //$sql1 = $sql1." WHERE u_login!='conges' AND u_resp_login = 'conges' ORDER BY u_nom, u_prenom";
+                $sql1 = $sql1." WHERE u_login!='conges'  AND u_login!='admin' ORDER BY u_nom, u_prenom";
+            }
+        }
+        //sinon (authentification, le user est identifié)
+        else {
+            //construction de la requete sql pour recupérer les users à afficher :
 
-    			//recup de la liste des users des groupes dont le user est membre
-    			$list_users=get_list_users_du_groupe($select_groupe,  $DEBUG);
-    			if($list_users!="")  //si la liste n'est pas vide ( serait le cas si groupe vide)
-    				$sql1 = $sql1." AND u_login IN ($list_users) ORDER BY u_nom, u_prenom ";
-    		}
-    		else // affiche tous les users
-    		{
-    			$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    			//$sql1 = $sql1." WHERE u_login!='conges' AND u_resp_login = 'conges' ORDER BY u_nom, u_prenom";
-    			$sql1 = $sql1." WHERE u_login!='conges'  AND u_login!='admin' ORDER BY u_nom, u_prenom";
-    		}
-    	}
-    	//sinon (authentification, le user est identifié)
-    	else
-    	{
-    		//construction de la requete sql pour recupérer les users à afficher :
+            //si le user a le droit de voir tout le monde
+            $user_see_all_in_calendrier=get_user_see_all($_SESSION['userlogin']);
+            if($user_see_all_in_calendrier) // si le user a "u_see_all" à "Y" dans la table users : affiche tous les users
+            {
+                //si gestion des groupes et un groupe a ete selectionne
+                if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
+                    $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                    $sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
 
-    		//si le user a le droit de voir tout le monde
-    		$user_see_all_in_calendrier=get_user_see_all($_SESSION['userlogin']);
-    		if($user_see_all_in_calendrier) // si le user a "u_see_all" à "Y" dans la table users : affiche tous les users
-    		{
-    			//si gestion des groupes et un groupe a ete selectionne
-    			if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) )
-    			{
-    				$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    				$sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
+                    //recup de la liste des users des groupes dont le user est membre
+                    $list_users=get_list_users_du_groupe($select_groupe,  $DEBUG);
+                    if($list_users!="")  //si la liste n'est pas vide ( serait le cas si groupe vide)
+                    $sql1 = $sql1." AND u_login IN ($list_users) ";
 
-    				//recup de la liste des users des groupes dont le user est membre
-    				$list_users=get_list_users_du_groupe($select_groupe,  $DEBUG);
-    				if($list_users!="")  //si la liste n'est pas vide ( serait le cas si groupe vide)
-    				$sql1 = $sql1." AND u_login IN ($list_users) ";
+                    $sql1 = $sql1." ORDER BY u_nom, u_prenom";
+                } else {
+                    $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                    //$sql1 = $sql1." WHERE u_login!='conges' AND u_resp_login = 'conges' ORDER BY u_nom, u_prenom";
+                    $sql1 = $sql1." WHERE u_login!='conges'  AND u_login!='admin' ORDER BY u_nom, u_prenom";
+                }
+            }
+            // sinon (le user n'a pas le droit de voir tout le monde)
+            else {
+                //si gestion des groupes et un groupe a ete selectionne
+                if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
+                    $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                    $sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
+                    $sql1 = $sql1.' AND ( u_login = "'. \includes\SQL::quote($_SESSION['userlogin']).'" ';
 
-    				$sql1 = $sql1." ORDER BY u_nom, u_prenom";
-    			}
-    			else
-    			{
-    				$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    				//$sql1 = $sql1." WHERE u_login!='conges' AND u_resp_login = 'conges' ORDER BY u_nom, u_prenom";
-    				$sql1 = $sql1." WHERE u_login!='conges'  AND u_login!='admin' ORDER BY u_nom, u_prenom";
-    			}
-    		}
-    		// sinon (le user n'a pas le droit de voir tout le monde)
-    		else
-    		{
-    			//si gestion des groupes et un groupe a ete selectionne
-    			if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) )
-    			{
-    				$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    				$sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
-    				$sql1 = $sql1.' AND ( u_login = "'. \includes\SQL::quote($_SESSION['userlogin']).'" ';
+                    //recup de la liste des users des groupes dont le user est membre
+                    $list_users=get_list_users_du_groupe($select_groupe,  $DEBUG);
+                    if($list_users!="")  //si la liste n'est pas vide ( serait le cas si groupe vide)
+                        $sql1 = $sql1." OR u_login IN ($list_users) ";
+                        $sql1 = $sql1." ) ";
 
-    				//recup de la liste des users des groupes dont le user est membre
-    				$list_users=get_list_users_du_groupe($select_groupe,  $DEBUG);
-    				if($list_users!="")  //si la liste n'est pas vide ( serait le cas si groupe vide)
-    					$sql1 = $sql1." OR u_login IN ($list_users) ";
-    					$sql1 = $sql1." ) ";
+                    $sql1 = $sql1." ORDER BY u_nom, u_prenom";
+                }
+                // si user n'est pas un responsable
+                else {
+                    if( !is_resp($_SESSION['userlogin']) ) {
+                        $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                        $sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
 
-    				$sql1 = $sql1." ORDER BY u_nom, u_prenom";
-    			}
-    			// si user n'est pas un responsable
-    			else
-    			{
-    				if( !is_resp($_SESSION['userlogin']) )
-    				{
-    					$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    					$sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
+                        //si affichage par groupe : on affiche les membres des groupes du user ($_SESSION['userlogin'])
+                        if( ($_SESSION['config']['gestion_groupes']) && ($_SESSION['config']['affiche_groupe_in_calendrier']) ) {
+                            //recup de la liste des users des groupes dont le user est membre
+                            $list_users=get_list_users_des_groupes_du_user($_SESSION['userlogin']);
+                            if($list_users!="")  //si la liste n'est pas vide ( serait le cas si n'est membre d'aucun groupe)
+                            $sql1 = $sql1." AND u_login IN ($list_users) ";
+                        }
 
-    					//si affichage par groupe : on affiche les membres des groupes du user ($_SESSION['userlogin'])
-    					if( ($_SESSION['config']['gestion_groupes']) && ($_SESSION['config']['affiche_groupe_in_calendrier']) )
-    					{
-    						//recup de la liste des users des groupes dont le user est membre
-    						$list_users=get_list_users_des_groupes_du_user($_SESSION['userlogin']);
-    						if($list_users!="")  //si la liste n'est pas vide ( serait le cas si n'est membre d'aucun groupe)
-    						$sql1 = $sql1." AND u_login IN ($list_users) ";
-    					}
+                        $sql1 = $sql1." ORDER BY u_nom, u_prenom";
+                    }
+                    // si user est un responsable
+                    else {
+                        $sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
+                        $sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
 
-    					$sql1 = $sql1." ORDER BY u_nom, u_prenom";
-    				}
-    				// si user est un responsable
-    				else
-    				{
-    					$sql1 = "SELECT DISTINCT u_login, u_nom, u_prenom, u_quotite FROM conges_users ";
-    					$sql1 = $sql1." WHERE u_login!='conges' AND u_login!='admin' ";
+                        if($_SESSION['userlogin']!="conges") {
+                            $sql1 = $sql1.' AND ( u_login = "'. \includes\SQL::quote($_SESSION['userlogin']).'" ';
 
-    					if($_SESSION['userlogin']!="conges")
-    					{
-    						$sql1 = $sql1.' AND ( u_login = "'. \includes\SQL::quote($_SESSION['userlogin']).'" ';
+                            //si affichage par groupe : on affiche les membres des groupes du user ($_SESSION['userlogin'])
+                            if( ($_SESSION['config']['gestion_groupes']) && ($_SESSION['config']['affiche_groupe_in_calendrier']) ) {
+                                //recup de la liste des users des groupes dont le user est membre
+                                $list_users=get_list_users_des_groupes_du_user($_SESSION['userlogin']);
+                                if($list_users!="")  //si la liste n'est pas vide ( serait le cas si n'est membre d'aucun groupe)
+                                    $sql1 = $sql1." OR u_login IN ($list_users) ";
 
-    						//si affichage par groupe : on affiche les membres des groupes du user ($_SESSION['userlogin'])
-    						if( ($_SESSION['config']['gestion_groupes']) && ($_SESSION['config']['affiche_groupe_in_calendrier']) )
-    						{
-    							//recup de la liste des users des groupes dont le user est membre
-    							$list_users=get_list_users_des_groupes_du_user($_SESSION['userlogin']);
-    							if($list_users!="")  //si la liste n'est pas vide ( serait le cas si n'est membre d'aucun groupe)
-    								$sql1 = $sql1." OR u_login IN ($list_users) ";
+                            }
 
-    						}
+                            //recup de la liste des users dont le user est responsable
+                            $list_users_2=get_list_all_users_du_resp($_SESSION['userlogin'],  $DEBUG);
+                            if($list_users_2!="")  //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
+                                $sql1 = $sql1." OR u_login IN ($list_users_2) ";
 
-    						//recup de la liste des users dont le user est responsable
-    						$list_users_2=get_list_all_users_du_resp($_SESSION['userlogin'],  $DEBUG);
-    						if($list_users_2!="")  //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
-    							$sql1 = $sql1." OR u_login IN ($list_users_2) ";
+                            if ($_SESSION['config']['double_validation_conges']) {
+                                $list_groupes_3 = get_list_login_du_grand_resp($_SESSION['userlogin'] );
+                                if (count($list_groupes_3) > 0) {
+                                    $list_groupes_3 = array_map("\includes\SQL::quote", $list_groupes_3);
+                                    $list_groupes_3 = '\'' . implode('\', \'', $list_groupes_3).'\'';
 
-    						if ($_SESSION['config']['double_validation_conges']) {
-    							$list_groupes_3 = get_list_login_du_grand_resp($_SESSION['userlogin'] );
-    							if (count($list_groupes_3) > 0) {
-    								$list_groupes_3 = array_map("\includes\SQL::quote", $list_groupes_3);
-    								$list_groupes_3 = '\'' . implode('\', \'', $list_groupes_3).'\'';
-
-    								$sql1 = $sql1." OR u_login IN ( $list_groupes_3 ) ";
-    							}
-    						}
+                                    $sql1 = $sql1." OR u_login IN ( $list_groupes_3 ) ";
+                                }
+                            }
 
 
-    						$sql1 = $sql1." ) ";
-    					}
+                            $sql1 = $sql1." ) ";
+                        }
 
-    					$sql1 = $sql1." ORDER BY u_nom, u_prenom";
+                        $sql1 = $sql1." ORDER BY u_nom, u_prenom";
 
-    				}
-    			}
-    		}
-    	}
+                    }
+                }
+            }
+        }
 
-    	$ReqLog = \includes\SQL::query($sql1);
-    	$tab_all_users=array();
-    	while ($resultat = $ReqLog->fetch_array())
-    	{
-    		$tab_user=array();
-    		$tab_user['nom']=$resultat["u_nom"];
-    		$tab_user['prenom']=$resultat["u_prenom"];
-    		$tab_user['quotite']=$resultat["u_quotite"];
-    		$sql_login=$resultat["u_login"];
-    		$tab_all_users[$sql_login]= $tab_user;
-    	}
+        $ReqLog = \includes\SQL::query($sql1);
+        $tab_all_users=array();
+        while ($resultat = $ReqLog->fetch_array()) {
+            $tab_user=array();
+            $tab_user['nom']=$resultat["u_nom"];
+            $tab_user['prenom']=$resultat["u_prenom"];
+            $tab_user['quotite']=$resultat["u_quotite"];
+            $sql_login=$resultat["u_login"];
+            $tab_all_users[$sql_login]= $tab_user;
+        }
 
-    	return($tab_all_users);
+        return($tab_all_users);
     }
 
     // Affichage d'un SELECT de formulaire pour choix d'un groupe
@@ -191,68 +174,71 @@ class Fonctions
     public static function affiche_select_groupe($select_groupe, $selected, $printable, $year, $mois, $first_jour,  $group_names )
     {
 
-    	$PHP_SELF=$_SERVER['PHP_SELF'];
-    	$session=session_id();
+        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $session=session_id();
+        $return = '';
 
-    	// quelle liste de groupes recuperer ?
-    	//if( ($_SESSION['config']['consult_calendrier_sans_auth']) && (!isset($_SESSION['userlogin'])) )
-    	if( is_hr($_SESSION['userlogin']) )
-    		$list_groupes=get_list_all_groupes( );
-    	elseif($_SESSION['config']['calendrier_select_all_groups'])
-    		$list_groupes=get_list_all_groupes(  );
-    	elseif(is_resp($_SESSION['userlogin'] ))
-    	{
-    		// on propose la liste des groupes dont user est resp + groupes dont user est membre
-    		$list_groupes_1=get_list_groupes_du_resp($_SESSION['userlogin'] );
-    		$list_groupes_2=get_list_groupes_du_user($_SESSION['userlogin'] );
-    		if ($list_groupes_1 == '' || $list_groupes_2 == '')
-    			$list_groupes = $list_groupes_1.$list_groupes_2 ;
-    		else
-    			$list_groupes = $list_groupes_1.",".$list_groupes_2 ;
+        // quelle liste de groupes recuperer ?
+        //if( ($_SESSION['config']['consult_calendrier_sans_auth']) && (!isset($_SESSION['userlogin'])) )
+        if( is_hr($_SESSION['userlogin']) ) {
+            $list_groupes=get_list_all_groupes( );
+        } elseif($_SESSION['config']['calendrier_select_all_groups']) {
+            $list_groupes=get_list_all_groupes(  );
+        } elseif(is_resp($_SESSION['userlogin'] )) {
+            // on propose la liste des groupes dont user est resp + groupes dont user est membre
+            $list_groupes_1=get_list_groupes_du_resp($_SESSION['userlogin'] );
+            $list_groupes_2=get_list_groupes_du_user($_SESSION['userlogin'] );
+            if ($list_groupes_1 == '' || $list_groupes_2 == '') {
+                $list_groupes = $list_groupes_1.$list_groupes_2 ;
+            } else {
+                $list_groupes = $list_groupes_1.",".$list_groupes_2 ;
+            }
+            if ($_SESSION['config']['double_validation_conges']) {
+                $list_groupes_3 = get_list_groupes_du_grand_resp($_SESSION['userlogin'] );
+                if ($list_groupes == '' || $list_groupes_3 == '') {
+                    $list_groupes = $list_groupes.$list_groupes_3 ;
+                } else {
+                    $list_groupes = $list_groupes.",".$list_groupes_3 ;
+                }
+            }
+        }
+        else {
+            $list_groupes=get_list_groupes_du_user($_SESSION['userlogin'] );
+        }
 
-    		if ($_SESSION['config']['double_validation_conges']) {
-    			$list_groupes_3 = get_list_groupes_du_grand_resp($_SESSION['userlogin'] );
-    			if ($list_groupes == '' || $list_groupes_3 == '')
-    				$list_groupes = $list_groupes.$list_groupes_3 ;
-    			else
-    				$list_groupes = $list_groupes.",".$list_groupes_3 ;
-    		}
-    	}
-    	else
-    		$list_groupes=get_list_groupes_du_user($_SESSION['userlogin'] );
+        $return .= '<form id="group-select-form" class="form-inline" action="' . $PHP_SELF . '?session=' . $session . '&printable=' . $printable . '&selected=' . $selected . '&year=' . $year . '&mois=' . $mois . '&first_jour=' . $first_jour . '" method="POST">';
+        if (trim($list_groupes) == '') {
+            $tab_groupes=array();
+        } else {
+            $tab_groupes=array_unique(explode(",", $list_groupes));
+        }
 
-    	echo "<form id=\"group-select-form\" class=\"form-inline\" action=\"$PHP_SELF?session=$session&printable=$printable&selected=$selected&year=$year&mois=$mois&first_jour=$first_jour\" method=\"POST\">\n";
-    	if (trim($list_groupes) == '')
-    		$tab_groupes=array();
-    	else
-    		$tab_groupes=array_unique(explode(",", $list_groupes));
+        $return .= '<div class="form-group">';
+        $return .= '<label for="select_groupe">' . _('calendrier_afficher_groupe') . '</label>';
+        $return .= '<select class="form-control" name="select_groupe">';
 
-    	echo "<div class=\"form-group\">\n";
-    	echo "<label for=\"select_groupe\">" . _('calendrier_afficher_groupe') ."</label>\n";
-    	echo "<select class=\"form-control\" name=\"select_groupe\">\n";
+        $tmp = false;
+        foreach($tab_groupes as $grp) {
+            $grp=trim($grp);
+            if($grp == $select_groupe) {
+                $return .= '<option value="' . $grp . '" selected="selected">' . $group_names[$grp] . '</option>';
+                $tmp = true;
+            } else {
+                $return .= '<option value="' . $grp . '">' . $group_names[$grp] . '</option>';
+            }
+        }
+        //option pour retour a l'affichage normal ...
+        if ($tmp) {
+            $return .= '<option value="0">' . _('divers_normal_maj_1') . '</option>';
+        } else {
+            $return .= '<option value="0" selected="selected">' . _('divers_normal_maj_1') . '</option>';
+        }
 
-    	$tmp = false;
-    	foreach($tab_groupes as $grp)
-    	{
-    		$grp=trim($grp);
-    		if($grp == $select_groupe)
-    		{
-    			echo "<option value=\"$grp\" selected=\"selected\">".$group_names[$grp]."</option>\n";
-    			$tmp = true;
-    		}
-    		else
-    			echo "<option value=\"$grp\">".$group_names[$grp]."</option>\n";
-    	}
-    	//option pour retour a l'affichage normal ...
-    	if ($tmp)
-    		echo "<option value=\"0\">". _('divers_normal_maj_1') ."</option>\n";
-    	else
-    		echo "<option value=\"0\" selected=\"selected\">". _('divers_normal_maj_1') ."</option>\n";
-
-    	echo "</select>\n";
-    	echo "</div>\n";
-    	echo "<input class=\"btn btn-default\" type=\"submit\" value=\"ok\">\n";
-    	echo "</form>\n";
+        $return .= '</select>';
+        $return .= '</div>';
+        $return .= '<input class="btn btn-default" type="submit" value="ok">';
+        $return .= '</form>';
+        return $return;
     }
 
     /**************************************************/
@@ -260,737 +246,690 @@ class Fonctions
     /**************************************************/
     public static function recup_tableau_periodes($mois, $first_jour, $year,  $tab_logins = false)
     {
-
-    	$tab_calendrier=array();  //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
-    						//il contient pour chaque clé : un tableau ($tab_jour) qui contient lui même des
-    						// tableaux indexés contenant les infos des periode de conges dont ce jour fait partie
-    						// ($tab_periode)
-
-
-    	$timestamp_deb	= mktime (0,0,0,$mois, $first_jour, $year);
-    	$timestamp_fin	= mktime (0,0,0,$mois +1 , $first_jour, $year);
-
-    	$date_deb	= date("Y-m-d", $timestamp_deb );
-    	$date_fin	= date("Y-m-d", $timestamp_fin );
-
-    	$sql	= 'SELECT  p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_type, p_etat, p_fermeture_id, p_commentaire
-    				FROM conges_periode
-    				WHERE ( p_etat=\'ok\' OR  p_etat=\'demande\' OR  p_etat=\'valid\')
-    					AND (p_date_fin >= "'. \includes\SQL::quote($date_deb).'" AND p_date_deb <= "'. \includes\SQL::quote($date_fin).'")
-    					'.($tab_logins !== false ? 'AND p_login IN (\''.implode('\', \'', $tab_logins).'\')' : '' ).'
-    				ORDER BY p_date_deb;';
-    	$result = \includes\SQL::query($sql);
-    	while($l = $result->fetch_array()) {
-
-    		// on ne stoque les "demandes" que pour le user qui consulte (il ne voit pas celles des autres !)(suivant l'option de config)
-    		if( $l['p_etat'] != 'demande' || $_SESSION['config']['affiche_demandes_dans_calendrier'] )
-    			$tab_jour	= $l;
-    		elseif( isset($_SESSION['userlogin']) && $l['p_login']==$_SESSION['userlogin'] )
-    			$tab_jour	= $l;
-    		else
-    			continue;
-
-    		$p_timestamp_deb = \DateTime::createFromFormat('Y-m-d', $l['p_date_deb']);
-    		$p_timestamp_fin = \DateTime::createFromFormat('Y-m-d', $l['p_date_fin']);
+        $tab_calendrier=array();  //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
+                            //il contient pour chaque clé : un tableau ($tab_jour) qui contient lui même des
+                            // tableaux indexés contenant les infos des periode de conges dont ce jour fait partie
+                            // ($tab_periode)
 
 
-    		$deb	= ( $timestamp_deb < $p_timestamp_deb->getTimestamp() ? $p_timestamp_deb : new \DateTime( '@'.$timestamp_deb) );
-    		$fin	= ( $timestamp_fin > $p_timestamp_fin->getTimestamp() ? $p_timestamp_fin : new \DateTime( '@'.$timestamp_fin) );
+        $timestamp_deb    = mktime (0,0,0,$mois, $first_jour, $year);
+        $timestamp_fin    = mktime (0,0,0,$mois +1 , $first_jour, $year);
 
-    		$tmp	= $deb;
-    		while ( $tmp <= $fin ){
-    			$date_j = date('Y-m-d',$tmp->getTimestamp() );
-    			if (!isset($tab_calendrier[$date_j]) || !is_array($tab_calendrier[$date_j]))
-    				$tab_calendrier[$date_j] = array();
-    			$tab_calendrier[$date_j][] = $tab_jour;
-    			$tmp->add(new \DateInterval('P1D'));
-    		}
-    	}
-    	return $tab_calendrier;
+        $date_deb    = date("Y-m-d", $timestamp_deb );
+        $date_fin    = date("Y-m-d", $timestamp_fin );
+
+        $sql    = 'SELECT  p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_type, p_etat, p_fermeture_id, p_commentaire
+                    FROM conges_periode
+                    WHERE ( p_etat=\'ok\' OR  p_etat=\'demande\' OR  p_etat=\'valid\')
+                        AND (p_date_fin >= "'. \includes\SQL::quote($date_deb).'" AND p_date_deb <= "'. \includes\SQL::quote($date_fin).'")
+                        '.($tab_logins !== false ? 'AND p_login IN (\''.implode('\', \'', $tab_logins).'\')' : '' ).'
+                    ORDER BY p_date_deb;';
+        $result = \includes\SQL::query($sql);
+        while($l = $result->fetch_array()) {
+
+            // on ne stoque les "demandes" que pour le user qui consulte (il ne voit pas celles des autres !)(suivant l'option de config)
+            if( $l['p_etat'] != 'demande' || $_SESSION['config']['affiche_demandes_dans_calendrier'] ) {
+                $tab_jour    = $l;
+            } elseif( isset($_SESSION['userlogin']) && $l['p_login'] == $_SESSION['userlogin'] ) {
+                $tab_jour    = $l;
+            } else {
+                continue;
+            }
+
+            $p_timestamp_deb = \DateTime::createFromFormat('Y-m-d', $l['p_date_deb']);
+            $p_timestamp_fin = \DateTime::createFromFormat('Y-m-d', $l['p_date_fin']);
+
+
+            $deb    = ( $timestamp_deb < $p_timestamp_deb->getTimestamp() ? $p_timestamp_deb : new \DateTime( '@'.$timestamp_deb) );
+            $fin    = ( $timestamp_fin > $p_timestamp_fin->getTimestamp() ? $p_timestamp_fin : new \DateTime( '@'.$timestamp_fin) );
+
+            $tmp    = $deb;
+            while ( $tmp <= $fin ){
+                $date_j = date('Y-m-d',$tmp->getTimestamp() );
+                if (!isset($tab_calendrier[$date_j]) || !is_array($tab_calendrier[$date_j])) {
+                    $tab_calendrier[$date_j] = array();
+                }
+                $tab_calendrier[$date_j][] = $tab_jour;
+                $tmp->add(new \DateInterval('P1D'));
+            }
+        }
+        return $tab_calendrier;
     }
 
     // renvoit conges , demande ou autre ....
     public static function get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id, $DEBUG=FALSE)
     {
-    	if($sql_p_fermeture_id!="")
-    		return "fermeture";
-    	elseif ( $tab_type_absence[$sql_p_type] && $tab_type_absence[$sql_p_type]['type']=="absences")
-    		return "autre";
-    	elseif($sql_p_etat=='ok')
-    		return "conges";
-    	elseif( ($sql_p_etat=="demande") || ($sql_p_etat=="valid") )
-    		return "demande";
+        if($sql_p_fermeture_id!="") {
+            return "fermeture";
+        } elseif ( $tab_type_absence[$sql_p_type] && $tab_type_absence[$sql_p_type]['type'] == "absences") {
+            return "autre";
+        } elseif($sql_p_etat=='ok') {
+            return "conges";
+        } elseif( ($sql_p_etat=="demande") || ($sql_p_etat=="valid") ) {
+            return "demande";
+        }
     }
 
     // affichage de la légende explicative des abréviations
     public static function affiche_legende_type_absence($tab_type_absence, $DEBUG=FALSE)
     {
-    	$session=session_id();
+        $session=session_id();
 
-    //	echo "      <table cellpadding=\"1\" cellspacing=\"1\" border=\"1\">\n" ;
-    	echo "      <table cellpadding=\"1\" class=\"tablo-cal\">\n" ;
-    	foreach($tab_type_absence as $id_abs => $tab)
-    	{
-    		echo "      <tr align=\"center\">\n" ;
-    		echo "         <td class=\"cal-legende\"> ".$tab['short_libelle']." : </td>\n" ;
-    		echo "         <td class=\"cal-legende\"> ".$tab['libelle']." </td>\n" ;
-    		echo "      </tr>\n" ;
-    	}
-    	echo "      </table>\n" ;
+        //    echo "      <table cellpadding=\"1\" cellspacing=\"1\" border=\"1\">\n" ;
+        echo "      <table cellpadding=\"1\" class=\"tablo-cal\">\n" ;
+        foreach($tab_type_absence as $id_abs => $tab) {
+            echo "      <tr align=\"center\">\n" ;
+            echo "         <td class=\"cal-legende\"> ".$tab['short_libelle']." : </td>\n" ;
+            echo "         <td class=\"cal-legende\"> ".$tab['libelle']." </td>\n" ;
+            echo "      </tr>\n" ;
+        }
+        echo "      </table>\n" ;
     }
 
     // affichage de la légende des couleurs
     public static function affiche_legende($DEBUG=FALSE)
     {
-    	$session=session_id();
+        $session=session_id();
 
-    //	echo "      <table cellpadding=\"1\" cellspacing=\"1\" border=\"1\">\n" ;
-    	echo "      <table cellpadding=\"1\" class=\"tablo-cal\">\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['semaine_bgcolor']."\" class=\"cal-legende\"> - </td>\n" ;
-    	echo "         <td class=\"cal-legende\"> </td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['week_end_bgcolor']."\" class=\"cal-legende\"> - </td>\n" ;
-    	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_we') ."</td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['conges_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
-    	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_conges') ."</td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['demande_conges_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
-    	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_demande') ."</td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    //	echo "         <td bgcolor=\"".$_SESSION['config']['temps_partiel_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['temps_partiel_bgcolor']."\" class=\"cal-legende\"> - </td>\n" ;
-    	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_part_time') ."</td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['absence_autre_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
-    	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_abs') ."</td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      <tr align=\"center\">\n" ;
-    	echo "         <td bgcolor=\"".$_SESSION['config']['fermeture_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
-    	echo "         <td class=\"cal-legende\"> ". _('divers_fermeture') ."</td>\n" ;
-    	echo "      </tr>\n" ;
-    	echo "      </table>\n" ;
+        //    echo "      <table cellpadding=\"1\" cellspacing=\"1\" border=\"1\">\n" ;
+        echo "      <table cellpadding=\"1\" class=\"tablo-cal\">\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['semaine_bgcolor']."\" class=\"cal-legende\"> - </td>\n" ;
+        echo "         <td class=\"cal-legende\"> </td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['week_end_bgcolor']."\" class=\"cal-legende\"> - </td>\n" ;
+        echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_we') ."</td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['conges_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
+        echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_conges') ."</td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['demande_conges_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
+        echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_demande') ."</td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        //    echo "         <td bgcolor=\"".$_SESSION['config']['temps_partiel_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['temps_partiel_bgcolor']."\" class=\"cal-legende\"> - </td>\n" ;
+        echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_part_time') ."</td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['absence_autre_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
+        echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_abs') ."</td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      <tr align=\"center\">\n" ;
+        echo "         <td bgcolor=\"".$_SESSION['config']['fermeture_bgcolor']."\" class=\"cal-legende\">abs</td>\n" ;
+        echo "         <td class=\"cal-legende\"> ". _('divers_fermeture') ."</td>\n" ;
+        echo "      </tr>\n" ;
+        echo "      </table>\n" ;
     }
 
     // affichage de la cellule correspondant au jour et au user considéré
     // et renvoit un tableau avec une key / une valeur : key = id type absence / valeur = nb jours pris le jour J
-    public static function affiche_cellule_jour_user($sql_login, $j_timestamp, $year_select, $mois_select, $j, $second_class, $printable, $tab_calendrier, $tab_rtt_echange, $tab_rtt_planifiees, $tab_type_absence,  $DEBUG=FALSE)
+    public static function affiche_cellule_jour_user($sql_login, $j_timestamp, $year_select, $mois_select, $j, $second_class, $printable, $tab_calendrier, $tab_rtt_echange, $tab_rtt_planifiees, $tab_type_absence, &$returnString, $DEBUG=FALSE)
     {
+        $session=session_id();
+        $return = array();
 
-    	$session=session_id();
-
-    	$return = array();
-
-    	// info bulle
-    	$j_date_fr=date_fr("d/m/Y", $j_timestamp);
-    	$j_num_semaine=date_fr("W", $j_timestamp);
-    	$info_bulle=" title=\"$sql_login - $j_date_fr\" ";
+        // info bulle
+        $j_date_fr=date_fr("d/m/Y", $j_timestamp);
+        $j_num_semaine=date_fr("W", $j_timestamp);
+        $info_bulle=" title=\"$sql_login - $j_date_fr\" ";
 
 
-    	if($second_class=="weekend")
-    	{
-    		$class="cal-day_".$second_class ;
-    		if($printable!=1)  // si version écran :
-    			echo "<td class=\"$class\" $info_bulle>-</td>";
-    		else
-    			echo "<td class=\"$class\">-</td>";
-    	}
-    	else
-    	{
-    		$date_j=date("Y-m-d", $j_timestamp );
+        if($second_class=="weekend") {
+            $class="cal-day_".$second_class ;
+            if($printable!=1) { // si version écran :
+                $returnString .= '<td class="' . $class . '" ' . $info_bulle . '>-</td>';
+            } else {
+                $returnString .= '<td class="' . $class . '">-</td>';
+            }
+        } else {
+            $date_j=date("Y-m-d", $j_timestamp );
 
-    		$class_am="travail_am";
-    		$class_pm="travail_pm";
-    		$text_am="-";
-    		$text_pm="-";
+            $class_am="travail_am";
+            $class_pm="travail_pm";
+            $text_am="-";
+            $text_pm="-";
 
-    		$val_matin="";
-    		$val_aprem="";
-    		// recup des infos ARTT ou Temps Partiel :
-    		// la fonction suivante change les valeurs de $val_matin $val_aprem ....
-    		recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, $val_matin, $val_aprem, $tab_rtt_echange, $tab_rtt_planifiees,  $DEBUG=FALSE);
+            $val_matin="";
+            $val_aprem="";
+            // recup des infos ARTT ou Temps Partiel :
+            // la fonction suivante change les valeurs de $val_matin $val_aprem ....
+            recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, $val_matin, $val_aprem, $tab_rtt_echange, $tab_rtt_planifiees,  $DEBUG=FALSE);
 
-    		//## AFICHAGE ##
-    		if($val_matin=="Y")
-    		{
-    			$class_am="rtt_am";
-    	//		$text_am="a";
-    		}
-    		if($val_aprem=="Y")
-    		{
-    			$class_pm = "rtt_pm";
-    	//		$text_pm="a";
-    		}
+            //## AFICHAGE ##
+            if($val_matin=="Y") {
+                $class_am="rtt_am";
+        //        $text_am="a";
+            }
+            if($val_aprem=="Y") {
+                $class_pm = "rtt_pm";
+        //        $text_pm="a";
+            }
 
 
 
-    		$text_bulle_type_abs="";
+            $text_bulle_type_abs="";
 
-    		if( !(($val_matin=="Y")&&($val_aprem=="Y")) ) //si pas journée complète temps-partiel ou rtt, on regarde les conges)
-    		{
-    			// Récupération des conges du user
-    			if (array_key_exists($date_j, $tab_calendrier))   //verif la clé du jour exite dans $tab_calendrier
-    			{
-    				$tab_day=$tab_calendrier["$date_j"];  // on recup le tableau ($tab_jour) de la date que l'on affiche
-    				//print_r($tab_day);
+            if( !(($val_matin=="Y")&&($val_aprem=="Y")) ) //si pas journée complète temps-partiel ou rtt, on regarde les conges)
+            {
+                // Récupération des conges du user
+                if (array_key_exists($date_j, $tab_calendrier))   //verif la clé du jour exite dans $tab_calendrier
+                {
+                    $tab_day=$tab_calendrier["$date_j"];  // on recup le tableau ($tab_jour) de la date que l'on affiche
+                    //print_r($tab_day);
 
-    				$nb_resultat_periode = count($tab_day);  //
-    				if($nb_resultat_periode>0)      // si on est dans une periode de conges
-    				{
-    					for ($i = 0; $i < $nb_resultat_periode; $i++)
-    					{
-    						// on regarde chaque periode l'une après l'autre
-    						$tab_per=$tab_day[$i];  // on recup le tableau de la periode
-    						if(in_array($sql_login, $tab_per))   // si la periode correspond au user que l'on est en train de traiter
-    						{
-    							//echo "tab_per =<br/>\n"; print_r($tab_per); echo "<br/>\n";
+                    $nb_resultat_periode = count($tab_day);  //
+                    if($nb_resultat_periode>0)      // si on est dans une periode de conges
+                    {
+                        for ($i = 0; $i < $nb_resultat_periode; $i++) {
+                            // on regarde chaque periode l'une après l'autre
+                            $tab_per=$tab_day[$i];  // on recup le tableau de la periode
+                            if(in_array($sql_login, $tab_per))   // si la periode correspond au user que l'on est en train de traiter
+                            {
+                                //echo "tab_per =<br/>\n"; print_r($tab_per); echo "<br/>\n";
 
-    							$sql_p_type=$tab_per["p_type"];
-    							$sql_p_etat=$tab_per["p_etat"];
-    							$sql_p_date_deb=$tab_per["p_date_deb"];
-    							$sql_p_date_fin=$tab_per["p_date_fin"];
-    							$sql_p_demi_jour_deb=$tab_per["p_demi_jour_deb"];
-    							$sql_p_demi_jour_fin=$tab_per["p_demi_jour_fin"];
-    							$sql_p_fermeture_id=$tab_per["p_fermeture_id"];
+                                $sql_p_type=$tab_per["p_type"];
+                                $sql_p_etat=$tab_per["p_etat"];
+                                $sql_p_date_deb=$tab_per["p_date_deb"];
+                                $sql_p_date_fin=$tab_per["p_date_fin"];
+                                $sql_p_demi_jour_deb=$tab_per["p_demi_jour_deb"];
+                                $sql_p_demi_jour_fin=$tab_per["p_demi_jour_fin"];
+                                $sql_p_fermeture_id=$tab_per["p_fermeture_id"];
 
-    							$sql_p_date_deb_fr=substr($sql_p_date_deb,8,2)."/".substr($sql_p_date_deb,5,2)."/".substr($sql_p_date_deb,0,4);
-    							$sql_p_date_fin_fr=substr($sql_p_date_fin,8,2)."/".substr($sql_p_date_fin,5,2)."/".substr($sql_p_date_fin,0,4);
+                                $sql_p_date_deb_fr=substr($sql_p_date_deb,8,2)."/".substr($sql_p_date_deb,5,2)."/".substr($sql_p_date_deb,0,4);
+                                $sql_p_date_fin_fr=substr($sql_p_date_fin,8,2)."/".substr($sql_p_date_fin,5,2)."/".substr($sql_p_date_fin,0,4);
 
-    							//si on est le premier jour ET le dernier jour de conges
-    							if( ($sql_p_date_deb==$date_j) && ($sql_p_date_fin==$date_j) )
-    							{
-    								if($sql_p_demi_jour_deb=="am")
-    								{
-    									$class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
-    									$text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                //si on est le premier jour ET le dernier jour de conges
+                                if( ($sql_p_date_deb==$date_j) && ($sql_p_date_fin==$date_j) ) {
+                                    if($sql_p_demi_jour_deb=="am") {
+                                        $class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
+                                        $text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        if ($tab_per['p_commentaire'] == "") { // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        } else {
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        }
 
-    									if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ]))
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
-    									else
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
-    								}
-    								if($sql_p_demi_jour_fin=="pm")
-    								{
-    									$class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
-    									$text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ])) {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
+                                        } else {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
+                                        }
+                                    }
+                                    if($sql_p_demi_jour_fin=="pm") {
+                                        $class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
+                                        $text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        if ($tab_per['p_commentaire'] == "") {  // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        } else {
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        }
 
-    									if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ]))
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
-    									else
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
-    								}
-    							}
-    							elseif($sql_p_date_deb==$date_j) //si on est le premier jour
-    							{
-    								if($sql_p_demi_jour_deb=="am")
-    								{
-    									$class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
-    									$text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									$class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
-    									$text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ])) {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
+                                        } else {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
+                                        }
+                                    }
+                                }
+                                elseif($sql_p_date_deb==$date_j) //si on est le premier jour
+                                {
+                                    if($sql_p_demi_jour_deb=="am") {
+                                        $class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
+                                        $text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        $class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
+                                        $text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        if ($tab_per['p_commentaire'] == "") {  // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        } else {
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        }
 
-    									$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 1;
-    								}
-    								else
-    								{
-    									$class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
-    									$text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 1;
+                                    } else {
+                                        $class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
+                                        $text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        if ($tab_per['p_commentaire'] == "") {   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        } else {
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        }
+                                        if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ])) {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
+                                        } else {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
+                                        }
+                                    }
+                                } elseif($sql_p_date_fin==$date_j) //si on est le dernier jour
+                                {
+                                    if($sql_p_demi_jour_fin=="pm") {
+                                        $class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
+                                        $text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        $class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
+                                        if ($tab_per['p_commentaire'] == "") { // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        } else {
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        }
+                                        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
 
+                                        $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 1;
+                                    } else {
+                                        $class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
+                                        $text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        if ($tab_per['p_commentaire'] == "") {  // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        } else {
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        }
 
-    									if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ]))
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
-    									else
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
-    								}
-    							}
-    							elseif($sql_p_date_fin==$date_j) //si on est le dernier jour
-    							{
-    								if($sql_p_demi_jour_fin=="pm")
-    								{
-    									$class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
-    									$text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									$class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									$text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-
-    									$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 1;
-    								}
-    								else
-    								{
-    									$class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
-    									$text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-
-    									if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ]))
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
-    									else
-    										$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
-    								}
-    							}
-    							else // si on est ni le premier ni le dernier jour
-    							{
-    								$class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
-    								$text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
-    								$class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
-    								$text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
-    									if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
-    									        $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
-    									else
-    									        $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        if (isset($return[ $tab_type_absence[$sql_p_type]['libelle'] ])) {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] += 0.5;
+                                        } else {
+                                            $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 0.5;
+                                        }
+                                    }
+                                }
+                                else // si on est ni le premier ni le dernier jour
+                                {
+                                    $class_am=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_am";
+                                    $text_am=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                    $class_pm=\calendrier\Fonctions::get_class_titre($sql_p_type, $tab_type_absence, $sql_p_etat, $sql_p_fermeture_id)."_pm";
+                                    $text_pm=$tab_type_absence[$sql_p_type]['short_libelle'];
+                                        if ($tab_per['p_commentaire'] == "")   // *** si le commentaire est renseigné on l'affiche dans l'infobulle, sinon on affiche le type d'absence ***
+                                                $text_bulle_type_abs='<div class="type-abscence">' . $tab_type_absence[$sql_p_type]['libelle'] ."</div>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
+                                        else
+                                                $text_bulle_type_abs=$tab_per['p_commentaire']."<br/>$sql_p_date_deb_fr <i class=\"fa fa-long-arrow-right\"></i> $sql_p_date_fin_fr";
 
 
-    								$return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 1;
-    							}
-    						}
-    					}
-    				}
-    			}
-    		}
+                                    $return[ $tab_type_absence[$sql_p_type]['libelle'] ] = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-    		if(($text_am=="a")&&($text_pm=="a"))
-    		{
-    			$text_am="abs";
-    			$text_pm="";
-    		}
+            if(($text_am=="a")&&($text_pm=="a")) {
+                $text_am="abs";
+                $text_pm="";
+            }
 
-    		// on affiche qu'un seule fois le texte si c'est le même le matin et l'aprem :
-    		if($text_am==$text_pm)
-    			$text_pm="";
-    		elseif(($text_am=="-") &&($text_pm!="") ) //on a un "-" le matin et qq chose l'aprem :on affiche que le texte de l'aprem
-    			$text_am="";
-    		elseif(($text_am!="") && ($text_pm=="-"))  //on a un qq chose le matin et un "-" l'aprem :on affiche que le texte du matin
-    			$text_pm="";
-
-
-    		$class="cal-day cal-day_".$second_class."_".$class_am."_".$class_pm ;
+            // on affiche qu'un seule fois le texte si c'est le même le matin et l'aprem :
+            if($text_am==$text_pm)
+                $text_pm="";
+            elseif(($text_am=="-") &&($text_pm!="") ) //on a un "-" le matin et qq chose l'aprem :on affiche que le texte de l'aprem
+                $text_am="";
+            elseif(($text_am!="") && ($text_pm=="-"))  //on a un qq chose le matin et un "-" l'aprem :on affiche que le texte du matin
+                $text_pm="";
 
 
-    		if($printable!=1)  // si version écran :
-    		{
-    			if( ($text_am=="-") && ($text_pm=="") )
-    			{
-    				echo "<td class=\"$class\"  $info_bulle>";
-    				echo "	$text_am $text_pm ";
-    			}
-    			else
-    			{
-    				echo "<td class=\"$class\">";
-    				echo "	$text_am $text_pm ";
+            $class="cal-day cal-day_".$second_class."_".$class_am."_".$class_pm ;
 
-    				// affiche l'info-bulle (affichée grace au javascript)
-    				//$texte_info_bulle=" $j_date_fr / ". _('divers_semaine') ." $j_num_semaine <br/>$text_bulle_type_abs<br/>periode";
-    				// $texte_info_bulle=" $j_date_fr <br/>$text_bulle_type_abs";
-    				echo "	<div class=\"cal-tooltip\" id='$sql_login-$j_timestamp' name='$sql_login-$j_timestamp' >
-    							<div class=\"pull-right current-date\">$j_date_fr</div>
-    							<strong>$sql_login</strong>
-    							<hr/>
-    							<div>$text_bulle_type_abs</div>
-    						</div> ";
-    			}
-    		}
-    		else
-    		{
-    			echo "<td class=\"$class\" >";
-    			echo "	$text_am $text_pm ";
-    		}
-    		echo "</td>";
-    	}
-    	return $return;
+
+            if($printable!=1)  // si version écran :
+            {
+                if( ($text_am=="-") && ($text_pm=="") ) {
+                    $returnString .= '<td class="' . $class . '"  ' . $info_bulle . '>';
+                    $returnString .= $text_am . ' ' . $text_pm;
+                } else {
+                    $returnString .= '<td class="' . $class . '">';
+                    $returnString .= $text_am . ' ' . $text_pm;
+
+                    // affiche l'info-bulle (affichée grace au javascript)
+                    //$texte_info_bulle=" $j_date_fr / ". _('divers_semaine') ." $j_num_semaine <br/>$text_bulle_type_abs<br/>periode";
+                    // $texte_info_bulle=" $j_date_fr <br/>$text_bulle_type_abs";
+                    $returnString .= '<div class="cal-tooltip" id="' . $sql_login . '-' . $j_timestamp. '" name="' . $sql_login . '-' . $j_timestamp . '"><div class="pull-right current-date">' . $j_date_fr . '</div><strong>' . $sql_login . '</strong><hr/><div>' . $text_bulle_type_abs . '</div></div>';
+                }
+            } else {
+                $returnString .= '<td class="' . $class . '">';
+                $returnString .= $text_am . ' ' . $text_pm;
+            }
+            $returnString .= '</td>';
+        }
+        return $return;
     }
 
     // AFFICHAGE  TABLEAU (CALENDRIER)
     public static function affichage_calendrier($year, $mois, $first_jour, $timestamp_today, $printable, $selected, $tab_type_absence, $select_groupe, $DEBUG=FALSE)
     {
-    	$PHP_SELF=$_SERVER['PHP_SELF'];
-    	$session=session_id();
-    		$nb_day = date('t', mktime(1,1,1,$mois,1,$year));
-
-    		// recup du tableau des types de conges (seulement les conges)
-    		$tab_type_cong=recup_tableau_types_conges($DEBUG);
-    		if ($_SESSION['config']['gestion_conges_exceptionnels'])
-    			$tab_type_cong_excep=recup_tableau_types_conges_exceptionnels($DEBUG);
-
-    		/*****************************************/
-    		/** Récupération des users à afficher:  **/
-
-    		$tab_all_users	= \calendrier\Fonctions::recup_tableau_des_users_a_afficher($select_groupe,$DEBUG);
-
-
-    		if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
-    			$tab_logins = array_keys( $tab_all_users );
-    			$tab_logins = array_map("\includes\SQL::quote", $tab_logins);
-    		}
-    		else
-    			$tab_logins = false;
-    		/** FIN de Récupération des users à afficher:  **/
-    		/************************************************/
-
-
-    		/*************************/
-    		/**  AFFICHAGE TABLEAU  **/
-
-    		if($printable!=1)  // si version ecran :
-    			echo "<table class=\"calendar table table-responsive table-bordered table-stripped\">\n";
-    		else               // si version imprimable :
-    			echo "<table>\n";
-
-    		echo "<tr><th colspan=\"2\"></th><th colspan=\"$nb_day\">". _('divers_semaine') ."</th><th colspan=\"8\">Solde</th></tr>\n";
-
-    		/*************************************/
-    		// affichage premiere ligne (semaines)
-    		echo "<tr align=\"center\">\n";
-
-    		// affichage nom prenom quotité
-    		$nb_colonnes=3;
-    		echo "	<th rowspan=\"2\">Utilisateur</th>\n\n";
-    		echo "	<th rowspan=\"2\">Quotité</th>";
-
-    		// affichage des semaines
-    		// ... du premier jour voulu à la fin du mois
-    		for($j=$first_jour; checkdate($mois, $j, $year); $j++)
-    		{
-    			$j_timestamp=mktime (0,0,0,$mois, $j, $year);
-    			$j_num_semaine=date_fr("W", $j_timestamp);
-    			// attention date_fr("w", $j_timestamp) renvoit 0 pour dimanche !
-    			if(date_fr("w", $j_timestamp)==0)
-    				$j_num_jour_semaine=7;
-    			else
-    				$j_num_jour_semaine=date_fr("w", $j_timestamp);
-
-    			//DEBUG : echo "<td class=\"cal-day\" >$j_num_jour_semaine / $j_num_semaine</td>";
-    			if($j==$first_jour)
-    			{
-    					$colspan = 8 - $j_num_jour_semaine;
-
-    				echo "<th class=\"cal-day-first\" colspan=\"$colspan\" >$j_num_semaine</th>\n";
-    			}
-    			else
-    			{
-    				$month_rest = $nb_day - $j;
-    				$colspan = 7;
-    				if($month_rest < 6)
-    					$colspan = $month_rest + 1;
-    				// on affiche que les lundi
-    				if($j_num_jour_semaine==1) {
-    					echo "<th class=\"cal-day\" colspan=\"$colspan\" >$j_num_semaine</th>\n";
-    				}
-
-    			}
-
-    		}
-
-    		// ... si le premier jour voulu n'etait pas le premier du mois, on va jusqu'à la meme date du mois suivant.
-    		if($first_jour!=1)
-    		{
-    			for($j=1; $j<$first_jour; $j++)
-    			{
-    				if($mois==12)
-    				{
-    					$mois_select=1;
-    					$year_select=$year+1;
-    				}
-    				else
-    				{
-    					$mois_select=$mois+1 ;
-    					$year_select=$year;
-    				}
-
-    				$j_timestamp=mktime (0,0,0,$mois_select, $j, $year_select);
-    				$j_num_jour_semaine=date_fr("w", $j_timestamp);
-
-    				$j_num_semaine=date_fr("W", $j_timestamp);
-    				// attention date_fr("w", $j_timestamp) renvoit 0 pour dimanche !
-    				if(date_fr("w", $j_timestamp)==0)
-    					$j_num_jour_semaine=7;
-    				else
-    					$j_num_jour_semaine=date_fr("w", $j_timestamp);
-
-    				//DEBUG : echo "<td class=\"cal-day\" >$j_num_jour_semaine / $j_num_semaine</td>";
-    				if($j==$first_jour)
-    				{
-    					$colspan=8-$j_num_jour_semaine;
-    					echo "<td class=\"cal-day-first\" colspan=\"$colspan\" >$j_num_semaine</td>\n";
-    				}
-    				else
-    				{
-    					// on affiche que les lundi
-    					if($j_num_jour_semaine==1) {
-    						echo "<td class=\"cal-day\" colspan=\"7\" >$j_num_semaine</td>\n";
-    					}
-    				}
-    			}
-    		}
-
-
-
-    		if( $_SESSION['config']['affiche_soldes_calendrier'] || is_resp($_SESSION['userlogin']) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
-    		{
-    			// affichage des libellé des conges
-    			$abs_libelle = recup_tableau_tout_types_abs();
-
-    			foreach($tab_type_cong as $id => $libelle)
-    			{
-    					echo "<th rowspan=\"2\">" . $abs_libelle[$id]['short_libelle'] . "</th>\n";
-    					$nb_colonnes=$nb_colonnes+1;
-    			}
-
-
-    			if ($_SESSION['config']['gestion_conges_exceptionnels'])
-    			{
-    				foreach($tab_type_cong_excep as $id => $libelle)
-    				{
-    					echo "<th rowspan=\"2\">" . $abs_libelle[$id]['short_libelle'] . "</th>\n";
-    					$nb_colonnes=$nb_colonnes+1;
-    				}
-    			}
-    		}
-
-
-    		echo "</tr>\n\n";
-
-
-    		/*************************************/
-    		// affichage 2ieme ligne (dates)
-    		echo "<tr>\n";
-
-    		// on affiche pas car on a fait de "rowspan" à la ligne supérieure
-    		// affichage d'une cellule vide sous les titres
-    		//echo "	<td class=\"cal-user\" colspan=\"$nb_colonnes\">&nbsp;</td>\n";
-    		//dernier jour = dimanche ?
-    		$last = 7;
-
-
-    		// affichage des dates
-    		// ... du premier jour voulu à la fin du mois
-    		for($j=$first_jour; checkdate($mois, $j, $year); $j++)
-    		{
-    			$j_timestamp=mktime (0,0,0,$mois, $j, $year);
-    			// $j_name=date_fr("D", $j_timestamp);
-    			$j_name = substr(date_fr("D", $j_timestamp), 0, 1);
-    			$last =date("N", $j_timestamp);
-    			$j_date_fr=date_fr("d-m-Y", $j_timestamp);
-    			$j_num_semaine=date_fr("W", $j_timestamp);
-    			$td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
-
-    			// on affiche en gras le jour d'aujourd'hui
-    			if($j_timestamp==$timestamp_today)
-    				$text_titre_date="<b>$j_name <br/>$j</b>";
-    			else
-    				$text_titre_date="$j_name <br/>$j";
-
-    			// on regarde si c'est la premiere cellule ou non
-    			if($j==$first_jour)
-    				$cal_day="cal-day-first";
-    			else
-    				$cal_day="cal-day";
-
-    			// on affiche le titre -date (la date du jour)
-    			echo "<td class=\"$cal_day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\">$text_titre_date</td>";
-    		}
-
-    		// ... si le premier jour voulu n'etait pas le premier du mois, on va jusqu'à la meme date du mois suivant.
-    		if($first_jour!=1)
-    		{
-    			for($j=1; $j<$first_jour; $j++)
-    			{
-    				if($mois==12)
-    				{
-    					$mois_select=1;
-    					$year_select=$year+1;
-    				}
-    				else
-    				{
-    					$mois_select=$mois+1 ;
-    					$year_select=$year;
-    				}
-
-    				$j_timestamp=mktime (0,0,0,$mois_select, $j, $year_select);
-    				$last =date("N", $j_timestamp);
-    				// $j_name=date_fr("D", $j_timestamp);
-    				$j_name = substr(date_fr("D", $j_timestamp), 0, 1);
-    				$j_date_fr=date_fr("d-m-Y", $j_timestamp);
-    				$j_num_semaine=date_fr("W", $j_timestamp);
-    				$td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
-
-    				// on affiche en gras le jour d'aujourd'hui
-    				if($j_timestamp==$timestamp_today)
-    					echo "<td class=\"cal-day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\"><strong>$j_name $j</strong></td>";
-    					// echo "<td class=\"cal-day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\"><b>$j_name $j/$mois_select</b></td>";
-    				else
-    					echo "<td class=\"cal-day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\">$j_name $j</td>";
-    					// echo "<td class=\"cal-day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\">$j_name $j/$mois_select</td>";
-    			}
-    		}
-
-    		// if ($last < 7)
-    		// for ($i = $last; $i <7; $i ++)
-    		// 	echo '<td></td>';
-    		// echo "</tr>\n";
-
-
-    		/**************************************************/
-    		/**************************************************/
-    		/* recup des info de chaque jour pour tous les users et stockage dans 1 tableau de tableaux */
-
-    		$tab_calendrier = \calendrier\Fonctions::recup_tableau_periodes($mois, $first_jour, $year,  $tab_logins);
-
-
-
-    		/**************************************************/
-    		/* recup des rtt de chaque jour pour tous les users et stockage dans 2 tableaux de tableaux */
-    		/**************************************************/
-    		//$tab_rtt_echange  //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
-    						//il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
-    						// qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
-    						// jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
-    		//$tab_rtt_planifiees=array();  //tableau indexé dont la clé est le login_user
-    					// il contient pour chaque clé login : un tableau ($tab_user_grille) indexé dont la
-    					// clé est la date_fin_grille.
-    					// qui contient lui meme pour chaque clé : un tableau ($tab_user_rtt) qui contient enfin
-    					// les infos pour le matin et l'après midi ('Y' si rtt, 'N' sinon) sur 2 semaines
-    					// ( du sem_imp_lu_am au sem_p_ve_pm ) + la date de début et de fin de la grille
-
-
-    		$tab_rtt_echange= recup_tableau_rtt_echange($mois, $first_jour, $year  , $tab_logins );
-    		$tab_rtt_planifiees= recup_tableau_rtt_planifiees($mois, $first_jour, $year , $tab_logins);
-
-    		$tab_cong_users = recup_tableau_conges_for_users(false, $tab_logins);
-
-    		/**************************************************/
-    		/**************************************************/
-    		// affichage lignes suivantes (users)
-
-    		// pour chaque user :
-    		foreach($tab_all_users as $sql_login => $tab_current_user)
-    		{
-    			$sql_nom=$tab_current_user["nom"];
-    			$sql_prenom=$tab_current_user["prenom"];
-    			$sql_quotite=$tab_current_user["quotite"];
-
-    			// nb de jour pris dans le mois en cours (pour un type d'absence donné)
-    			$nb_jours_current_month = array();
-
-    			// recup dans un tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-    			$tab_cong_user = isset($tab_cong_users[$sql_login]) ? $tab_cong_users[$sql_login] : [];
-
-    			if($printable==1)
-    				echo "<tr align=\"center\" class=\"cal-ligne-user-edit\">\n";
-    			elseif($selected==$sql_login)
-    				echo "<tr align=\"center\" class=\"cal-ligne-user-selected\">\n";
-    			else
-    				echo "<tr align=\"center\" class=\"cal-ligne-user\">\n";
-
-    			if($printable==1)
-    				$text_nom="<strong>$sql_nom</strong>";
-    			else
-    				$text_nom="<a href=\"$PHP_SELF?session=$session&selected=$sql_login&year=$year&mois=$mois&first_jour=$first_jour&printable=$printable&select_groupe=$select_groupe\" method=\"GET\">$sql_nom $sql_prenom</a>";
-
-    			// affichage nom prenom quotité
-    			echo "<td class=\"cal-user\">$text_nom</td><td class=\"cal-percent\">$sql_quotite %</td>";
-
-
-    			// pour chaque jour : (du premier jour demandé à la fin du mois ...)
-    			for($j=$first_jour; checkdate($mois, $j, $year); $j++)
-    			{
-    				$j_timestamp=mktime (0,0,0,$mois, $j, $year);
-    				$td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
-
-    				$mois_select=$mois;
-    				$year_select=$year ;
-
-    				// affichage de la cellule correspondant au jour et au user considéré
-    				$t_nb_j_type_abs = \calendrier\Fonctions::affiche_cellule_jour_user($sql_login, $j_timestamp, $year, $mois_select, $j , $td_second_class, $printable, $tab_calendrier, $tab_rtt_echange, $tab_rtt_planifiees, $tab_type_absence);
-    				foreach($t_nb_j_type_abs as $id_type_abs => $nb_j_pris)
-    				{
-    					if (isset($nb_jours_current_month[ $id_type_abs ]))
-    						$nb_jours_current_month[ $id_type_abs ] +=$nb_j_pris;
-    					else
-    						$nb_jours_current_month[ $id_type_abs ] =$nb_j_pris;
-    				}
-    			}
-    			// si le premier jour demandé n'est pas le 1ier du mois , on va jusqu'à la meme date le mois suivant :
-    			if($first_jour!=1)
-    			{
-    				// pour chaque jour jusqu'a la date voulue : (meme num de jour le mois suivant)
-    				for($j=1; $j<$first_jour; $j++)
-    				{
-    					$j_timestamp=mktime (0,0,0,$mois+1, $j, $year);
-    					$td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
-
-    					if($mois==12)
-    					{
-    						$mois_select=1;
-    						$year_select=$year+1 ;
-    					}
-    					else
-    					{
-    						$mois_select=$mois+1 ;
-    						$year_select=$year ;
-    					}
-
-    					// affichage de la cellule correspondant au jour et au user considéré
-    					$t_nb_j_type_abs = \calendrier\Fonctions::affiche_cellule_jour_user($sql_login, $j_timestamp, $year, $mois_select, $j, $td_second_class, $printable, $tab_calendrier, $tab_rtt_echange, $tab_rtt_planifiees, $tab_type_absence);
-    					foreach($t_nb_j_type_abs as $id_type_abs => $nb_j_pris)
-    					{
-    						if (isset($nb_jours_current_month[ $id_type_abs ]))
-    							$nb_jours_current_month[ $id_type_abs ] +=$nb_j_pris;
-    						else
-    							$nb_jours_current_month[ $id_type_abs ] =$nb_j_pris;
-    					}
-    				}
-    			}
-
-
-    			//if ($last < 7)
-    			//for ($i = $last; $i <7; $i ++)
-    			//	echo '<td></td>';
-
-    			if( $_SESSION['config']['affiche_soldes_calendrier'] || is_resp($_SESSION['userlogin']) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
-    			{
-    				// affichage des divers soldes
-    				foreach($tab_cong_user as $id => $tab_conges)
-    				{
-    					// si des jours ont été pris durant le mois affiché, on indique combien :
-    					if((isset($nb_jours_current_month[$id])) && ($_SESSION['config']['affiche_jours_current_month_calendrier']) )
-    						echo "<td class=\"cal-user\">".$tab_conges['solde']."&nbsp;(".$nb_jours_current_month[$id].")</td>";
-    					else
-    						echo "<td class=\"cal-user\">".$tab_conges['solde']."</td>";
-    				}
-    			}
-
-
-    			echo "\n</tr>\n";
-    		}
-
-    		echo "</table>\n\n";
+        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $session=session_id();
+        $nb_day = date('t', mktime(1,1,1,$mois,1,$year));
+        $return = '';
+
+        // recup du tableau des types de conges (seulement les conges)
+        $tab_type_cong=recup_tableau_types_conges($DEBUG);
+        if ($_SESSION['config']['gestion_conges_exceptionnels'])
+            $tab_type_cong_excep=recup_tableau_types_conges_exceptionnels($DEBUG);
+
+        /*****************************************/
+        /** Récupération des users à afficher:  **/
+
+        $tab_all_users    = \calendrier\Fonctions::recup_tableau_des_users_a_afficher($select_groupe,$DEBUG);
+
+
+        if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
+            $tab_logins = array_keys( $tab_all_users );
+            $tab_logins = array_map("\includes\SQL::quote", $tab_logins);
+        }
+        else {
+            $tab_logins = false;
+        }
+        /** FIN de Récupération des users à afficher:  **/
+        /************************************************/
+
+
+        /*************************/
+        /**  AFFICHAGE TABLEAU  **/
+
+        if($printable!=1) { // si version ecran :
+            $return .= '<table class="calendar table table-responsive table-bordered table-stripped">';
+        } else {               // si version imprimable :
+            $return .= '<table>';
+        }
+
+        $return .= '<tr><th colspan="2"></th><th colspan="' . $nb_day . '">' . _('divers_semaine') . '</th><th colspan="8">Solde</th></tr>';
+
+        /*************************************/
+        // affichage premiere ligne (semaines)
+        $return .= '<tr align="center">';
+
+        // affichage nom prenom quotité
+        $nb_colonnes=3;
+        $return .= '<th rowspan="2">Utilisateur</th>';
+        $return .= '<th rowspan="2">Quotité</th>';
+
+        // affichage des semaines
+        // ... du premier jour voulu à la fin du mois
+        for($j=$first_jour; checkdate($mois, $j, $year); $j++) {
+            $j_timestamp=mktime (0,0,0,$mois, $j, $year);
+            $j_num_semaine=date_fr("W", $j_timestamp);
+            // attention date_fr("w", $j_timestamp) renvoit 0 pour dimanche !
+            if(date_fr("w", $j_timestamp)==0) {
+                $j_num_jour_semaine=7;
+            } else {
+                $j_num_jour_semaine=date_fr("w", $j_timestamp);
+            }
+
+            //DEBUG : echo "<td class=\"cal-day\" >$j_num_jour_semaine / $j_num_semaine</td>";
+            if($j==$first_jour) {
+                $colspan = 8 - $j_num_jour_semaine;
+                $return .= '<th class="cal-day-first" colspan="' . $colspan . '" >' . $j_num_semaine . '</th>';
+            } else {
+                $month_rest = $nb_day - $j;
+                $colspan = 7;
+                if($month_rest < 6) {
+                    $colspan = $month_rest + 1;
+                }
+                // on affiche que les lundi
+                if($j_num_jour_semaine==1) {
+                    $return .= '<th class="cal-day" colspan="' . $colspan . '" >' . $j_num_semaine . '</th>';
+                }
+
+            }
+
+        }
+
+        // ... si le premier jour voulu n'etait pas le premier du mois, on va jusqu'à la meme date du mois suivant.
+        if($first_jour!=1) {
+            for($j=1; $j<$first_jour; $j++) {
+                if($mois==12) {
+                    $mois_select=1;
+                    $year_select=$year+1;
+                } else {
+                    $mois_select=$mois+1 ;
+                    $year_select=$year;
+                }
+
+                $j_timestamp=mktime (0,0,0,$mois_select, $j, $year_select);
+                $j_num_jour_semaine=date_fr("w", $j_timestamp);
+
+                $j_num_semaine=date_fr("W", $j_timestamp);
+                // attention date_fr("w", $j_timestamp) renvoit 0 pour dimanche !
+                if(date_fr("w", $j_timestamp)==0) {
+                    $j_num_jour_semaine=7;
+                } else {
+                    $j_num_jour_semaine=date_fr("w", $j_timestamp);
+                }
+
+                //DEBUG : echo "<td class=\"cal-day\" >$j_num_jour_semaine / $j_num_semaine</td>";
+                if($j==$first_jour) {
+                    $colspan=8-$j_num_jour_semaine;
+                    $return .= '<td class="cal-day-first" colspan="' . $colspan . '">' . $j_num_semaine . '</td>';
+                } else {
+                    // on affiche que les lundi
+                    if($j_num_jour_semaine==1) {
+                        $return .= '<td class="cal-day" colspan="7" >' . $j_num_semaine . '</td>';
+                    }
+                }
+            }
+        }
+
+        if( $_SESSION['config']['affiche_soldes_calendrier'] || is_resp($_SESSION['userlogin']) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) ) {
+            // affichage des libellé des conges
+            $abs_libelle = recup_tableau_tout_types_abs();
+
+            foreach($tab_type_cong as $id => $libelle) {
+                $return .= '<th rowspan="2">' . $abs_libelle[$id]['short_libelle'] . '</th>';
+                $nb_colonnes=$nb_colonnes+1;
+            }
+
+
+            if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                foreach($tab_type_cong_excep as $id => $libelle) {
+                    $return .= '<th rowspan="2">' . $abs_libelle[$id]['short_libelle'] . '</th>';
+                    $nb_colonnes=$nb_colonnes+1;
+                }
+            }
+        }
+
+        $return .= '</tr>';
+
+        /*************************************/
+        // affichage 2ieme ligne (dates)
+        $return .= '<tr>';
+
+        // on affiche pas car on a fait de "rowspan" à la ligne supérieure
+        // affichage d'une cellule vide sous les titres
+        //echo "    <td class=\"cal-user\" colspan=\"$nb_colonnes\">&nbsp;</td>\n";
+        //dernier jour = dimanche ?
+        $last = 7;
+
+
+        // affichage des dates
+        // ... du premier jour voulu à la fin du mois
+        for($j=$first_jour; checkdate($mois, $j, $year); $j++) {
+            $j_timestamp=mktime (0,0,0,$mois, $j, $year);
+            // $j_name=date_fr("D", $j_timestamp);
+            $j_name = substr(date_fr("D", $j_timestamp), 0, 1);
+            $last =date("N", $j_timestamp);
+            $j_date_fr=date_fr("d-m-Y", $j_timestamp);
+            $j_num_semaine=date_fr("W", $j_timestamp);
+            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+
+            // on affiche en gras le jour d'aujourd'hui
+            if($j_timestamp==$timestamp_today) {
+                $text_titre_date="<b>$j_name <br/>$j</b>";
+            } else {
+                $text_titre_date="$j_name <br/>$j";
+            }
+
+            // on regarde si c'est la premiere cellule ou non
+            if($j==$first_jour) {
+                $cal_day="cal-day-first";
+            } else {
+                $cal_day="cal-day";
+            }
+
+            // on affiche le titre -date (la date du jour)
+            $return .= '<td class="' . $cal_day . ' ' . $td_second_class . '" title="' . $j_date_fr . ' / ' . _('divers_semaine') . ' ' .  $j_num_semaine . '">' . $text_titre_date . '</td>';
+        }
+
+        // ... si le premier jour voulu n'etait pas le premier du mois, on va jusqu'à la meme date du mois suivant.
+        if($first_jour!=1) {
+            for($j=1; $j<$first_jour; $j++) {
+                if($mois==12) {
+                    $mois_select=1;
+                    $year_select=$year+1;
+                } else {
+                    $mois_select=$mois+1 ;
+                    $year_select=$year;
+                }
+
+                $j_timestamp=mktime (0,0,0,$mois_select, $j, $year_select);
+                $last =date("N", $j_timestamp);
+                // $j_name=date_fr("D", $j_timestamp);
+                $j_name = substr(date_fr("D", $j_timestamp), 0, 1);
+                $j_date_fr=date_fr("d-m-Y", $j_timestamp);
+                $j_num_semaine=date_fr("W", $j_timestamp);
+                $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+
+                // on affiche en gras le jour d'aujourd'hui
+                if($j_timestamp==$timestamp_today) {
+                    $return .= '<td class="cal-day ' . $td_second_class . '" title="' . $j_date_fr . ' / ' . _('divers_semaine') . ' ' . $j_num_semaine . '"><strong>' . $j_name . ' ' . $j . '</strong></td>';
+                    // echo "<td class=\"cal-day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\"><b>$j_name $j/$mois_select</b></td>";
+                } else {
+                    $return .= '<td class="cal-day ' . $td_second_class . '" title="' . $j_date_fr . ' / ' . _('divers_semaine') . ' ' . $j_num_semaine . '">' . $j_name . ' ' . $j . '</td>';
+                    // echo "<td class=\"cal-day $td_second_class\" title=\"$j_date_fr / ". _('divers_semaine') ." $j_num_semaine\">$j_name $j/$mois_select</td>";
+                }
+            }
+        }
+
+        // if ($last < 7)
+        // for ($i = $last; $i <7; $i ++)
+        //     echo '<td></td>';
+        // echo "</tr>\n";
+
+
+        /**************************************************/
+        /**************************************************/
+        /* recup des info de chaque jour pour tous les users et stockage dans 1 tableau de tableaux */
+
+        $tab_calendrier = \calendrier\Fonctions::recup_tableau_periodes($mois, $first_jour, $year,  $tab_logins);
+
+        /**************************************************/
+        /* recup des rtt de chaque jour pour tous les users et stockage dans 2 tableaux de tableaux */
+        /**************************************************/
+        //$tab_rtt_echange  //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
+        //il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
+        // qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
+        // jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
+        //$tab_rtt_planifiees=array();  //tableau indexé dont la clé est le login_user
+        // il contient pour chaque clé login : un tableau ($tab_user_grille) indexé dont la
+        // clé est la date_fin_grille.
+        // qui contient lui meme pour chaque clé : un tableau ($tab_user_rtt) qui contient enfin
+        // les infos pour le matin et l'après midi ('Y' si rtt, 'N' sinon) sur 2 semaines
+        // ( du sem_imp_lu_am au sem_p_ve_pm ) + la date de début et de fin de la grille
+
+
+        $tab_rtt_echange= recup_tableau_rtt_echange($mois, $first_jour, $year  , $tab_logins );
+        $tab_rtt_planifiees= recup_tableau_rtt_planifiees($mois, $first_jour, $year , $tab_logins);
+
+        $tab_cong_users = recup_tableau_conges_for_users(false, $tab_logins);
+
+        /**************************************************/
+        /**************************************************/
+        // affichage lignes suivantes (users)
+
+        // pour chaque user :
+        foreach($tab_all_users as $sql_login => $tab_current_user) {
+            $sql_nom=$tab_current_user["nom"];
+            $sql_prenom=$tab_current_user["prenom"];
+            $sql_quotite=$tab_current_user["quotite"];
+
+            // nb de jour pris dans le mois en cours (pour un type d'absence donné)
+            $nb_jours_current_month = array();
+
+            // recup dans un tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
+            $tab_cong_user = isset($tab_cong_users[$sql_login]) ? $tab_cong_users[$sql_login] : [];
+
+            if($printable==1) {
+                $return .= '<tr align="center" class="cal-ligne-user-edit">';
+            } elseif($selected==$sql_login) {
+                $return .= '<tr align="center" class="cal-ligne-user-selected">';
+            } else {
+                $return .= '<tr align="center" class="cal-ligne-user">';
+            }
+
+            if($printable==1) {
+                $text_nom="<strong>$sql_nom</strong>";
+            } else {
+                $text_nom="<a href=\"$PHP_SELF?session=$session&selected=$sql_login&year=$year&mois=$mois&first_jour=$first_jour&printable=$printable&select_groupe=$select_groupe\" method=\"GET\">$sql_nom $sql_prenom</a>";
+            }
+
+            // affichage nom prenom quotité
+            $return .= '<td class="cal-user">' . $text_nom . '</td><td class="cal-percent">' . $sql_quotite . '%</td>';
+
+
+            // pour chaque jour : (du premier jour demandé à la fin du mois ...)
+            for($j=$first_jour; checkdate($mois, $j, $year); $j++) {
+                $j_timestamp=mktime (0,0,0,$mois, $j, $year);
+                $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+
+                $mois_select=$mois;
+                $year_select=$year ;
+
+                // affichage de la cellule correspondant au jour et au user considéré
+                $t_nb_j_type_abs = \calendrier\Fonctions::affiche_cellule_jour_user($sql_login, $j_timestamp, $year, $mois_select, $j , $td_second_class, $printable, $tab_calendrier, $tab_rtt_echange, $tab_rtt_planifiees, $tab_type_absence, $return);
+                foreach($t_nb_j_type_abs as $id_type_abs => $nb_j_pris) {
+                    if (isset($nb_jours_current_month[ $id_type_abs ])) {
+                        $nb_jours_current_month[ $id_type_abs ] +=$nb_j_pris;
+                    } else {
+                        $nb_jours_current_month[ $id_type_abs ] =$nb_j_pris;
+                    }
+                }
+            }
+            // si le premier jour demandé n'est pas le 1ier du mois , on va jusqu'à la meme date le mois suivant :
+            if($first_jour!=1) {
+                // pour chaque jour jusqu'a la date voulue : (meme num de jour le mois suivant)
+                for($j=1; $j<$first_jour; $j++) {
+                    $j_timestamp=mktime (0,0,0,$mois+1, $j, $year);
+                    $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+
+                    if($mois==12) {
+                        $mois_select=1;
+                        $year_select=$year+1 ;
+                    } else  {
+                        $mois_select=$mois+1 ;
+                        $year_select=$year ;
+                    }
+
+                    // affichage de la cellule correspondant au jour et au user considéré
+                    $t_nb_j_type_abs = \calendrier\Fonctions::affiche_cellule_jour_user($sql_login, $j_timestamp, $year, $mois_select, $j, $td_second_class, $printable, $tab_calendrier, $tab_rtt_echange, $tab_rtt_planifiees, $tab_type_absence, $return);
+                    foreach($t_nb_j_type_abs as $id_type_abs => $nb_j_pris) {
+                        if (isset($nb_jours_current_month[ $id_type_abs ])) {
+                            $nb_jours_current_month[ $id_type_abs ] +=$nb_j_pris;
+                        } else {
+                            $nb_jours_current_month[ $id_type_abs ] =$nb_j_pris;
+                        }
+                    }
+                }
+            }
+
+
+            //if ($last < 7)
+            //for ($i = $last; $i <7; $i ++)
+            //    echo '<td></td>';
+
+            if( $_SESSION['config']['affiche_soldes_calendrier'] || is_resp($_SESSION['userlogin']) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) ) {
+                // affichage des divers soldes
+                foreach($tab_cong_user as $id => $tab_conges) {
+                    // si des jours ont été pris durant le mois affiché, on indique combien :
+                    if((isset($nb_jours_current_month[$id])) && ($_SESSION['config']['affiche_jours_current_month_calendrier']) ) {
+                        $return .= '<td class="cal-user">' . $tab_conges['solde'] . '&nbsp;(' . $nb_jours_current_month[$id] . ')</td>';
+                    } else {
+                        $return .= '<td class="cal-user">' . $tab_conges['solde'] . '</td>';
+                    }
+                }
+            }
+            $return .= '</tr>';
+        }
+        $return .= '</table>';
+        return $return;
     }
 
     /******************************/
@@ -998,40 +937,42 @@ class Fonctions
     /******************************/
     public static function affichage_boutons_defilement($first_jour, $mois, $year, $select_groupe, $DEBUG=FALSE)
     {
-    	$PHP_SELF=$_SERVER['PHP_SELF'];
-    	$session=session_id();
+        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $session=session_id();
+        $return = '';
 
-    		if($mois==12) $next_mois=1;  else $next_mois=$mois+1 ;
-    		if($mois==1) $prev_mois=12;  else $prev_mois=$mois-1 ;
+        if($mois==12) $next_mois=1;  else $next_mois=$mois+1 ;
+        if($mois==1) $prev_mois=12;  else $prev_mois=$mois-1 ;
 
-    		if($prev_mois==12) $prev_year=$year-1; else $prev_year=$year;
-    		if($next_mois==1) $next_year=$year+1; else $next_year=$year;
+        if($prev_mois==12) $prev_year=$year-1; else $prev_year=$year;
+        if($next_mois==1) $next_year=$year+1; else $next_year=$year;
 
-    		$prev_first_jour=date("j", \calendrier\Fonctions::jour_precedent($first_jour, $mois, $year))  ;
-    			$prev_first_jour_mois=date("n", \calendrier\Fonctions::jour_precedent($first_jour, $mois, $year))  ;
-    			$prev_first_jour_year=date("Y", \calendrier\Fonctions::jour_precedent($first_jour, $mois, $year))  ;
-    		$next_first_jour=date("j", \calendrier\Fonctions::jour_suivant($first_jour, $mois, $year)) ;
-    			$next_first_jour_mois=date("n", \calendrier\Fonctions::jour_suivant($first_jour, $mois, $year)) ;
-    			$next_first_jour_year=date("Y", \calendrier\Fonctions::jour_suivant($first_jour, $mois, $year)) ;
+        $prev_first_jour=date("j", \calendrier\Fonctions::jour_precedent($first_jour, $mois, $year))  ;
+        $prev_first_jour_mois=date("n", \calendrier\Fonctions::jour_precedent($first_jour, $mois, $year))  ;
+        $prev_first_jour_year=date("Y", \calendrier\Fonctions::jour_precedent($first_jour, $mois, $year))  ;
+        $next_first_jour=date("j", \calendrier\Fonctions::jour_suivant($first_jour, $mois, $year)) ;
+        $next_first_jour_mois=date("n", \calendrier\Fonctions::jour_suivant($first_jour, $mois, $year)) ;
+        $next_first_jour_year=date("Y", \calendrier\Fonctions::jour_suivant($first_jour, $mois, $year)) ;
 
-    		echo "<ul class=\"pager\">\n";
-    		echo "<li><a href=\"$PHP_SELF?session=$session&first_jour=1&mois=$prev_mois&year=$prev_year&select_groupe=$select_groupe\" method=\"POST\"><i class=\"fa fa-angle-double-left\"></i>&nbsp;". _('divers_mois_precedent_maj_1') ." </a></li>\n";
- 		echo "<li><a href=\"$PHP_SELF?session=$session&first_jour=$prev_first_jour&mois=$prev_first_jour_mois&year=$prev_first_jour_year&select_groupe=$select_groupe\" method=\"POST\"><i class=\"fa fa-angle-double-left\"></i>&nbsp;". _('calendrier_jour_precedent') ." </a></li>\n";
-    		echo "<li><a href=\"$PHP_SELF?session=$session&first_jour=$next_first_jour&mois=$next_first_jour_mois&year=$next_first_jour_year&select_groupe=$select_groupe\" method=\"POST\"> ". _('calendrier_jour_suivant') ."&nbsp;<i class=\"fa fa-angle-double-right\"></i></a></li>\n";
-   		echo "<li><a href=\"$PHP_SELF?session=$session&first_jour=1&mois=$next_mois&year=$next_year&select_groupe=$select_groupe\" method=\"POST\">". _('divers_mois_suivant_maj_1') ."&nbsp;<i class=\"fa fa-angle-double-right\"></i></a></li>\n";
-    		echo "</ul>\n";
+        $return .= '<ul class="pager">';
+        $return .= '<li><a href="' . $PHP_SELF . '?session=' . $session . '&first_jour=1&mois=' . $prev_mois . '&year=' . $prev_year . '&select_groupe=' . $select_groupe . '" method="POST"><i class="fa fa-angle-double-left"></i>&nbsp;' . _('divers_mois_precedent_maj_1') . ' </a></li>';
+        $return .= '<li><a href="' . $PHP_SELF . '?session=' . $session . '&first_jour=' . $prev_first_jour . '&mois=' . $prev_first_jour_mois . '&year=' . $prev_first_jour_year . '&select_groupe=' . $select_groupe . '" method="POST"><i class="fa fa-angle-double-left"></i>&nbsp;' . _('calendrier_jour_precedent') . '</a></li>';
+        $return .= '<li><a href="' . $PHP_SELF . '?session=' . $session . '&first_jour=' . $next_first_jour . '&mois=' . $next_first_jour_mois .  '&year=' . $next_first_jour_year . '&select_groupe=' . $select_groupe . '" method="POST">' . _('calendrier_jour_suivant') . '&nbsp;<i class="fa fa-angle-double-right"></i></a></li>';
+        $return .= '<li><a href="' . $PHP_SELF . '?session=' . $session . '&first_jour=1&mois=' . $next_mois . '&year=' . $next_year  . '&select_groupe=' . $select_groupe . '" method="POST">' . _('divers_mois_suivant_maj_1') . '&nbsp;<i class="fa fa-angle-double-right"></i></a></li>';
+        $return .= '</ul>';
+        return $return;
     }
 
     // retourne le timestamp calculé du jour suivant
     public static function jour_suivant($jour, $mois, $year)
     {
-    	return mktime (0,0,0,$mois,$jour +7,$year);
+        return mktime (0,0,0,$mois,$jour +7,$year);
     }
 
     // retourne le timestamp calculé du jour precedent
     public static function jour_precedent($jour, $mois, $year)
     {
-    	return mktime (0,0,0,$mois,$jour -7,$year);
+        return mktime (0,0,0,$mois,$jour -7,$year);
     }
 
     /**
@@ -1046,191 +987,183 @@ class Fonctions
      */
     public static function calendrierModule($session, $DEBUG = false)
     {
+        $return = '';
 
-        if(substr($session, 0, 9)!="phpconges")
-        {
-        	session_start();
-        	$_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
-        	if($_SESSION['config']['consult_calendrier_sans_auth']==FALSE)
-        	{
-        		redirect( ROOT_PATH . 'index.php' );
-        	}
+        if(substr($session, 0, 9)!="phpconges") {
+            session_start();
+            $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
+            if($_SESSION['config']['consult_calendrier_sans_auth']==FALSE) {
+                redirect( ROOT_PATH . 'index.php' );
+            }
         }
-        else
-        	include_once INCLUDE_PATH .'session.php';
+        else {
+            include_once INCLUDE_PATH .'session.php';
+        }
 
-        if( $DEBUG ) { echo "lang_file=".$_SESSION['config']['lang_file']."<br/>\n";  echo "_SESSION =<br/>\n"; print_r($_SESSION); echo "<br/><br/>\n"; }
+        if( $DEBUG ) {
+            $return .= 'lang_file=' . $_SESSION['config']['lang_file'] . '<br/>' . '_SESSION =<br/>' . var_export($_SESSION, true) . '<br/><br/>';
+        }
 
         $script = '<script language=javascript>
         function afficher(id)
         {
-        	el = document.getElementById(id);
-        	el.style.display = "block";
+            el = document.getElementById(id);
+            el.style.display = "block";
         }
 
         function cacher(id)
         {
-        	el = document.getElementById(id);
-        	el.style.display = "none";
+            el = document.getElementById(id);
+            el.style.display = "none";
         }
         </script>';
 
 
-        $add_css = NULL;
-        header_menu('', 'Libertempo : '._('calendrier_titre'), $add_css);
+        /*************************************/
+        // recup des parametres reçus :
+        // SERVER
+        $PHP_SELF=$_SERVER['PHP_SELF'];
+        // GET / POST
+        $selected      = getpost_variable('selected') ;
+        $printable     = getpost_variable('printable', 0) ;
+        $year          = getpost_variable('year', date("Y")) ;
+        $mois          = getpost_variable('mois', date("n")) ;
+        $first_jour    = getpost_variable('first_jour', 1) ;
+        //    $first_load    = getpost_variable('first_load', "Y") ;
+        $select_groupe = getpost_variable('select_groupe', 0) ;
 
 
-        	/*************************************/
-        	// recup des parametres reçus :
-        	// SERVER
-        	$PHP_SELF=$_SERVER['PHP_SELF'];
-        	// GET / POST
-        	$selected      = getpost_variable('selected') ;
-        	$printable     = getpost_variable('printable', 0) ;
-        	$year          = getpost_variable('year', date("Y")) ;
-        	$mois          = getpost_variable('mois', date("n")) ;
-        	$first_jour    = getpost_variable('first_jour', 1) ;
-        //	$first_load    = getpost_variable('first_load', "Y") ;
-        	$select_groupe = getpost_variable('select_groupe', 0) ;
+        /*************************************/
 
-
-        	/*************************************/
-
-        	// on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
-        	if(!isset($_SESSION["tab_j_feries"]))
-        	{
-        		init_tab_jours_feries();
-        		//print_r($_SESSION["tab_j_feries"]);   // verif DEBUG
-        	}
-
-        	// renvoit un tableau de tableau contenant les infos des types de conges et absences
-        	$tab_type_absence=recup_tableau_tout_types_abs($DEBUG);
-
-
-        //	echo "<hr align=\"center\" size=\"2\" width=\"90%\"> \n";
-
-        	$jour_today=date("j");
-        	$mois_today=date("m");
-        	$year_today=date("Y");
-        	$timestamp_today = mktime (0,0,0,$mois_today,$jour_today,$year_today);
-
-        	$mois_timestamp = mktime (0,0,0,$mois,1,$year);
-        	$nom_mois=date_fr("F", $mois_timestamp);
-
-        	$group_names =get_groups_name();
-
-        	// AFFICHAGE PAGE
-        	echo "<div id=\"main-calendar\" class=\"main-content\">\n";
-        	if( ($_SESSION['config']['gestion_groupes']) && ($printable!=1) )  // si gestion des groupes active et pas version imprimable
-        	{
-        	// affiche le select des groupes du user OU les groupes du resp (si user est resp) OU tous les groupes (si option de config ok)
-        		echo "<div class=\"pull-right\">\n";
-        		\calendrier\Fonctions::affiche_select_groupe($select_groupe, $selected, $printable, $year, $mois, $first_jour, $group_names) ;
-        		echo "</div>\n";
-        	}
-
-        	echo "   <h1>". _('calendrier_titre') . "</h1>\n";
-        	if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
-        		echo "<h2>". _('divers_groupe') ." : <strong>".$group_names[ $select_groupe ]."</strong></h2>\n";
-
-        	}
-
-        	echo "<hr/>\n";
-        	echo "<h3 class=\"current-month\">$nom_mois $year</h3>\n";
-        	echo "<hr/>\n";
-
-        	/**********************/
-        	/* Boutons de defilement */
-        	if($printable!=1)   // si version ecran :
-        	{
-        		\calendrier\Fonctions::affichage_boutons_defilement($first_jour, $mois, $year, $select_groupe, $DEBUG) ;
-        	}
-
-
-        	/***********************************/
-        	/* AFFICHAGE  TABLEAU (CALENDRIER) */
-        	\calendrier\Fonctions::affichage_calendrier($year, $mois, $first_jour, $timestamp_today, $printable, $selected, $tab_type_absence, $select_groupe, $DEBUG);
-
-
-        	/**********************/
-        	/* Boutons de defilement */
-        	if($printable!=1)   // si version ecran :
-        	{
-        		echo "<tr>\n";
-        		echo "   <td align=\"center\">\n";
-        		\calendrier\Fonctions::affichage_boutons_defilement($first_jour, $mois, $year, $select_groupe, $DEBUG) ;
-        		echo "   </td>\n";
-        		echo "</tr>\n";
-        	}
-
-        	echo "<tr>\n";
-        	echo "</tr>\n";
-        	echo "</table>\n";
-
-        	if($printable!=1) // si version ecran :
-        		{
-        			echo "      <br/><a href=\"$PHP_SELF?session=$session&printable=1&year=$year&mois=$mois&first_jour=$first_jour&select_groupe=$select_groupe\" target=\"_blank\" method=\"post\">\n";
-        			echo "<i class=\"fa fa-print\"></i>\n";
-        			echo "      ". _('calendrier_imprimable') ."\n";
-        			echo "      </a>\n";
-				echo "      <br><a href=\"calendrier-pdf.php?session=$session&printable=1&year=$year&mois=$mois&first_jour=$first_jour&select_groupe=$select_groupe\" target=\"_blank\" method=\"post\">\n";
-				echo "		<img src=\"". TEMPLATE_PATH . "img/pdf_22x22_2.png\" width=\"22\" height=\"22\" border=\"0\" title=\"Version PDF\">\n";
-				echo "      PDF\n";
-				echo "      </a>\n";
-
-
-        		}
-
-        	echo "      <br><br><table cellpadding=\"1\" class=\"calendar table-responsive table-bordered table-stripped\">\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#FFFFFF\" class=\"cal-legende\"> - </td>\n" ;
-        	echo "         <td class=\"cal-legende\"> </td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#DCDCDC\" class=\"cal-legende\"> - </td>\n" ;
-        	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_we') ."</td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#8addf2\" class=\"cal-legende\">abs</td>\n" ;
-        	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_conges') ."</td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#ffc1ff\" class=\"cal-legende\">abs</td>\n" ;
-        	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_demande') ."</td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#ffffad\" class=\"cal-legende\"> - </td>\n" ;
-        	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_part_time') ."</td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#C3C3C3\" class=\"cal-legende\">abs</td>\n" ;
-        	echo "         <td class=\"cal-legende\"> ". _('calendrier_legende_abs') ."</td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      <tr align=\"center\">\n" ;
-        	echo "         <td bgcolor=\"#CEB6FF\" class=\"cal-legende\">abs</td>\n" ;
-        	echo "         <td class=\"cal-legende\"> ". _('divers_fermeture') ."</td>\n" ;
-        	echo "      </tr>\n" ;
-        	echo "      </table>\n" ;
-        	echo "</div>";
-        	/********************/
-        	/* bouton retour */
-        	/********************/
-        	if($printable==1)   // si version imprimable :
-        	{
-        	// appel de la fenetre d'impression directe
-        ?>
-        <script type="text/javascript" language="javascript1.2">
-        <!--
-        // Do print the page
-        if (typeof(window.print) != 'undefined') {
-            window.print();
+        // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
+        if(!isset($_SESSION["tab_j_feries"])) {
+            init_tab_jours_feries();
+            //print_r($_SESSION["tab_j_feries"]);   // verif DEBUG
         }
-        //-->
-        </script>
-        <?php
-        	}
 
-        	bottom();
+        // renvoit un tableau de tableau contenant les infos des types de conges et absences
+        $tab_type_absence=recup_tableau_tout_types_abs($DEBUG);
 
+        //    echo "<hr align=\"center\" size=\"2\" width=\"90%\"> \n";
+
+        $jour_today=date("j");
+        $mois_today=date("m");
+        $year_today=date("Y");
+        $timestamp_today = mktime (0,0,0,$mois_today,$jour_today,$year_today);
+
+        $mois_timestamp = mktime (0,0,0,$mois,1,$year);
+        $nom_mois=date_fr("F", $mois_timestamp);
+
+        $group_names =get_groups_name();
+
+        // AFFICHAGE PAGE
+        $return .= '<div id="main-calendar" class="main-content">';
+        if( ($_SESSION['config']['gestion_groupes']) && ($printable!=1) )  // si gestion des groupes active et pas version imprimable
+        {
+            // affiche le select des groupes du user OU les groupes du resp (si user est resp) OU tous les groupes (si option de config ok)
+            $return .= '<div class="pull-right">';
+            $return .= \calendrier\Fonctions::affiche_select_groupe($select_groupe, $selected, $printable, $year, $mois, $first_jour, $group_names) ;
+            $return .= '</div>';
+        }
+
+        $return .= '<h1>' . _('calendrier_titre') . '</h1>';
+        if( ($_SESSION['config']['gestion_groupes']) && ($select_groupe!=0) ) {
+            $return .= '<h2>' . _('divers_groupe') . ' : <strong>' . $group_names[$select_groupe] . '</strong></h2>';
+
+        }
+
+        $return .= '<hr/>';
+        $return .= '<h3 class="current-month">' . $nom_mois . ' ' . $year . '</h3>';
+        $return .= '<hr/>';
+
+        /**********************/
+        /* Boutons de defilement */
+        if($printable!=1)   // si version ecran :
+        {
+            $return .= \calendrier\Fonctions::affichage_boutons_defilement($first_jour, $mois, $year, $select_groupe, $DEBUG) ;
+        }
+
+
+        /***********************************/
+        /* AFFICHAGE  TABLEAU (CALENDRIER) */
+        $return .= \calendrier\Fonctions::affichage_calendrier($year, $mois, $first_jour, $timestamp_today, $printable, $selected, $tab_type_absence, $select_groupe, $DEBUG);
+
+
+        /**********************/
+        /* Boutons de defilement */
+        if($printable!=1)   // si version ecran :
+        {
+            $return .= '<tr>';
+            $return .= '<td align="center">';
+            $return .= \calendrier\Fonctions::affichage_boutons_defilement($first_jour, $mois, $year, $select_groupe, $DEBUG) ;
+            $return .= '</td>';
+            $return .= '</tr>';
+        }
+
+        $return .= '<tr>';
+        $return .= '</tr>';
+        $return .= '</table>';
+
+        if($printable!=1) // si version ecran :
+        {
+            $return .= '<br/><a href="' . $PHP_SELF . '?session=' . $session . '&printable=1&year=' . $year . '&mois=' . $mois . '&first_jour=' . $first_jour . '&select_groupe=' . $select_groupe . '" target="_blank" method="post">';
+            $return .= '<i class="fa fa-print"></i>';
+            $return .= _('calendrier_imprimable');
+            $return .= '</a>';
+            $return .= '<br><a href="calendrier-pdf.php?session=' . $session . '&printable=1&year=' . $year . '&mois=' . $mois . '&first_jour=' . $first_jour . '&select_groupe=' . $select_groupe . '" target="_blank" method="post">';
+            $return .= '<img src="' . TEMPLATE_PATH . 'img/pdf_22x22_2.png" width="22" height="22" border="0" title="Version PDF">';
+            $return .= 'PDF';
+            $return .= '</a>';
+        }
+
+        $return .= '<br><br><table cellpadding="1" class="calendar table-responsive table-bordered table-stripped">';
+        $return .= '<tr align="center">';
+        $return .= '<td bgcolor="#FFFFFF" class="cal-legende"> - </td>';
+        $return .= '<td class="cal-legende"> </td>';
+        $return .= '</tr>';
+        $return .= '<tr align="center">';
+        $return .= '<td bgcolor="#DCDCDC" class="cal-legende"> - </td>';
+        $return .= '<td class="cal-legende">' . _('calendrier_legende_we') . '</td>' ;
+        $return .= '</tr>' ;
+        $return .= '<tr align="center">';
+        $return .= '<td bgcolor="#8addf2" class="cal-legende">abs</td>';
+        $return .= '<td class="cal-legende">' . _('calendrier_legende_conges') . '</td>';
+        $return .= '</tr>' ;
+        $return .= '<tr align="center">' ;
+        $return .= '<td bgcolor="#ffc1ff" class="cal-legende">abs</td>';
+        $return .= '<td class="cal-legende">' . _('calendrier_legende_demande') . '</td>';
+        $return .= '</tr>';
+        $return .= '<tr align="center">';
+        $return .= '<td bgcolor="#ffffad" class="cal-legende"> - </td>';
+        $return .= '<td class="cal-legende">' . _('calendrier_legende_part_time') . '</td>';
+        $return .= '</tr>';
+        $return .= '<tr align="center">';
+        $return .= '<td bgcolor="#C3C3C3" class="cal-legende">abs</td>';
+        $return .= '<td class="cal-legende">' . _('calendrier_legende_abs') . '</td>';
+        $return .= '</tr>';
+        $return .= '<tr align="center">';
+        $return .= '<td bgcolor="#CEB6FF" class="cal-legende">abs</td>';
+        $return .= '<td class="cal-legende">' . _('divers_fermeture') . '</td>' ;
+        $return .= '</tr>';
+        $return .= '</table>';
+        $return .= '</div>';
+        /********************/
+        /* bouton retour */
+        /********************/
+        if($printable==1)   // si version imprimable :
+        {
+            // appel de la fenetre d'impression directe
+            ?>
+            <script type="text/javascript" language="javascript1.2">
+            <!--
+            // Do print the page
+            if (typeof(window.print) != 'undefined') {
+                window.print();
+            }
+            //-->
+            </script>
+            <?php
+        }
+        return $return;
     }
 }

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -46,29 +46,28 @@ class Fonctions
 
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         // recup de la liste des users d'un groupe donné
         $list_users = get_list_users_du_groupe($choix_groupe,  $DEBUG);
 
-        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours)
-        {
-            if($nb_jours!=0)
-            {
+        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
+            if($nb_jours!=0) {
                 $comment = $tab_new_comment_all[$id_conges];
 
                 $sql1="SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users) ORDER BY u_login ";
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                while ($resultat1 = $ReqLog1->fetch_array())
-                {
+                while ($resultat1 = $ReqLog1->fetch_array()) {
                     $current_login  =$resultat1["u_login"];
                     $current_quotite=$resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                         $nb_conges=$nb_jours;
-                    else
+                    } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
                         $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                    }
                     $nb_conges_ok = verif_saisie_decimal($nb_conges, $DEBUG);
                     if($nb_conges_ok){
                         // 1 : on update conges_solde_user
@@ -89,32 +88,32 @@ class Fonctions
 
                 $group_name = get_group_name_from_id($choix_groupe,  $DEBUG);
                 // 3 : Enregistrement du commentaire relatif à l'ajout de jours de congés
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
-                else
+                } else {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
+                }
                 log_action(0, "ajout", "groupe", $comment_log,  $DEBUG);
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo " ". _('form_modif_ok') ." <br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= ' ' . _('form_modif_ok') . '<br><br>';
             redirect( ROOT_PATH .'responsable/resp_index.php?session=' . $session );
         }
+        return $return;
     }
 
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         // $tab_new_nb_conges_all[$id_conges]= nb_jours
         // $tab_calcul_proportionnel[$id_conges]= TRUE / FALSE
@@ -123,34 +122,37 @@ class Fonctions
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $list_users_du_resp = get_list_all_users_du_resp($_SESSION['userlogin'],  $DEBUG);
-        if( $DEBUG ) { echo "list_all_users_du_resp = $list_users_du_resp<br>\n";}
+        if( $DEBUG ) {
+            $return .= 'list_all_users_du_resp = ' . $list_users_du_resp . '<br>';
+        }
 
-        if( $DEBUG ) { echo "tab_new_nb_conges_all = <br>"; print_r($tab_new_nb_conges_all); echo "<br>\n" ;}
-        if( $DEBUG ) { echo "tab_calcul_proportionnel = <br>"; print_r($tab_calcul_proportionnel); echo "<br>\n" ;}
+        if( $DEBUG ) {
+            $return .= 'tab_new_nb_conges_all = <br>' . var_export($tab_new_nb_conges_all, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_calcul_proportionnel = <br>' . var_export($tab_calcul_proportionnel, true) . '<br>';
+        }
 
-        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours)
-        {
-            if($nb_jours!=0)
-            {
+        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
+            if($nb_jours!=0) {
                 $comment = $tab_new_comment_all[$id_conges];
 
                 $sql1="SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users_du_resp) ORDER BY u_login ";
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                while($resultat1 = $ReqLog1->fetch_array())
-                {
+                while($resultat1 = $ReqLog1->fetch_array()) {
                     $current_login  =$resultat1["u_login"];
                     $current_quotite=$resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                         $nb_conges=$nb_jours;
-                    else
+                    } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
                         $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                    }
 
                     $nb_conges_ok = verif_saisie_decimal($nb_conges, $DEBUG);
-                    if ($nb_conges_ok)
-                    {
+                    if ($nb_conges_ok) {
                         // 1 : update de la table conges_solde_user
                         $req_update = "UPDATE conges_solde_user SET su_solde = su_solde+$nb_conges
                             WHERE  su_login = '$current_login' AND su_abs_id = $id_conges   ";
@@ -163,46 +165,45 @@ class Fonctions
                     }
                 }
                 // 3 : Enregistrement du commentaire relatif à l'ajout de jours de congés
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) )
+                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
-                else
+                } else {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
+                }
                 log_action(0, "ajout", "tous", $comment_log,  $DEBUG);
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo " ". _('form_modif_ok') ." <br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= ' ' . _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
             redirect( ROOT_PATH .'responsable/resp_index.php?session=' . $session );
         }
+        return $return;
     }
 
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         foreach($tab_champ_saisie as $user_name => $tab_conges)   // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
         {
-            foreach($tab_conges as $id_conges => $user_nb_jours_ajout)
-            {
+            foreach($tab_conges as $id_conges => $user_nb_jours_ajout) {
                 $user_nb_jours_ajout_float =(float) $user_nb_jours_ajout ;
                 $valid=verif_saisie_decimal($user_nb_jours_ajout_float, $DEBUG);   //verif la bonne saisie du nombre décimal
-                if($valid)
-                {
-                    if( $DEBUG ) {echo "$user_name --- $id_conges --- $user_nb_jours_ajout_float<br>\n";}
+                if($valid) {
+                    if( $DEBUG ) {
+                        $return .= $user_name . '---' . $id_conges . '---' . $user_nb_jours_ajout_float . '<br>';
+                    }
 
-                    if($user_nb_jours_ajout_float!=0)
-                    {
+                    if($user_nb_jours_ajout_float!=0) {
                         /* Modification de la table conges_users */
                         $sql1 = "UPDATE conges_solde_user SET su_solde = su_solde+$user_nb_jours_ajout_float WHERE su_login='$user_name' AND su_abs_id = $id_conges " ;
                         /* On valide l'UPDATE dans la table ! */
@@ -222,176 +223,172 @@ class Fonctions
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo " ". _('form_modif_ok') ." <br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= ' '. _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '">';
         }
+        return $return;
     }
 
     public static function affichage_saisie_globale_groupe($tab_type_conges,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
 
         // on établi la liste complète des groupes dont on est le resp (ou le grd resp)
         $list_group_resp=get_list_groupes_du_resp($_SESSION['userlogin']);
-        if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) )
+        if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
             $list_group_grd_resp=get_list_groupes_du_grand_resp($_SESSION['userlogin'],  $DEBUG);
-        else
+        } else {
             $list_group_grd_resp="";
+        }
 
         $list_group="";
-        if($list_group_resp!="")
-        {
+        if($list_group_resp!="") {
             $list_group = $list_group_resp;
-            if($list_group_grd_resp!="")
+            if($list_group_grd_resp!="") {
                 $list_group = $list_group.",".$list_group_grd_resp;
-        }
-        else
-        {
-            if($list_group_grd_resp!="")
+            }
+        } else {
+            if($list_group_grd_resp!="") {
                 $list_group = $list_group_grd_resp;
+            }
         }
 
 
         if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
-            echo "<h2>". _('resp_ajout_conges_ajout_groupe') ."</h2>\n";
-            echo "<form action=\"$PHP_SELF?session=$session&onglet=ajout_conges\" method=\"POST\"> \n";
-            echo "	<fieldset class=\"cal_saisie\">\n";
-            echo "<div class=\"table-responsive\"><table class=\"table table-hover table-condensed table-striped\">\n";
-            echo "	<tr>\n";
-            echo "		<td class=\"big\">". _('resp_ajout_conges_choix_groupe') ." : </td>\n";
+            $return .= '<h2>' . _('resp_ajout_conges_ajout_groupe') . '</h2>';
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+            $return .= '<fieldset class="cal_saisie">';
+            $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
+            $return .= '<tr>';
+            $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') . ' : </td>';
             // création du select pour le choix du groupe
             $text_choix_group="<select name=\"choix_groupe\" >";
             $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
             $ReqLog_group = \includes\SQL::query($sql_group) ;
 
-            while ($resultat_group = $ReqLog_group->fetch_array())
-            {
+            while ($resultat_group = $ReqLog_group->fetch_array()) {
                 $current_group_id=$resultat_group["g_gid"];
                 $current_group_name=$resultat_group["g_groupename"];
                 $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
             }
             $text_choix_group=$text_choix_group."</select>" ;
 
-            echo "		<td colspan=\"3\">$text_choix_group</td>\n";
-            echo "	</tr>\n";
-            echo "<tr>\n";
-            echo "<th colspan=\"2\">" . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . "</th>\n";
-            echo "<th>" ._('resp_ajout_conges_calcul_prop') . "</th>\n";
-            echo "<th>" . _('divers_comment_maj_1') . "</th>\n";
-            echo "</tr>\n";
-            foreach($tab_type_conges as $id_conges => $libelle)
-            {
-                echo "	<tr>\n";
-                echo "		<td><strong>$libelle<strong></td>\n";
-                echo "		<td><input class=\"form-control\" type=\"text\" name=\"tab_new_nb_conges_all[$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\"></td>\n";
-                echo "		<td>". _('resp_ajout_conges_oui') ." <input type=\"checkbox\" name=\"tab_calcul_proportionnel[$id_conges]\" value=\"TRUE\" checked></td>\n";
-                echo "		<td><input class=\"form-control\" type=\"text\" name=\"tab_new_comment_all[$id_conges]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-                echo "	</tr>\n";
+            $return .= '<td colspan="3">' . $text_choix_group . '</td>';
+            $return .= '</tr>';
+            $return .= '<tr>';
+            $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
+            $return .= '<th>' ._('resp_ajout_conges_calcul_prop') . '</th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+            $return .= '</tr>';
+            foreach($tab_type_conges as $id_conges => $libelle) {
+                $return .= '<tr>';
+                $return .= '<td><strong>' . $libelle . '<strong></td>';
+                $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
+                $return .= '<td>' . _('resp_ajout_conges_oui') . '<input type="checkbox" name="tab_calcul_proportionnel[' . $id_conges . ']" value="TRUE" checked></td>';
+                $return .= '<td><input class="form-control" type="text" name="tab_new_comment_all[' . $id_conges . ']" size="30" maxlength="200" value=""></td>';
+                $return .= '</tr>';
             }
-            echo "	</table></div>\n";
-            echo "<p>" . _('resp_ajout_conges_calcul_prop_arondi') . "! </p>\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_valid_groupe') ."\">\n";
-            echo "	</fieldset>\n";
-            echo "<input type=\"hidden\" name=\"ajout_groupe\" value=\"TRUE\">\n";
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "</form> \n";
+            $return .= '</table></div>';
+            $return .= '<p>' . _('resp_ajout_conges_calcul_prop_arondi') . '! </p>';
+            $return .= '<input class="btn" type="submit" value="' . _('form_valid_groupe') . '">';
+            $return .= '</fieldset>';
+            $return .= '<input type="hidden" name="ajout_groupe" value="TRUE">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '</form>';
         }
+        return $return;
     }
 
     public static function affichage_saisie_globale_pour_tous($tab_type_conges,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /************************************************************/
         /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
-        echo "<h2>". _('resp_ajout_conges_ajout_all') ."</h2>\n";
-        echo "<form action=\"$PHP_SELF?session=$session&onglet=ajout_conges\" method=\"POST\"> \n";
-        echo "	<fieldset class=\"cal_saisie\">\n";
-        echo "<div class=\"table-responsive\"><table class=\"table table-hover table-condensed table-striped\">\n";
-        echo "<thead>\n";
-        echo "<tr>\n";
-        echo "<th colspan=\"2\">" . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . "</th>\n";
-        echo "<th>" ._('resp_ajout_conges_calcul_prop') . "</th>\n";
-        echo "<th>" . _('divers_comment_maj_1') . "</th>\n";
-        echo "</tr>\n";
-        echo "</thead>\n";
-        foreach($tab_type_conges as $id_conges => $libelle)
-        {
-            echo "	<tr>\n";
-            echo "		<td><strong>$libelle<strong></td>\n";
-            echo "		<td><input class=\"form-control\" type=\"text\" name=\"tab_new_nb_conges_all[$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\"></td>\n";
-            echo "		<td>". _('resp_ajout_conges_oui') ." <input type=\"checkbox\" name=\"tab_calcul_proportionnel[$id_conges]\" value=\"TRUE\" checked></td>\n";
-            echo "		<td><input class=\"form-control\" type=\"text\" name=\"tab_new_comment_all[$id_conges]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-            echo "	</tr>\n";
+        $return .= '<h2>' . _('resp_ajout_conges_ajout_all') . '</h2>';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+        $return .= '<fieldset class="cal_saisie">';
+        $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
+        $return .= '<thead>';
+        $return .= '<tr>';
+        $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
+        $return .= '<th>' ._('resp_ajout_conges_calcul_prop') . '</th>';
+        $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+        $return .= '</tr>';
+        $return .= '</thead>';
+        foreach($tab_type_conges as $id_conges => $libelle) {
+            $return .= '<tr>';
+            $return .= '<td><strong>' . $libelle . '<strong></td>';
+            $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
+            $return .= '<td>' . _('resp_ajout_conges_oui') . '<input type="checkbox" name="tab_calcul_proportionnel[' . $id_conges . ']" value="TRUE" checked></td>';
+            $return .= '<td><input class="form-control" type="text" name="tab_new_comment_all[' . $id_conges . ']" size="30" maxlength="200" value=""></td>';
+            $return .= '</tr>';
         }
-        echo "</table></div>\n";
+        $return .= '</table></div>';
         // texte sur l'arrondi du calcul proportionnel
-        echo "<p>" . _('resp_ajout_conges_calcul_prop_arondi') . "!</p>\n";
+        $return .= '<p>' . _('resp_ajout_conges_calcul_prop_arondi') . '!</p>';
         // bouton valider
-        echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_valid_global') ."\">\n";
-        echo "</fieldset>\n";
-        echo "<input type=\"hidden\" name=\"ajout_global\" value=\"TRUE\">\n";
-        echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-        echo "</form> \n";
+        $return .= '<input class="btn" type="submit" value="' . _('form_valid_global') . '">';
+        $return .= '</fieldset>';
+        $return .= '<input type="hidden" name="ajout_global" value="TRUE">';
+        $return .= '<input type="hidden" name="session" value="' . $session . '">';
+        $return .= '</form>';
+        return $return;
     }
 
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_resp, $tab_all_users_du_grand_resp,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /************************************************************/
         /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
-        echo "<h2>Ajout par utilisateur</h2>\n";
-        echo " <form action=\"$PHP_SELF?session=$session&onglet=ajout_conges\" method=\"POST\"> \n";
+        $return .= '<h2>Ajout par utilisateur</h2>';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
 
         // Récupération des informations
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est responsable
         //$tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
         //$tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) )
-        {
+        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             // AFFICHAGE TITRES TABLEAU
-            echo "<div class=\"table-responsive\"><table class=\"table table-hover table-condensed table-striped\">\n";
-            echo "<thead>\n";
-            echo "<tr align=\"center\">\n";
-            echo "<th>". _('divers_nom_maj_1') ."</th>\n";
-            echo "<th>". _('divers_prenom_maj_1') ."</th>\n";
-            echo "<th>". _('divers_quotite_maj_1') ."</td>\n";
-            foreach($tab_type_conges as $id_conges => $libelle)
-            {
-                echo "<th>$libelle<br><i>(". _('divers_solde') .")</i></th>\n";
-                echo "<th>$libelle<br>". _('resp_ajout_conges_nb_jours_ajout') ."</th>\n" ;
+            $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
+            $return .= '<thead>';
+            $return .= '<tr align="center">';
+            $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_quotite_maj_1') . '</td>';
+            foreach($tab_type_conges as $id_conges => $libelle) {
+                $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
+                $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
             }
-            if ($_SESSION['config']['gestion_conges_exceptionnels'])
-            {
-                foreach($tab_type_conges_exceptionnels as $id_conges => $libelle)
-                {
-                    echo "<th>$libelle<br><i>(". _('divers_solde') .")</i></th>\n";
-                    echo "<th>$libelle<br>". _('resp_ajout_conges_nb_jours_ajout') ."</th>\n" ;
+            if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                    $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
+                    $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
                 }
             }
-            echo "<th>". _('divers_comment_maj_1') ."<br></th>\n" ;
-            echo"</tr>\n";
-            echo "</thead>\n";
-            echo "<tbody>\n";
+            $return .= '<th>' . _('divers_comment_maj_1') . '<br></th>';
+            $return .= '</tr>';
+            $return .= '</thead>';
+            $return .= '<tbody>';
 
             // AFFICHAGE LIGNES TABLEAU
             $cpt_lignes=0 ;
@@ -399,140 +396,134 @@ class Fonctions
 
             $i = true;
             // affichage des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user)
-            {
-                echo '<tr class="'.($i?'i':'p').'">';
+            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+                $return .= '<tr class="'.($i?'i':'p').'">';
                 //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
                 $tab_conges=$tab_current_user['conges'];
 
                 /** sur la ligne ,   **/
-                echo "<td>".$tab_current_user['nom']."</td>\n";
-                echo "<td>".$tab_current_user['prenom']."</td>\n";
-                echo "<td>".$tab_current_user['quotite']."%</td>\n";
+                $return .= '<td>' . $tab_current_user['nom'] . '</td>';
+                $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
+                $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-                foreach($tab_type_conges as $id_conges => $libelle)
-                {
+                foreach($tab_type_conges as $id_conges => $libelle) {
                     /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
                     $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
-                    echo "<td>".$tab_conges[$libelle]['nb_an']." <i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
-                    echo "<td align=\"center\" class=\"histo\">$champ_saisie_conges</td>\n" ;
+                    $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
+                    $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                 }
-                if ($_SESSION['config']['gestion_conges_exceptionnels'])
-                {
-                    foreach($tab_type_conges_exceptionnels as $id_conges => $libelle)
-                    {
+                if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                    foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                         /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
                         $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
-                        echo "<td><i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
-                        echo "<td align=\"center\" class=\"histo\">$champ_saisie_conges</td>\n" ;
+                        $return .= '<td><i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
+                        $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                     }
                 }
-                echo "<td align=\"center\" class=\"histo\"><input class=\"form-control\" type=\"text\" name=\"tab_commentaire_saisie[$current_login]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-                echo "</tr>\n";
+                $return .= '<td align="center" class="histo"><input class="form-control" type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="30" maxlength="200" value=""></td>';
+                $return .= '</tr>';
                 $cpt_lignes++ ;
                 $i = !$i;
             }
 
             // affichage des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) )
-            {
+            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
                 $nb_colspan=50;
-                echo "<tr align=\"center\"><td class=\"histo\" style=\"background-color: #CCC;\" colspan=\"$nb_colspan\"><i>". _('resp_etat_users_titre_double_valid') ."</i></td></tr>\n";
+                $return .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="' . $nb_colspan . '"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
 
                 $i = true;
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user)
-                {
-                    echo '<tr class="'.($i?'i':'p').'">';
+                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+                    $return .= '<tr class="'.($i?'i':'p').'">';
                     //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
                     $tab_conges=$tab_current_user['conges'];
 
                     /** sur la ligne ,   **/
-                    echo "<td>".$tab_current_user['nom']."</td>\n";
-                    echo "<td>".$tab_current_user['prenom']."</td>\n";
-                    echo "<td>".$tab_current_user['quotite']."%</td>\n";
+                    $return .= '<td>' . $tab_current_user['nom'] . '</td>';
+                    $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
+                    $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-                    foreach($tab_type_conges as $id_conges => $libelle)
-                    {
+                    foreach($tab_type_conges as $id_conges => $libelle) {
                         /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
                         $champ_saisie_conges="<input type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
-                        echo "<td>".$tab_conges[$libelle]['nb_an']." <i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
-                        echo "<td align=\"center\" class=\"histo\">$champ_saisie_conges</td>\n" ;
+                        $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
+                        $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                     }
-                    if ($_SESSION['config']['gestion_conges_exceptionnels'])
-                    {
-                        foreach($tab_type_conges_exceptionnels as $id_conges => $libelle)
-                        {
+                    if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                        foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                             /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
                             $champ_saisie_conges="<input type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
-                            echo "<td><i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
-                            echo "<td align=\"center\" class=\"histo\">$champ_saisie_conges</td>\n" ;
+                            $return .= '<td><i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
+                            $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                         }
                     }
-                    echo "<td align=\"center\" class=\"histo\"><input type=\"text\" name=\"tab_commentaire_saisie[$current_login]\" size=\"30\" maxlength=\"200\" value=\"\"></td>\n";
-                    echo "</tr>\n";
+                    $return .= '<td align="center" class="histo"><input type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="30" maxlength="200" value=""></td>';
+                    $return .= '</tr>';
                     $cpt_lignes++ ;
                     $i = !$i;
                 }
             }
 
-            echo "</tbody>\n";
-            echo "</table></div>\n\n";
+            $return .= '</tbody>';
+            $return .= '</table></div>';
 
-            echo "<input type=\"hidden\" name=\"ajout_conges\" value=\"TRUE\">\n";
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_submit') ."\">\n";
-            echo " </form> \n";
+            $return .= '<input type="hidden" name="ajout_conges" value="TRUE">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
+            $return .= ' </form>';
         }
+        return $return;
     }
 
     public static function saisie_ajout( $tab_type_conges,  $DEBUG)
     {
-
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         // recup du tableau des types de conges (seulement les congesexceptionnels )
-        if ($_SESSION['config']['gestion_conges_exceptionnels'])
-        {
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
             $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
-            if( $DEBUG ) { echo "tab_type_conges_exceptionnels = "; print_r($tab_type_conges_exceptionnels); echo "<br><br>\n";}
-        }
-        else
+            if( $DEBUG ) {
+                $return .= 'tab_type_conges_exceptionnels = ' . var_export($tab_type_conges_exceptionnels, true) . '<br><br>';
+            }
+        } else {
             $tab_type_conges_exceptionnels = array();
+        }
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
         $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( $DEBUG ) { echo "tab_all_users_du_resp =<br>\n"; print_r($tab_all_users_du_resp); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_all_users_du_grand_resp =<br>\n"; print_r($tab_all_users_du_grand_resp); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_resp =<br>' . var_export($tab_all_users_du_resp, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_grand_resp =<br>' . var_export($tab_all_users_du_grand_resp, true) . '<br>';
+        }
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) )
-        {
+        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
-            \responsable\Fonctions::affichage_saisie_globale_pour_tous($tab_type_conges,  $DEBUG);
-            echo "<br>\n";
+            $return .= \responsable\Fonctions::affichage_saisie_globale_pour_tous($tab_type_conges,  $DEBUG);
+            $return .= '<br>';
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes'] )
-            {
-                \responsable\Fonctions::affichage_saisie_globale_groupe($tab_type_conges,  $DEBUG);
+            if( $_SESSION['config']['gestion_groupes'] ) {
+                $return .= \responsable\Fonctions::affichage_saisie_globale_groupe($tab_type_conges,  $DEBUG);
             }
 
-            echo "<hr/>\n";
+            $return .= '<hr/>';
 
             /************************************************************/
             /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
-            \responsable\Fonctions::affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_resp, $tab_all_users_du_grand_resp,  $DEBUG);
-            echo "<br>\n";
-
+            $return .= \responsable\Fonctions::affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_resp, $tab_all_users_du_grand_resp,  $DEBUG);
+            $return .= '<br>';
+        } else {
+            $return .= _('resp_etat_aucun_user') . '<br>';
         }
-        else
-            echo  _('resp_etat_aucun_user') ."<br>\n";
-
+        return $return;
     }
 
     /**
@@ -555,49 +546,45 @@ class Fonctions
         $tab_new_nb_conges_all   = getpost_variable('tab_new_nb_conges_all');
         $tab_calcul_proportionnel = getpost_variable('tab_calcul_proportionnel');
         $tab_new_comment_all     = getpost_variable('tab_new_comment_all');
+        $return = '';
 
 
-        if( $DEBUG ) { echo "tab_new_nb_conges_all = <br>"; print_r($tab_new_nb_conges_all); echo "<br>\n" ;}
-        if( $DEBUG ) { echo "tab_calcul_proportionnel = <br>"; print_r($tab_calcul_proportionnel); echo "<br>\n" ;}
+        if( $DEBUG ) {
+            $return .= 'tab_new_nb_conges_all = <br>' . var_export($tab_new_nb_conges_all, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_calcul_proportionnel = <br>' . var_export($tab_calcul_proportionnel, true) . '<br>';
+        }
 
 
         // titre
-        echo "<h1>". _('resp_ajout_conges_titre') ."</h1>\n";
+        $return .= '<h1>' . _('resp_ajout_conges_titre') . '</h1>';
 
-        if($ajout_conges=="TRUE")
-        {
-            \responsable\Fonctions::ajout_conges($tab_champ_saisie, $tab_commentaire_saisie, $DEBUG);
+        if($ajout_conges=="TRUE") {
+            $return .= \responsable\Fonctions::ajout_conges($tab_champ_saisie, $tab_commentaire_saisie, $DEBUG);
+        } elseif($ajout_global=="TRUE") {
+            $return .= \responsable\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all,  $DEBUG);
+        } elseif($ajout_groupe=="TRUE") {
+            $return .= \responsable\Fonctions::ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all,  $DEBUG);
+        } else {
+            $return .= \responsable\Fonctions::saisie_ajout($tab_type_cong, $DEBUG);
         }
-        elseif($ajout_global=="TRUE")
-        {
-            \responsable\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all,  $DEBUG);
-        }
-        elseif($ajout_groupe=="TRUE")
-        {
-            \responsable\Fonctions::ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all,  $DEBUG);
-        }
-        else
-        {
-            \responsable\Fonctions::saisie_ajout($tab_type_cong, $DEBUG);
-        }
+        return $return;
     }
 
     // calcule de la date limite d'utilisation des reliquats (si on utilise une date limite et qu'elle n'est pas encore calculée) et stockage dans la table
     public static function set_nouvelle_date_limite_reliquat( $DEBUG=FALSE)
     {
         //si on autorise les reliquats
-        if($_SESSION['config']['autorise_reliquats_exercice'])
-        {
+        if($_SESSION['config']['autorise_reliquats_exercice']) {
             // s'il y a une date limite d'utilisationdes reliquats (au format jj-mm)
-            if($_SESSION['config']['jour_mois_limite_reliquats']!=0)
-            {
+            if($_SESSION['config']['jour_mois_limite_reliquats']!=0) {
                 // nouvelle date limite au format aaa-mm-jj
                 $t=explode("-", $_SESSION['config']['jour_mois_limite_reliquats']);
                 $new_date_limite = date("Y")."-".$t[1]."-".$t[0];
 
                 //si la date limite n'a pas encore été updatée
-                if($_SESSION['config']['date_limite_reliquats'] < $new_date_limite)
-                {
+                if($_SESSION['config']['date_limite_reliquats'] < $new_date_limite) {
                     /* Modification de la table conges_appli */
                     $sql_update= "UPDATE conges_appli SET appli_valeur = '$new_date_limite' WHERE appli_variable='date_limite_reliquats' " ;
                     $ReqLog_update = \includes\SQL::query($sql_update) ;
@@ -612,37 +599,37 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         // recup de la liste de TOUS les users du groupe
         $tab_all_users_du_groupe=recup_infos_all_users_du_groupe($group_id,  $DEBUG);
-        if( $DEBUG ) { echo "tab_all_users_du_groupe =<br>\n"; print_r($tab_all_users_du_groupe); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_type_conges =<br>\n"; print_r($tab_type_conges); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_groupe =<br>' . var_export($tab_all_users_du_groupe, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_type_conges =<br>' . var_export($tab_type_conges, true) . '<br>';
+        }
 
         $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
 
-        if(count($tab_all_users_du_groupe)!=0)
-        {
+        if(count($tab_all_users_du_groupe)!=0) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_groupe as $current_login => $tab_current_user)
-            {
-                cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture,  $DEBUG);
+            foreach($tab_all_users_du_groupe as $current_login => $tab_current_user) {
+                $return .= cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture,  $DEBUG);
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo " ". _('form_modif_ok') ." <br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= ' ' . _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '">';
         }
-
+        return $return;
     }
 
     // cloture / debut d'exercice pour TOUS les users du resp (ou grand resp)
@@ -650,48 +637,49 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
         $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( $DEBUG ) { echo "tab_all_users_du_resp =<br>\n"; print_r($tab_all_users_du_resp); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_all_users_du_grand_resp =<br>\n"; print_r($tab_all_users_du_grand_resp); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_type_conges =<br>\n"; print_r($tab_type_conges); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_resp =<br>' . var_export($tab_all_users_du_resp, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_grand_resp =<br>' . var_export($tab_all_users_du_grand_resp, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_type_conges =<br>' . var_export($tab_type_conges, true) . '<br>';
+        }
 
         $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) )
-        {
+        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user)
-            {
-                cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture,  $DEBUG);
+            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+                $return .= cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture,  $DEBUG);
             }
             // traitement des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) )
-            {
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user)
-                {
-                    cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture,  $DEBUG);
+            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
+                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+                    $return .= cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture,  $DEBUG);
                 }
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo " ". _('form_modif_ok') ." <br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= ' ' . _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '">';
         }
+        return $return;
     }
 
     // verifie si tous les users on été basculés de l'exerccice précédent vers le suivant.
@@ -716,391 +704,396 @@ class Fonctions
 
     public static function cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire,  $DEBUG=FALSE)
     {
-    // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on le bascule d'exercice
-    if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice'])
-    {
-    // calcule de la date limite d'utilisation des reliquats (si on utilise une date limite et qu'elle n'est pas encore calculée)
-    \responsable\Fonctions::set_nouvelle_date_limite_reliquat( $DEBUG);
+        $return = '';
+        // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on le bascule d'exercice
+        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
+            // calcule de la date limite d'utilisation des reliquats (si on utilise une date limite et qu'elle n'est pas encore calculée)
+            \responsable\Fonctions::set_nouvelle_date_limite_reliquat( $DEBUG);
 
-    //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-    $tab_conges_current_user=$tab_current_user['conges'];
-    foreach($tab_type_conges as $id_conges => $libelle)
-    {
-    $user_nb_jours_ajout_an = $tab_conges_current_user[$libelle]['nb_an'];
-    $user_solde_actuel=$tab_conges_current_user[$libelle]['solde'];
-    $user_reliquat_actuel=$tab_conges_current_user[$libelle]['reliquat'];
+            //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
+            $tab_conges_current_user=$tab_current_user['conges'];
+            foreach($tab_type_conges as $id_conges => $libelle) {
+                $user_nb_jours_ajout_an = $tab_conges_current_user[$libelle]['nb_an'];
+                $user_solde_actuel=$tab_conges_current_user[$libelle]['solde'];
+                $user_reliquat_actuel=$tab_conges_current_user[$libelle]['reliquat'];
 
-    if( $DEBUG ) {echo "$current_login --- $id_conges --- $user_nb_jours_ajout_an<br>\n";}
+                if( $DEBUG ) {
+                    $return .= $current_login . '---' . $id_conges . '---' . $user_nb_jours_ajout_an . '<br>';
+                }
 
-    /**********************************************/
-    /* Modification de la table conges_solde_user */
+                /**********************************************/
+                /* Modification de la table conges_solde_user */
 
-    if($_SESSION['config']['autorise_reliquats_exercice'])
-    {
-        // ATTENTION : si le solde du user est négatif, on ne compte pas de reliquat et le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
-        if($user_solde_actuel>0)
-        {
-            //calcul du reliquat pour l'exercice suivant
-            if($_SESSION['config']['nb_maxi_jours_reliquats']!=0)
-            {
-                if($user_solde_actuel <= $_SESSION['config']['nb_maxi_jours_reliquats'])
-                    $new_reliquat = $user_solde_actuel ;
-                else
-                    $new_reliquat = $_SESSION['config']['nb_maxi_jours_reliquats'] ;
+                if($_SESSION['config']['autorise_reliquats_exercice']) {
+                    // ATTENTION : si le solde du user est négatif, on ne compte pas de reliquat et le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
+                    if($user_solde_actuel>0) {
+                        //calcul du reliquat pour l'exercice suivant
+                        if($_SESSION['config']['nb_maxi_jours_reliquats']!=0) {
+                            if($user_solde_actuel <= $_SESSION['config']['nb_maxi_jours_reliquats']) {
+                                $new_reliquat = $user_solde_actuel ;
+                            } else {
+                                $new_reliquat = $_SESSION['config']['nb_maxi_jours_reliquats'] ;
+                            }
+                        } else {
+                            $new_reliquat = $user_reliquat_actuel + $user_solde_actuel ;
+                        }
+
+                        //
+                        // update D'ABORD du reliquat
+                        $sql_reliquat = "UPDATE conges_solde_user SET su_reliquat = $new_reliquat WHERE su_login='$current_login' AND su_abs_id = $id_conges " ;
+                        $ReqLog_reliquat = \includes\SQL::query($sql_reliquat) ;
+                    } else {
+                        $new_reliquat = $user_solde_actuel ; // qui est nul ou negatif
+                    }
+
+
+                    $new_solde = $user_nb_jours_ajout_an + $new_reliquat  ;
+
+                    // update du solde
+                    $sql_solde = 'UPDATE conges_solde_user SET su_solde = \''.$new_solde.'\' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id ="'. \includes\SQL::quote($id_conges).'" ';
+                    $ReqLog_solde = \includes\SQL::query($sql_solde) ;
+                } else {
+                    // ATTENTION : meme si on accepte pas les reliquats, si le solde du user est négatif, il faut le reporter: le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
+                    if($user_solde_actuel < 0) {
+                        $new_solde = $user_nb_jours_ajout_an + $user_solde_actuel ; // qui est nul ou negatif
+                    } else {
+                        $new_solde = $user_nb_jours_ajout_an ;
+                    }
+
+                    $sql_solde = 'UPDATE conges_solde_user SET su_solde = \''.$new_solde.'\' WHERE su_login="'. \includes\SQL::quote($current_login).'"  AND su_abs_id = "'. \includes\SQL::quote($id_conges).'" ';
+                    $ReqLog_solde = \includes\SQL::query($sql_solde) ;
+                }
+
+                /* Modification de la table conges_users */
+                // ATTENTION : ne pas faire "SET u_num_exercice = u_num_exercice+1" dans la requete SQL car on incrémenterait pour chaque type d'absence !
+                $new_num_exercice=$_SESSION['config']['num_exercice'] ;
+                $sql2 = 'UPDATE conges_users SET u_num_exercice = \''.$new_num_exercice.'\' WHERE u_login="'. \includes\SQL::quote($current_login).'" ';
+                $ReqLog2 = \includes\SQL::query($sql2) ;
+
+                // on insert l'ajout de conges dans la table periode (avec le commentaire)
+                $date_today=date("Y-m-d");
+                insert_dans_periode($current_login, $date_today, "am", $date_today, "am", $user_nb_jours_ajout_an, $commentaire, $id_conges, "ajout", 0,  $DEBUG);
             }
-            else
-                $new_reliquat = $user_reliquat_actuel + $user_solde_actuel ;
 
-            //
-            // update D'ABORD du reliquat
-            $sql_reliquat = "UPDATE conges_solde_user SET su_reliquat = $new_reliquat WHERE su_login='$current_login' AND su_abs_id = $id_conges " ;
-            $ReqLog_reliquat = \includes\SQL::query($sql_reliquat) ;
+            // on incrémente le num_exercice de l'application si tous les users on été basculés.
+            \responsable\Fonctions::update_appli_num_exercice( $DEBUG);
         }
-        else
-            $new_reliquat = $user_solde_actuel ; // qui est nul ou negatif
-
-
-        $new_solde = $user_nb_jours_ajout_an + $new_reliquat  ;
-
-        // update du solde
-        $sql_solde = 'UPDATE conges_solde_user SET su_solde = \''.$new_solde.'\' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id ="'. \includes\SQL::quote($id_conges).'" ';
-        $ReqLog_solde = \includes\SQL::query($sql_solde) ;
-    }
-    else
-    {
-        // ATTENTION : meme si on accepte pas les reliquats, si le solde du user est négatif, il faut le reporter: le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
-        if($user_solde_actuel < 0)
-            $new_solde = $user_nb_jours_ajout_an + $user_solde_actuel ; // qui est nul ou negatif
-        else
-            $new_solde = $user_nb_jours_ajout_an ;
-
-        $sql_solde = 'UPDATE conges_solde_user SET su_solde = \''.$new_solde.'\' WHERE su_login="'. \includes\SQL::quote($current_login).'"  AND su_abs_id = "'. \includes\SQL::quote($id_conges).'" ';
-        $ReqLog_solde = \includes\SQL::query($sql_solde) ;
-    }
-
-    /* Modification de la table conges_users */
-    // ATTENTION : ne pas faire "SET u_num_exercice = u_num_exercice+1" dans la requete SQL car on incrémenterait pour chaque type d'absence !
-    $new_num_exercice=$_SESSION['config']['num_exercice'] ;
-    $sql2 = 'UPDATE conges_users SET u_num_exercice = \''.$new_num_exercice.'\' WHERE u_login="'. \includes\SQL::quote($current_login).'" ';
-    $ReqLog2 = \includes\SQL::query($sql2) ;
-
-    // on insert l'ajout de conges dans la table periode (avec le commentaire)
-    $date_today=date("Y-m-d");
-    insert_dans_periode($current_login, $date_today, "am", $date_today, "am", $user_nb_jours_ajout_an, $commentaire, $id_conges, "ajout", 0,  $DEBUG);
-    }
-
-    // on incrémente le num_exercice de l'application si tous les users on été basculés.
-    \responsable\Fonctions::update_appli_num_exercice( $DEBUG);
-    }
+        return $return;
     }
 
     // cloture / debut d'exercice user par user pour les users du resp (ou grand resp)
     public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie,  $DEBUG=FALSE)
     {
-    //$DEBUG=TRUE;
+        //$DEBUG=TRUE;
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
         $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( $DEBUG ) { echo "tab_all_users_du_resp =<br>\n"; print_r($tab_all_users_du_resp); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_all_users_du_grand_resp =<br>\n"; print_r($tab_all_users_du_grand_resp); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_type_conges =<br>\n"; print_r($tab_type_conges); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_cloture_users =<br>\n"; print_r($tab_cloture_users); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_commentaire_saisie =<br>\n"; print_r($tab_commentaire_saisie); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_resp =<br>' . var_export($tab_all_users_du_resp, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_grand_resp =<br>' . var_export($tab_all_users_du_grand_resp, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_type_conges =<br>' . var_export($tab_type_conges, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_cloture_users =<br>' . var_export($tab_cloture_users) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_commentaire_saisie =<br>' . var_export($tab_commentaire_saisie, true) . '<br>';
+        }
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) )
-        {
+        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user)
-            {
+            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
                 // tab_cloture_users[$current_login]=TRUE si checkbox "cloturer" est cochée
-                if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) )
-                {
+                if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) ) {
                     $commentaire = $tab_commentaire_saisie[$current_login];
-                    \responsable\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire,  $DEBUG);
+                    $return .= \responsable\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire,  $DEBUG);
                 }
             }
             // traitement des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) )
-            {
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user)
-                {
+            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
+                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
                     // tab_cloture_users[$current_login]=TRUE si checkbox "cloturer" est cochée
-                    if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) )
-                    {
+                    if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) ) {
                         $commentaire = $tab_commentaire_saisie[$current_login];
-                        \responsable\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire,  $DEBUG);
+                        $return .= \responsable\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire,  $DEBUG);
                     }
                 }
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo " ". _('form_modif_ok') ." <br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= ' ' . _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '">';
         }
-
+        return $return;
     }
 
     public static function affichage_cloture_globale_groupe($tab_type_conges,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
 
         // on établi la liste complète des groupes dont on est le resp (ou le grd resp)
         $list_group_resp=get_list_groupes_du_resp($_SESSION['userlogin']);
-        if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) )
+        if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
             $list_group_grd_resp=get_list_groupes_du_grand_resp($_SESSION['userlogin'],  $DEBUG);
-        else
+        } else {
             $list_group_grd_resp="";
+        }
 
         $list_group="";
-        if($list_group_resp!="")
-        {
+        if($list_group_resp!="") {
             $list_group = $list_group_resp;
-            if($list_group_grd_resp!="")
+            if($list_group_grd_resp!="") {
                 $list_group = $list_group.",".$list_group_grd_resp;
-        }
-        else
-        {
-            if($list_group_grd_resp!="")
+            }
+        } else {
+            if($list_group_grd_resp!="") {
                 $list_group = $list_group_grd_resp;
+            }
         }
 
 
         if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\"> \n";
-            echo "<table>\n";
-            echo "<tr><td align=\"center\">\n";
-            echo "	<fieldset class=\"cal_saisie\">\n";
-            echo "	<legend class=\"boxlogin\">". _('resp_cloture_exercice_groupe') ."</legend>\n";
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<table>';
+            $return .= '<tr><td align="center">';
+            $return .= '<fieldset class="cal_saisie">';
+            $return .= '<legend class="boxlogin">' . _('resp_cloture_exercice_groupe') . '</legend>';
 
-            echo "	<table>\n";
-            echo "	<tr>\n";
+            $return .= '<table>';
+            $return .= '<tr>';
 
-                // création du select pour le choix du groupe
-                $text_choix_group="<select name=\"choix_groupe\" >";
-                $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
-                $ReqLog_group = \includes\SQL::query($sql_group) ;
+            // création du select pour le choix du groupe
+            $text_choix_group="<select name=\"choix_groupe\" >";
+            $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
+            $ReqLog_group = \includes\SQL::query($sql_group) ;
 
-                while ($resultat_group = $ReqLog_group->fetch_array())
-                {
-                    $current_group_id=$resultat_group["g_gid"];
-                    $current_group_name=$resultat_group["g_groupename"];
-                    $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
-                }
-                $text_choix_group=$text_choix_group."</select>" ;
+            while ($resultat_group = $ReqLog_group->fetch_array()) {
+                $current_group_id=$resultat_group["g_gid"];
+                $current_group_name=$resultat_group["g_groupename"];
+                $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
+            }
+            $text_choix_group=$text_choix_group."</select>" ;
 
-            echo "		<td class=\"big\">". _('resp_ajout_conges_choix_groupe') ." : $text_choix_group</td>\n";
+            $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') .' : ' . $text_choix_group . '</td>';
 
-            echo "	</tr>\n";
-            echo "	<tr>\n";
-            echo "		<td class=\"big\">". _('resp_cloture_exercice_for_groupe_text_confirmer') ." </td>\n";
-            echo "	</tr>\n";
-            echo "	<tr>\n";
-            echo "		<td align=\"center\"><input class=\"btn\" type=\"submit\" value=\"". _('form_valid_cloture_group') ."\"></td>\n";
-            echo "	</tr>\n";
-            echo "	</table>\n";
+            $return .= '</tr>';
+            $return .= '<tr>';
+            $return .= '<td class="big">' . _('resp_cloture_exercice_for_groupe_text_confirmer') . '</td>';
+            $return .= '</tr>';
+            $return .= '<tr>';
+            $return .= '<td align="center"><input class="btn" type="submit" value="' . _('form_valid_cloture_group') . '"></td>';
+            $return .= '</tr>';
+            $return .= '</table>';
 
-            echo "	</fieldset>\n";
-            echo "</td></tr>\n";
-            echo "</table>\n";
+            $return .= '</fieldset>';
+            $return .= '/td></tr>';
+            $return .= '/table>';
 
-            echo "<input type=\"hidden\" name=\"onglet\" value=\"cloture_exercice\">\n";
-            echo "<input type=\"hidden\" name=\"cloture_groupe\" value=\"TRUE\">\n";
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "</form> \n";
+            $return .= '<input type="hidden" name="onglet" value="cloture_exercice">';
+            $return .= '<input type="hidden" name="cloture_groupe" value="TRUE">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '</form>';
         }
+        return $return;
     }
 
     public static function affichage_cloture_globale_pour_tous($tab_type_conges,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE GLOBALE pour tous les utilisateurs du responsable */
 
-        echo "<form action=\"$PHP_SELF?session=$session&onglet=cloture_exercice\" method=\"POST\"> \n";
-        echo "<table>\n";
-        echo "<tr><td align=\"center\">\n";
-        echo "	<fieldset class=\"cal_saisie\">\n";
-        echo "	<legend class=\"boxlogin\">". _('resp_cloture_exercice_all') ."</legend>\n";
-        echo "	<table>\n";
-        echo "	<tr>\n";
-        echo "		<td class=\"big\">&nbsp;&nbsp;&nbsp;". _('resp_cloture_exercice_for_all_text_confirmer') ." &nbsp;&nbsp;&nbsp;</td>\n";
-        echo "	</tr>\n";
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=cloture_exercice" method="POST">';
+        $return .= '<table>';
+        $return .= '<tr><td align="center">';
+        $return .= '<fieldset class="cal_saisie">';
+        $return .= '<legend class="boxlogin">' . _('resp_cloture_exercice_all') . '</legend>';
+        $return .= '<table>';
+        $return .= '<tr>';
+        $return .= '<td class="big">&nbsp;&nbsp;&nbsp;' . _('resp_cloture_exercice_for_all_text_confirmer') . ' &nbsp;&nbsp;&nbsp;</td>';
+        $return .= '</tr>';
         // bouton valider
-        echo "	<tr>\n";
-        echo "		<td colspan=\"5\" align=\"center\"><input class=\"btn\" type=\"submit\" value=\"". _('form_valid_cloture_global') ."\"></td>\n";
-        echo "	</tr>\n";
-        echo "	</table>\n";
-        echo "	</fieldset>\n";
-        echo "</td></tr>\n";
-        echo "</table>\n";
-        echo "<input type=\"hidden\" name=\"cloture_globale\" value=\"TRUE\">\n";
-        echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-        echo "</form> \n";
+        $return .= '<tr>';
+        $return .= '<td colspan="5" align="center"><input class="btn" type="submit" value="' . _('form_valid_cloture_global') . '"></td>';
+        $return .= '</tr>';
+        $return .= '</table>';
+        $return .= '</fieldset>';
+        $return .= '</td></tr>';
+        $return .= '</table>';
+        $return .= '<input type="hidden" name="cloture_globale" value="TRUE">';
+        $return .= '<input type="hidden" name="session" value="' . $session . '">';
+        $return .= '</form>';
+        return $return;
     }
 
     public static function affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user)
     {
-        echo " <tr align=\"center\">\n";
+        $return .= '<tr align="center">';
         //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
         $tab_conges=$tab_current_user['conges'];
 
         /** sur la ligne ,   **/
-        echo " <td>".$tab_current_user['nom']."</td>\n";
-        echo " <td>".$tab_current_user['prenom']."</td>\n";
-        echo " <td>".$tab_current_user['quotite']."%</td>\n";
+        $return .= '<td>' . $tab_current_user['nom'] . '</td>';
+        $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
+        $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-        foreach($tab_type_conges as $id_conges => $libelle)
-        {
-            echo " <td>".$tab_conges[$libelle]['nb_an']." <i>(".$tab_conges[$libelle]['solde'].")</i></td>\n";
+        foreach($tab_type_conges as $id_conges => $libelle) {
+            $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
         }
 
         // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on peut le cocher
-        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice'])
-            echo "	<td align=\"center\" class=\"histo\"><input type=\"checkbox\" name=\"tab_cloture_users[$current_login]\" value=\"TRUE\" checked></td>\n";
-        else
-            echo "	<td align=\"center\" class=\"histo\"><img src=\"". TEMPLATE_PATH ."img/stop.png\" width=\"16\" height=\"16\" border=\"0\" ></td>\n";
+        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
+            $return .= '<td align="center" class="histo"><input type="checkbox" name="tab_cloture_users[' . $current_login . ']" value="TRUE" checked></td>';
+        } else {
+            $return .= '<td align="center" class="histo"><img src="' . TEMPLATE_PATH . 'img/stop.png" width="16" height="16" border="0" ></td>';
+        }
 
         $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
-        echo "	<td align=\"center\" class=\"histo\"><input type=\"text\" name=\"tab_commentaire_saisie[$current_login]\" size=\"20\" maxlength=\"200\" value=\"$comment_cloture\"></td>\n";
-        echo " 	</tr>\n";
+        $return .= '<td align="center" class="histo"><input type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="20" maxlength="200" value="' . $comment_cloture . '"></td>';
+        $return .= '</tr>';
+        return $return;
     }
 
     public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_resp, $tab_all_users_du_grand_resp,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE USER PAR USER pour tous les utilisateurs du responsable */
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) )
-        {
-            echo "<form action=\"$PHP_SELF?session=$session&onglet=cloture_exercice\" method=\"POST\"> \n";
-            echo "<table>\n";
-            echo "<tr>\n";
-            echo "<td align=\"center\">\n";
-            echo "<fieldset class=\"cal_saisie\">\n";
-            echo "<legend class=\"boxlogin\">". _('resp_cloture_exercice_users') ."</legend>\n";
-            echo "	<table>\n";
-            echo "	<tr>\n";
-            echo "	<td align=\"center\">\n";
+        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=cloture_exercice" method="POST">';
+            $return .= '<table>';
+            $return .= '<tr>';
+            $return .= '<td align="center">';
+            $return .= '<fieldset class="cal_saisie">';
+            $return .= '<legend class="boxlogin">' . _('resp_cloture_exercice_users') . '</legend>';
+            $return .= '<table>';
+            $return .= '<tr>';
+            $return .= '<td align="center">';
 
             // AFFICHAGE TITRES TABLEAU
-            echo "	<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\" width=\"700\">\n";
-            echo "	<thead>\n";
-            echo "	<tr align=\"center\">\n";
-            echo "	<th>". _('divers_nom_maj_1') ."</th>\n";
-            echo "	<th>". _('divers_prenom_maj_1') ."</th>\n";
-            echo "	<th>". _('divers_quotite_maj_1') ."</th>\n";
-            foreach($tab_type_conges as $id_conges => $libelle)
-            {
-                echo "	<th>$libelle<br><i>(". _('divers_solde') .")</i></th>\n";
+            $return .= '<table cellpadding="2" class="table table-hover table-responsive table-condensed table-striped" width="700">';
+            $return .= '<thead>';
+            $return .= '<tr align="center">';
+            $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
+            foreach($tab_type_conges as $id_conges => $libelle) {
+                $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
             }
-            echo "	<th>". _('divers_cloturer_maj_1') ."<br></th>\n" ;
-            echo "	<th>". _('divers_comment_maj_1') ."<br></th>\n" ;
-            echo "	</tr>\n";
-            echo "	</thead>\n";
-            echo "	<tbody>\n";
+            $return .= '<th>' . _('divers_cloturer_maj_1') . '<br></th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '<br></th>';
+            $return .= '</tr>';
+            $return .= '</thead>';
+            $return .= '<tbody>';
 
             // AFFICHAGE LIGNES TABLEAU
 
             // affichage des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user)
-            {
-                \responsable\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user);
+            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+                $return .= \responsable\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user);
             }
 
             // affichage des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) )
-            {
+            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
                 $nb_colspan=50;
-                echo "<tr align=\"center\"><td class=\"histo\" style=\"background-color: #CCC;\" colspan=\"$nb_colspan\"><i>". _('resp_etat_users_titre_double_valid') ."</i></td></tr>\n";
+                $return .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="' . $nb_colspan . '"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
 
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user)
-                {
-                    \responsable\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user);
+                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+                    $return .= \responsable\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user);
                 }
             }
-            echo "	</tbody>\n";
-            echo "	</table>\n\n";
+            $return .= '</tbody>';
+            $return .= '</table>';
 
-            echo "	</td>\n";
-            echo "	</tr>\n";
-            echo "	<tr>\n";
-            echo "	<td align=\"center\">\n";
-            echo "	<input class=\"btn\" type=\"submit\" value=\"". _('form_submit') ."\">\n";
-            echo "	</td>\n";
-            echo "	</tr>\n";
-            echo "	</table>\n";
+            $return .= '</td>';
+            $return .= '</tr>';
+            $return .= '<tr>';
+            $return .= '<td align="center">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
+            $return .= '</td>';
+            $return .= '</tr>';
+            $return .= '</table>';
 
-            echo "</fieldset>\n";
-            echo "</td></tr>\n";
-            echo "</table>\n";
-            echo "<input type=\"hidden\" name=\"cloture_users\" value=\"TRUE\">\n";
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "</form> \n";
+            $return .= '</fieldset>';
+            $return .= '</td></tr>';
+            $return .= '</table>';
+            $return .= '<input type="hidden" name="cloture_users" value="TRUE">';
+            $return .= '<input type="hidden" name="session" value="' . $session  . '">';
+            $return .= '</form>';
         }
+        return $return;
     }
 
     public static function saisie_cloture( $tab_type_conges,  $DEBUG)
     {
-
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id() ;
+        $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
         $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( $DEBUG ) { echo "tab_all_users_du_resp =<br>\n"; print_r($tab_all_users_du_resp); echo "<br>\n"; }
-        if( $DEBUG ) { echo "tab_all_users_du_grand_resp =<br>\n"; print_r($tab_all_users_du_grand_resp); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_resp =<br>' . var_export($tab_all_users_du_resp, true) . '<br>';
+        }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_grand_resp =<br>' . var_export($tab_all_users_du_grand_resp, true) . '<br>';
+        }
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) )
-        {
+        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
-            affichage_cloture_globale_pour_tous($tab_type_conges,  $DEBUG);
-            echo "<br>\n";
+            $return .= affichage_cloture_globale_pour_tous($tab_type_conges,  $DEBUG);
+            $return .= '<br>';
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes'] )
-            {
-                \responsable\Fonctions::affichage_cloture_globale_groupe($tab_type_conges,  $DEBUG);
+            if( $_SESSION['config']['gestion_groupes'] ) {
+                $return .= \responsable\Fonctions::affichage_cloture_globale_groupe($tab_type_conges,  $DEBUG);
             }
-            echo "<br>\n";
+            $return .= '<br>';
 
             /************************************************************/
             /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
-            \responsable\Fonctions::affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_resp, $tab_all_users_du_grand_resp,  $DEBUG);
-            echo "<br>\n";
+            $return .= \responsable\Fonctions::affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_resp, $tab_all_users_du_grand_resp,  $DEBUG);
+            $return .= '<br>';
 
+        } else {
+            $return .= _('resp_etat_aucun_user') . '<br>';
         }
-        else
-            echo  _('resp_etat_aucun_user') ."<br>\n";
+        return $return;
     }
 
     /**
@@ -1118,6 +1111,7 @@ class Fonctions
         $cloture_groupe          = getpost_variable('cloture_groupe');
         $tab_cloture_users       = getpost_variable('tab_cloture_users');
         $tab_commentaire_saisie       = getpost_variable('tab_commentaire_saisie');
+        $return = '';
         /*************************************/
 
         header_popup( $_SESSION['config']['titre_resp_index'] );
@@ -1133,25 +1127,18 @@ class Fonctions
         $tab_type_cong = ( recup_tableau_types_conges( $DEBUG) + recup_tableau_types_conges_exceptionnels( $DEBUG)  );
 
         // titre
-        echo "<H2>". _('resp_cloture_exercice_titre') ."</H2>\n\n";
+        $return .= '<H2>' . _('resp_cloture_exercice_titre') . '</H2>';
 
-        if($cloture_users=="TRUE")
-        {
-            \responsable\Fonctions::cloture_users($tab_type_cong, $tab_cloture_users, $tab_commentaire_saisie,  $DEBUG);
+        if($cloture_users=="TRUE") {
+            $return .= \responsable\Fonctions::cloture_users($tab_type_cong, $tab_cloture_users, $tab_commentaire_saisie,  $DEBUG);
+        } elseif($cloture_globale=="TRUE") {
+            $return .= \responsable\Fonctions::cloture_globale($tab_type_cong,  $DEBUG);
+        } elseif($cloture_groupe=="TRUE") {
+            $return .= \responsable\Fonctions::cloture_globale_groupe($choix_groupe, $tab_type_cong,  $DEBUG);
+        } else {
+            $return .= \responsable\Fonctions::saisie_cloture($tab_type_cong, $DEBUG);
         }
-        elseif($cloture_globale=="TRUE")
-        {
-            \responsable\Fonctions::cloture_globale($tab_type_cong,  $DEBUG);
-        }
-        elseif($cloture_groupe=="TRUE")
-        {
-            \responsable\Fonctions::cloture_globale_groupe($choix_groupe, $tab_type_cong,  $DEBUG);
-        }
-        else
-        {
-            \responsable\Fonctions::saisie_cloture($tab_type_cong, $DEBUG);
-        }
-        bottom();
+        return $return;
     }
 
     /**
@@ -1163,50 +1150,46 @@ class Fonctions
      */
     public static function pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session, $DEBUG = false)
     {
+        $return = '';
         /***********************************/
         // AFFICHAGE ETAT CONGES TOUS USERS
 
         /***********************************/
         // AFFICHAGE TABLEAU (premiere ligne)
-        echo "<h1>". _('resp_traite_user_etat_conges') ."</h1>";
+        $return .= '<h1>' . _('resp_traite_user_etat_conges') . '</h1>';
 
-        echo "<table class=\"table table-hover table-responsive table-condensed table-striped\">\n";
-        echo '<thead>';
+        $return .= '<table class="table table-hover table-responsive table-condensed table-striped">';
+        $return .= '<thead>';
 
         $nb_colonnes = 0;
 
-        echo "<tr>\n";
-        echo '<th>'. _('divers_nom_maj') .'</th>';
-        echo '<th>'. _('divers_prenom_maj') .'</th>';
-        echo '<th>'. _('divers_quotite_maj_1') .'</th>' ;
+        $return .= '<tr>';
+        $return .= '<th>' . _('divers_nom_maj') .'</th>';
+        $return .= '<th>'. _('divers_prenom_maj') .'</th>';
+        $return .= '<th>'. _('divers_quotite_maj_1') .'</th>' ;
         $nb_colonnes = 3;
-        foreach($tab_type_cong as $id_conges => $libelle)
-        {
+        foreach($tab_type_cong as $id_conges => $libelle) {
             // cas d'une absence ou d'un congé
-            echo "<th> $libelle"." / ". _('divers_an_maj') .'</th>';
-            echo '<th>'. _('divers_solde_maj') ." ".$libelle .'</th>';
+            $return .= '<th>' . $libelle . ' / ' . _('divers_an_maj') . '</th>';
+            $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
             $nb_colonnes += 2;
         }
         // conges exceptionnels
-        if ($_SESSION['config']['gestion_conges_exceptionnels'])
-        {
-            foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle)
-            {
-                echo '<th>'. _('divers_solde_maj') ." $libelle</th>\n";
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+            foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
                 $nb_colonnes += 1;
             }
         }
-        echo "<th></th>";
+        $return .= '<th></th>';
         $nb_colonnes += 1;
-        if($_SESSION['config']['editions_papier'])
-        {
-            echo "<th></th>";
+        if($_SESSION['config']['editions_papier']) {
+            $return .= '<th></th>';
             $nb_colonnes += 1;
         }
-        echo "</tr>\n";
-
-        echo '</thead>';
-        echo '<tbody>';
+        $return .= '</tr>';
+        $return .= '</thead>';
+        $return .= '<tbody>';
 
         /***********************************/
         // AFFICHAGE USERS
@@ -1216,40 +1199,37 @@ class Fonctions
 
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est responsable
         $tab_all_users=recup_infos_all_users_du_resp($_SESSION['userlogin'],  $DEBUG);
-        if( $DEBUG ) {echo "tab_all_users :<br>\n";  print_r($tab_all_users); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_all_users :<br>' . var_export($tab_all_users) . '<br>';
+        }
 
-        if(count($tab_all_users)==0) // si le tableau est vide (resp sans user !!) on affiche une alerte !
-            echo "<tr align=\"center\"><td class=\"histo\" colspan=\"".$nb_colonnes."\">". _('resp_etat_aucun_user') ."</td></tr>\n" ;
-        else
-        {
+        if(count($tab_all_users)==0) {// si le tableau est vide (resp sans user !!) on affiche une alerte !
+            $return .= '<tr align="center"><td class="histo" colspan="' .  $nb_colonnes . '">' . _('resp_etat_aucun_user') . '</td></tr>';
+        } else {
             $i = true;
-            foreach($tab_all_users as $current_login => $tab_current_user)
-            {
-                if($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE')
-                {
+            foreach($tab_all_users as $current_login => $tab_current_user) {
+                if($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE') {
                     //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
                     $tab_conges=$tab_current_user['conges'];
                     $text_affich_user="<a class=\"action show\" href=\"resp_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\""._('resp_etat_users_afficher')."\"><i class=\"fa fa-eye\"></i></a>" ;
                     $text_edit_papier="<a class=\"action edit\" href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
 
-                    echo '<tr class="'.($i?'i':'p').'">';
-                    echo "<td>".$tab_current_user['nom']."</td><td>".$tab_current_user['prenom']."</td><td>".$tab_current_user['quotite']."%</td>";
-                    foreach($tab_type_cong as $id_conges => $libelle)
-                    {
-                        echo "<td>".$tab_conges[$libelle]['nb_an'].'</td>';
-                        echo "<td>".$tab_conges[$libelle]['solde'].'</td>';
+                    $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+                    $return .= '<td>' . $tab_current_user['nom'] . '</td><td>' . $tab_current_user['prenom'] . '</td><td>' . $tab_current_user['quotite'] . '%</td>';
+                    foreach($tab_type_cong as $id_conges => $libelle) {
+                        $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . '</td>';
+                        $return .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
                     }
-                    if ($_SESSION['config']['gestion_conges_exceptionnels'])
-                    {
-                        foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle)
-                        {
-                            echo "<td>".$tab_conges[$libelle]['solde'].'</td>';
+                    if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                        foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                            $return .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
                         }
                     }
-                    echo "<td>$text_affich_user</td>\n";
-                    if($_SESSION['config']['editions_papier'])
-                        echo "<td>$text_edit_papier</td>";
-                    echo "</tr>\n";
+                    $return .= '<td>' . $text_affich_user . '</td>';
+                    if($_SESSION['config']['editions_papier']) {
+                        $return .= '<td>' . $text_edit_papier . '</td>';
+                    }
+                    $return .= '</tr>';
                     $i = !$i;
                 }
             }
@@ -1258,28 +1238,29 @@ class Fonctions
         /***********************************/
         // AFFICHAGE DE USERS DONT LE RESP EST GRAND RESP
 
-        if($_SESSION['config']['double_validation_conges'])
-        {
+        if($_SESSION['config']['double_validation_conges']) {
             // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est GRAND responsable
             $tab_all_users_2=recup_infos_all_users_du_grand_resp($_SESSION['userlogin'],  $DEBUG);
 
-            if( $DEBUG ) {echo "tab_all_users_2 :<br>\n";  print_r($tab_all_users_2); echo "<br>\n"; }
+            if( $DEBUG ) {
+                $return .= 'tab_all_users_2 :<br>' . var_export($tab_all_users_2, true) . '<br>';
+            }
 
             $compteur=0;  // compteur de ligne a afficher en dessous (dés que passe à 1 : on affiche une ligne de titre)
 
             $i = true;
-            foreach($tab_all_users_2 as $current_login_2 => $tab_current_user_2)
-            {
+            foreach($tab_all_users_2 as $current_login_2 => $tab_current_user_2) {
                 if( !array_key_exists($current_login_2, $tab_all_users) ) // si le user n'est pas déjà dans le tableau précédent (deja affiché)
                 {
                     $compteur++;
                     if($compteur==1)  // alors on affiche une ligne de titre
                     {
                         $nb_colspan=9;
-                        if ($_SESSION['config']['gestion_conges_exceptionnels'])
+                        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
                             $nb_colspan=10;
+                        }
 
-                        echo "<tr align=\"center\"><td class=\"histo\" style=\"background-color: #CCC;\" colspan=\"$nb_colonnes\"><i>". _('resp_etat_users_titre_double_valid') ."</i></td></tr>\n";
+                        $return .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="' . $nb_colonnes . '"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
                     }
 
                     //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
@@ -1287,37 +1268,36 @@ class Fonctions
 
                     $text_affich_user="<a class=\"action show\" href=\"resp_index.php?session=$session&onglet=traite_user&user_login=$current_login_2\" title=\"". _('resp_etat_users_afficher') ."\"><i class=\"fa fa-eye\"></i></a>" ;
                     $text_edit_papier="<a class=\"action print\" href=\"../edition/edit_user.php?session=$session&user_login=$current_login_2\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
-                    echo '<tr class="'.($i?'i':'p').'">';
-                    echo "<td>".$tab_current_user_2['nom']."</td><td>".$tab_current_user_2['prenom']."</td><td>".$tab_current_user_2['quotite']."%</td>";
-                    foreach($tab_type_cong as $id_conges => $libelle)
-                    {
-                        echo "<td>".$tab_conges_2[$libelle]['nb_an']."</td><td>".$tab_conges_2[$libelle]['solde'].'</td>';
+                    $return .= '<tr class="'.($i?'i':'p').'">';
+                    $return .= '<td>' . $tab_current_user_2['nom'] . '</td><td>' . $tab_current_user_2['prenom'] . '</td><td>' . $tab_current_user_2['quotite'] . '%</td>';
+                    foreach($tab_type_cong as $id_conges => $libelle) {
+                        $return .= '<td>' . $tab_conges_2[$libelle]['nb_an'] . '</td><td>' . $tab_conges_2[$libelle]['solde'] . '</td>';
                     }
-                    if ($_SESSION['config']['gestion_conges_exceptionnels'])
-                    {
-                        foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle)
-                        {
-                            echo "<td>".$tab_conges_2[$libelle]['solde'].'</td>';
+                    if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+                        foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                            $return .= '<td>' . $tab_conges_2[$libelle]['solde'] . '</td>';
                         }
                     }
-                    echo "<td>$text_affich_user</td>\n";
-                    if($_SESSION['config']['editions_papier'])
-                        echo "<td>$text_edit_papier</td>";
-                    echo "</tr>\n";
+                    $return .= '<td>' . $text_affich_user . '</td>';
+                    if($_SESSION['config']['editions_papier']) {
+                        $return .= '<td>' . $text_edit_papier . '</td>';
+                    }
+                    $return .= '</tr>';
                     $i = !$i;
                 }
             }
-
         }
 
-        echo '</tbody>';
-        echo '</table>';
+        $return .= '</tbody>';
+        $return .= '</table>';
+        return $return;
     }
 
     public static function new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
         //conversion des dates
         $new_debut = convert_date($new_debut);
@@ -1326,10 +1306,11 @@ class Fonctions
         // verif validité des valeurs saisies
         $valid=verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment);
 
-        if( $DEBUG ) { echo "verif_saisie_new_demande resp_traite_user : $valid<br>\n"; }
-        if($valid)
-        {
-            echo "$user_login---$new_debut _ $new_demi_jour_deb---$new_fin _ $new_demi_jour_fin---$new_nb_jours---$new_comment---$new_type_id<br>\n";
+        if( $DEBUG ) {
+            $return .= 'verif_saisie_new_demande resp_traite_user : ' . $valid . '<br>';
+        }
+        if ($valid) {
+            $return .= $user_login . '---' . $new_debut . '_' . $new_demi_jour_deb . '---' . $new_fin . '_' .  $new_demi_jour_fin . '---' . $new_nb_jours . '---' . $new_comment . '---' . $new_type_id . '<br>';
 
             // recup dans un tableau de tableau les infos des types de conges et absences
             $tab_tout_type_abs = recup_tableau_tout_types_abs( $DEBUG);
@@ -1344,40 +1325,39 @@ class Fonctions
             /* UPDATE table "conges_solde_user" (jours restants) */
             // on retranche les jours seulement pour des conges pris (pas pour les absences)
             // donc seulement si le type de l'absence qu'on annule est un "conges"
-            if(isset($tab_tout_type_abs[$new_type_id]['type']) && $tab_tout_type_abs[$new_type_id]['type']=="conges")
-            {
+            if(isset($tab_tout_type_abs[$new_type_id]['type']) && $tab_tout_type_abs[$new_type_id]['type']=="conges") {
                 $user_nb_jours_pris_float=(float) $new_nb_jours ;
                 soustrait_solde_et_reliquat_user($user_login, "", $user_nb_jours_pris_float, $new_type_id, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin , $DEBUG);
             }
             $comment_log = "saisie conges par le responsable pour $user_login ($new_nb_jours jour(s)) type_conges = $new_type_id ( de $new_debut $new_demi_jour_deb a $new_fin $new_demi_jour_fin) ($new_comment)";
             log_action(0, "", $user_login, $comment_log,  $DEBUG);
 
-            if($result)
-                echo  _('form_modif_ok') ."<br><br> \n";
-            else
-                echo  _('form_modif_not_ok') ."<br><br> \n";
-        }
-        else
-        {
-            echo  _('resp_traite_user_valeurs_not_ok') ."<br><br> \n";
+            if($result) {
+                $return .= _('form_modif_ok') . '<br><br>';
+            } else {
+                $return .= _('form_modif_not_ok') . '<br><br>';
+            }
+        } else {
+            $return .= _('resp_traite_user_valeurs_not_ok') . '<br><br>';
         }
 
         /* APPEL D'UNE AUTRE PAGE */
-        echo "<form action=\"$PHP_SELF?session=$session&onglet=traite_user&user_login=$user_login\" method=\"POST\"> \n";
-        echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_retour') ."\">\n";
-        echo "</form> \n";
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '" method="POST">';
+        $return .= '<input class="btn" type="submit" value="' . _('form_retour') . '">';
+        $return .= '</form>';
+        return $return;
     }
 
     public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF']; ;
         $session=session_id();
+        $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
         $tab_tout_type_abs = recup_tableau_tout_types_abs( $DEBUG);
 
-        while($elem_tableau = each($tab_radio_traite_demande))
-        {
+        while($elem_tableau = each($tab_radio_traite_demande)) {
             $champs = explode("--", $elem_tableau['value']);
             $user_login=$champs[0];
             $user_nb_jours_pris=$champs[1];
@@ -1392,7 +1372,9 @@ class Fonctions
 
             $numero=$elem_tableau['key'];
             $numero_int=(int) $numero;
-            if( $DEBUG ) { echo "<br><br>conges numero :$numero --- User_login : $user_login --- nb de jours : $user_nb_jours_pris --->$value_traite<br>" ; }
+            if( $DEBUG ) {
+                $return .= '<br><br>conges numero :' . $numero . '--- User_login : ' . $user_login .  '--- nb de jours : ' . $user_nb_jours_pris . '---> ' .$value_traite . '<br>';
+            }
 
             if($reponse == "ACCEPTE") // acceptation definitive d'un conges
             {
@@ -1406,15 +1388,17 @@ class Fonctions
                 /* UPDATE table "conges_solde_user" (jours restants) */
                 // on retranche les jours seulement pour des conges pris (pas pour les absences)
                 // donc seulement si le type de l'absence qu'on accepte est un "conges"
-                if( $DEBUG ) { echo "type_abs = ".$tab_tout_type_abs[$value_type_abs_id]['type']."<br>\n" ; }
-                if(($tab_tout_type_abs[$value_type_abs_id]['type']=="conges")||($tab_tout_type_abs[$value_type_abs_id]['type']=="conges_exceptionnels"))
-                {
+                if( $DEBUG ) {
+                    $return .= 'type_abs = ' . $tab_tout_type_abs[$value_type_abs_id]['type'] . '<br>';
+                }
+                if(($tab_tout_type_abs[$value_type_abs_id]['type']=="conges")||($tab_tout_type_abs[$value_type_abs_id]['type']=="conges_exceptionnels")) {
                     soustrait_solde_et_reliquat_user($user_login, $numero_int, $user_nb_jours_pris_float, $value_type_abs_id, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin, $DEBUG);
                 }
 
                 //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_valid_conges_alerte_user'])
+                if($_SESSION['config']['mail_valid_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "accept_conges",  $DEBUG);
+                }
             }
             elseif($reponse == "VALID") // première validation dans le cas d'une double validation
             {
@@ -1426,13 +1410,14 @@ class Fonctions
                 log_action($numero_int,"valid", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $value_traite",  $DEBUG);
 
                 //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_valid_conges_alerte_user'])
+                if($_SESSION['config']['mail_valid_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "valid_conges",  $DEBUG);
+                }
             }
             elseif($reponse == "REFUSE") // refus d'un conges
             {
                 // recup di motif de refus
-                $motif_refus=addslashes($tab_text_refus[$numero_int]);
+                $motif_refus = addslashes($tab_text_refus[$numero_int]);
                 //$sql3 = "UPDATE conges_periode SET p_etat=\"refus\" WHERE p_num=$numero_int" ;
                 $sql3 = 'UPDATE conges_periode SET p_etat="refus", p_motif_refus=\''.$motif_refus.'\', p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'";';
                 $ReqLog3 = \includes\SQL::query($sql3);
@@ -1441,38 +1426,37 @@ class Fonctions
                 log_action($numero_int,"refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $value_traite",  $DEBUG);
 
                 //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_refus_conges_alerte_user'])
+                if($_SESSION['config']['mail_refus_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges",  $DEBUG);
+                }
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input type=\"hidden\" name=\"onglet\" value=\"traite_user\">\n";
-            echo "<input type=\"hidden\" name=\"user_login\" value=\"$user_login\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo  _('form_modif_ok') ."<br><br> \n";
+        if($DEBUG) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input type="hidden" name="onglet" value="traite_user">';
+            $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session&user_login=$user_login\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '&user_login=' . $user_login . '">';
         }
+        return $return;
     }
 
     public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul,  $DEBUG=FALSE)
     {
         $PHP_SELF=$_SERVER['PHP_SELF']; ;
         $session=session_id() ;
+        $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
         $tab_tout_type_abs = recup_tableau_tout_types_abs( $DEBUG);
 
-        while($elem_tableau = each($tab_checkbox_annule))
-        {
+        while($elem_tableau = each($tab_checkbox_annule)) {
             $champs = explode("--", $elem_tableau['value']);
             $user_login=$champs[0];
             $user_nb_jours_pris=$champs[1];
@@ -1484,7 +1468,9 @@ class Fonctions
 
             $motif_annul=addslashes($tab_text_annul[$numero_int]);
 
-            if( $DEBUG ) { echo "<br><br>conges numero :$numero ---> login : $user_login --- nb de jours : $user_nb_jours_pris_float --- type : $user_type_abs_id ---> ANNULER <br>"; }
+            if( $DEBUG ) {
+                $return .= '<br><br>conges numero :' . $numero . '---> login : ' . $user_login . '---  nb de jours :  ' . $user_nb_jours_pris_float . '--- type : ' . $user_type_abs_id . '---> ANNULER <br>';
+            }
 
             /* UPDATE table "conges_periode" */
             $sql1 = 'UPDATE conges_periode SET p_etat="annul", p_motif_refus="'. \includes\SQL::quote($motif_annul).'", p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'" ';
@@ -1496,33 +1482,31 @@ class Fonctions
             /* UPDATE table "conges_solde_user" (jours restants) */
             // on re-crédite les jours seulement pour des conges pris (pas pour les absences)
             // donc seulement si le type de l'absence qu'on annule est un "conges"
-            if($tab_tout_type_abs[$user_type_abs_id]['type']=="conges")
-            {
+            if($tab_tout_type_abs[$user_type_abs_id]['type']=="conges") {
                 $sql2 = 'UPDATE conges_solde_user SET su_solde = su_solde+"'. \includes\SQL::quote($user_nb_jours_pris_float).'" WHERE su_login="'. \includes\SQL::quote($user_login).'" AND su_abs_id="'. \includes\SQL::quote($user_type_abs_id).'";';
                 //echo($sql2."<br>");
                 $ReqLog2 = \includes\SQL::query($sql2);
             }
 
             //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-            if($_SESSION['config']['mail_annul_conges_alerte_user'])
+            if($_SESSION['config']['mail_annul_conges_alerte_user']) {
                 alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "annul_conges",  $DEBUG);
+            }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input type=\"hidden\" name=\"onglet\" value=\"traite_user\">\n";
-            echo "<input type=\"hidden\" name=\"user_login\" value=\"$user_login\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo  _('form_modif_ok') ."<br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input type="hidden" name="onglet" value="traite_user">';
+            $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session&user_login=$user_login\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '&user_login=' . $user_login . '">';
         }
+        return $return;
     }
 
     //affiche l'état des conges du user (avec le formulaire pour le responsable)
@@ -1530,19 +1514,20 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF']; ;
         $session=session_id() ;
+        $return = '';
 
         // affichage de l'année et des boutons de défilement
         $year_affichage_prec = $year_affichage-1 ;
         $year_affichage_suiv = $year_affichage+1 ;
-        echo "<div class=\"calendar-nav\">\n";
-        echo "<ul>\n";
-        echo "<li><a class=\"action previous\" href=\"$PHP_SELF?session=$session&onglet=traite_user&user_login=$user_login&year_affichage=$year_affichage_prec\"><i class=\"fa fa-chevron-left\"></i></a></li>\n";
-        echo "<li class=\"current-year\">$year_affichage</li>";
-        echo "<li><a class=\"action next\" href=\"$PHP_SELF?session=$session&onglet=traite_user&user_login=$user_login&year_affichage=$year_affichage_suiv\"><i class=\"fa fa-chevron-right\"></i></a></li>\n";
-        echo "</ul>\n";
-        echo "</div>\n";
+        $return .= '<div class="calendar-nav">';
+        $return .= '<ul>';
+        $return .= '<li><a class="action previous" href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_prec . '"><i class="fa fa-chevron-left"></i></a></li>';
+        $return .= '<li class="current-year">' . $year_affichage . '</li>';
+        $return .= '<li><a class="action next" href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_suiv . '"><i class="fa fa-chevron-right"></i></a></li>';
+        $return .= '</ul>';
+        $return .= '</div>';
 
-        echo "<h2>". _('resp_traite_user_etat_conges') ." $year_affichage</h2>\n";
+        $return .= '<h2>' . _('resp_traite_user_etat_conges') . $year_affichage . '</h2>';
 
         // Récupération des informations de speriodes de conges/absences
         $sql3 = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_motif_refus, p_date_demande, p_date_traitement, p_num FROM conges_periode " .
@@ -1550,65 +1535,63 @@ class Fonctions
             "AND p_etat !='demande' " .
             "AND p_etat !='valid' " .
             "AND (p_date_deb LIKE '$year_affichage%' OR p_date_fin LIKE '$year_affichage%') ";
-        if($tri_date=="descendant")
+        if($tri_date=="descendant") {
             $sql3=$sql3." ORDER BY p_date_deb DESC ";
-        else
+        } else {
             $sql3=$sql3." ORDER BY p_date_deb ASC ";
+        }
 
         $ReqLog3 = \includes\SQL::query($sql3);
 
         $count3=$ReqLog3->num_rows;
-        if($count3==0)
-        {
-            echo "<b>". _('resp_traite_user_aucun_conges') ."</b><br><br>\n";
-        }
-        else
-        {
+        if($count3==0) {
+            $return .= '<b>' . _('resp_traite_user_aucun_conges') . '</b><br><br>';
+        } else {
             // recup dans un tableau de tableau les infos des types de conges et absences
             $tab_types_abs = recup_tableau_tout_types_abs( $DEBUG) ;
 
             // AFFICHAGE TABLEAU
-            echo "<form action=\"$PHP_SELF?session=$session&onglet=traite_user\" method=\"POST\"> \n";
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
             //echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\" width=\"80%\">\n";
-            echo "<table class=\"table table-hover table-responsive table-condensed table-striped\">\n";
-            echo "<thead>";
-            echo "<tr align=\"center\">\n";
-            echo " <th>\n";
+            $return .= '<table class="table table-hover table-responsive table-condensed table-striped">';
+            $return .= '<thead>';
+            $return .= '<tr align="center">';
+            $return .= '<th>';
             // echo " <a href=\"$PHP_SELF?session=$session&user_login=$user_login&onglet=$onglet&tri_date=descendant\"><img src=\"". TEMPLATE_PATH ."img/1downarrow-16x16.png\" width=\"16\" height=\"16\" border=\"0\" title=\"trier\"></a>\n";
-            echo " ". _('divers_debut_maj_1') ." \n";
+            $return .= _('divers_debut_maj_1');
             // echo " <a href=\"$PHP_SELF?session=$session&user_login=$user_login&onglet=$onglet&tri_date=ascendant\"><img src=\"". TEMPLATE_PATH ."img/1uparrow-16x16.png\" width=\"16\" height=\"16\" border=\"0\" title=\"trier\"></a>\n";
-            echo " </th>\n";
-            echo " <th>". _('divers_fin_maj_1') ."</th>\n";
-            echo " <th>". _('divers_nb_jours_pris_maj_1') ."</th>\n";
-            echo " <th>". _('divers_comment_maj_1') ."</th>\n";
-            echo " <th>". _('divers_type_maj_1') ."</th>\n";
-            echo " <th>". _('divers_etat_maj_1') ."</th>\n";
-            echo " <th>". _('resp_traite_user_annul') ."</th>\n";
-            echo " <th>". _('resp_traite_user_motif_annul') ."</th>\n";
-            if($_SESSION['config']['affiche_date_traitement'])
-            {
-                echo "<th>". _('divers_date_traitement') ."</th>\n" ;
+            $return .= '</th>';
+            $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_nb_jours_pris_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_etat_maj_1') . '</th>';
+            $return .= '<th>' . _('resp_traite_user_annul') . '</th>';
+            $return .= '<th>' . _('resp_traite_user_motif_annul') . '</th>';
+            if($_SESSION['config']['affiche_date_traitement']) {
+                $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
-            echo "</tr>\n";
-            echo "</thead>";
-            echo "<tbody>";
+            $return .= '</tr>';
+            $return .= '</thead>';
+            $return .= '<tbody>';
             $tab_checkbox=array();
             $i = true;
-            while ($resultat3 = $ReqLog3->fetch_array())
-            {
+            while ($resultat3 = $ReqLog3->fetch_array()) {
                 $sql_login=$resultat3["p_login"] ;
                 $sql_date_deb=eng_date_to_fr($resultat3["p_date_deb"]) ;
                 $sql_demi_jour_deb=$resultat3["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am")
+                if($sql_demi_jour_deb=="am") {
                     $demi_j_deb =  _('divers_am_short') ;
-                else
+                } else {
                     $demi_j_deb =  _('divers_pm_short') ;
+                }
                 $sql_date_fin=eng_date_to_fr($resultat3["p_date_fin"]) ;
                 $sql_demi_jour_fin=$resultat3["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am")
+                if($sql_demi_jour_fin=="am") {
                     $demi_j_fin =  _('divers_am_short') ;
-                else
+                } else {
                     $demi_j_fin =  _('divers_pm_short') ;
+                }
                 $sql_nb_jours=affiche_decimal($resultat3["p_nb_jours"]) ;
                 $sql_commentaire=$resultat3["p_commentaire"] ;
                 $sql_type=$resultat3["p_type"] ;
@@ -1618,67 +1601,62 @@ class Fonctions
                 $sql_p_date_traitement = $resultat3["p_date_traitement"];
                 $sql_num=$resultat3["p_num"] ;
 
-                if(($sql_etat=="annul") || ($sql_etat=="refus") || ($sql_etat=="ajout"))
-                {
+                if(($sql_etat=="annul") || ($sql_etat=="refus") || ($sql_etat=="ajout")) {
                     $casecocher1="";
-                    if($sql_etat=="refus")
-                    {
-                        if($sql_motif_refus=="")
+                    if($sql_etat=="refus") {
+                        if($sql_motif_refus=="") {
                             $sql_motif_refus =  _('divers_inconnu')  ;
+                        }
                         //$text_annul="<i>motif du refus : $sql_motif_refus</i>";
                         $text_annul="<i>". _('resp_traite_user_motif') ." : $sql_motif_refus</i>";
-                    }
-                    elseif($sql_etat=="annul")
-                    {
+                    } elseif($sql_etat=="annul") {
                         if($sql_motif_refus=="")
                             $sql_motif_refus =  _('divers_inconnu')  ;
                         //$text_annul="<i>motif de l'annulation : $sql_motif_refus</i>";
                         $text_annul="<i>". _('resp_traite_user_motif') ." : $sql_motif_refus</i>";
-                    }
-                    elseif($sql_etat=="ajout")
-                    {
+                    } elseif($sql_etat=="ajout") {
                         $text_annul="&nbsp;";
                     }
-                }
-                else
-                {
+                } else {
                     $casecocher1=sprintf("<input type=\"checkbox\" name=\"tab_checkbox_annule[$sql_num]\" value=\"$sql_login--$sql_nb_jours--$sql_type--ANNULE\">");
                     $text_annul="<input type=\"text\" name=\"tab_text_annul[$sql_num]\" size=\"20\" max=\"100\">";
                 }
 
-                echo '<tr class="'.($i?'i':'p').'">';
-                echo "<td>$sql_date_deb _ $demi_j_deb</td>\n";
-                echo "<td>$sql_date_fin _ $demi_j_fin</td>\n";
-                echo "<td>$sql_nb_jours</td>\n";
-                echo "<td>$sql_commentaire</td>\n";
-                echo "<td>".$tab_types_abs[$sql_type]['libelle']."</td>\n";
-                echo "<td>";
-                if($sql_etat=="refus")
-                    echo  _('divers_refuse') ;
-                elseif($sql_etat=="annul")
-                    echo  _('divers_annule') ;
-                else
-                    echo "$sql_etat";
-                echo "</td>\n";
-                echo "<td>$casecocher1</td>\n";
-                echo "<td>$text_annul</td>\n";
-                if($_SESSION['config']['affiche_date_traitement'])
-                {
-                    if(empty($sql_p_date_traitement))
-                        echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : pas traité</td>\n" ;
-                    else
-                        echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : $sql_p_date_traitement</td>\n" ;
+                $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+                $return .= '<td>' . $sql_date_deb . '_' . $demi_j_deb . '</td>';
+                $return .= '<td>' . $sql_date_fin . '_' . $demi_j_fin . '</td>';
+                $return .= '<td>' . $sql_nb_jours . '</td>';
+                $return .= '<td>' . $sql_commentaire . '</td>';
+                $return .= '<td>' . $tab_types_abs[$sql_type]['libelle'] . '</td>';
+                $return .= '<td>';
+                if($sql_etat=="refus") {
+                    $return .= _('divers_refuse') ;
+                } elseif($sql_etat=="annul") {
+                    $return .= _('divers_annule') ;
+                } else {
+                    $return .= $sql_etat;
                 }
-                echo "</tr>\n";
+                $return .= '</td>';
+                $return .= '<td>' . $casecocher1 . '</td>';
+                $return .= '<td>' . $text_annul . '</td>';
+                if($_SESSION['config']['affiche_date_traitement']) {
+                    if(empty($sql_p_date_traitement)) {
+                        $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
+                    } else {
+                        $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
+                    }
+                }
+                $return .= '</tr>';
                 $i = !$i;
             }
-            echo "</tbody>";
-            echo "</table>\n\n";
+            $return .= '</tbody>';
+            $return .= '</table>';
 
-            echo "<input type=\"hidden\" name=\"user_login\" value=\"$user_login\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_submit') ."\">\n";
-            echo "</form> \n";
+            $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
+            $return .= '</form>';
         }
+        return $return;
     }
 
     //affiche l'état des demande en attente de 2ieme validation du user (avec le formulaire pour le responsable)
@@ -1686,6 +1664,7 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF']; ;
         $session=session_id() ;
+        $return = '';
 
         // Récupération des informations
         $sql2 = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement, p_num " .
@@ -1694,55 +1673,52 @@ class Fonctions
         $ReqLog2 = \includes\SQL::query($sql2);
 
         $count2=$ReqLog2->num_rows;
-        if($count2==0)
-        {
-            echo "<b>". _('resp_traite_user_aucune_demande') ."</b><br><br>\n";
-        }
-        else
-        {
+        if($count2==0) {
+            $return .= '<b>' . _('resp_traite_user_aucune_demande') . '</b><br><br>';
+        } else {
             // recup dans un tableau des types de conges
             $tab_type_all_abs = recup_tableau_tout_types_abs();
 
             // AFFICHAGE TABLEAU
-            echo " <form action=\"$PHP_SELF?session=$session&onglet=traite_user\" method=\"POST\"> \n";
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
             //echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\" width=\"80%\">\n";
-            echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\">\n";
-            echo "<thead>";
-            echo "<tr align=\"center\">\n";
-            echo "<th>". _('divers_debut_maj_1') ."</th>\n";
-            echo "<th>". _('divers_fin_maj_1') ."</th>\n";
-            echo "<th>". _('divers_nb_jours_pris_maj_1') ."</th>\n";
-            echo "<th>". _('divers_comment_maj_1') ."</th>\n";
-            echo "<th>". _('divers_type_maj_1') ."</th>\n";
-            echo "<th>". _('divers_accepter_maj_1') ."</th>\n";
-            echo "<th>". _('divers_refuser_maj_1') ."</th>\n";
-            echo "<th>". _('resp_traite_user_motif_refus') ."</th>\n";
-            if($_SESSION['config']['affiche_date_traitement'])
-            {
-                echo "<th>". _('divers_date_traitement') ."</th>\n" ;
+            $return .= '<table cellpadding="2" class="table table-hover table-responsive table-condensed table-striped">';
+            $return .= '<thead>';
+            $return .= '<tr align="center">';
+            $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_nb_jours_pris_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
+            $return .= '<th>' . _('resp_traite_user_motif_refus') . '</th>';
+            if($_SESSION['config']['affiche_date_traitement']) {
+                $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
-            echo "</tr>\n";
-            echo "</thead>";
-            echo "<tbody>";
+            $return .= '</tr>';
+            $return .= '</thead>';
+            $return .= '<tbody>';
 
             $i = true;
             $tab_checkbox=array();
-            while ($resultat2 = $ReqLog2->fetch_array())
-            {
+            while ($resultat2 = $ReqLog2->fetch_array()) {
                 $sql_date_deb = $resultat2["p_date_deb"];
                 $sql_date_deb_fr = eng_date_to_fr($resultat2["p_date_deb"]) ;
                 $sql_demi_jour_deb=$resultat2["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am")
+                if($sql_demi_jour_deb=="am") {
                     $demi_j_deb =  _('divers_am_short') ;
-                else
+                } else {
                     $demi_j_deb =  _('divers_pm_short') ;
+                }
                 $sql_date_fin = $resultat2["p_date_fin"];
                 $sql_date_fin_fr = eng_date_to_fr($resultat2["p_date_fin"]) ;
                 $sql_demi_jour_fin=$resultat2["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am")
+                if($sql_demi_jour_fin=="am") {
                     $demi_j_fin =  _('divers_am_short') ;
-                else
+                } else {
                     $demi_j_fin =  _('divers_pm_short') ;
+                }
                 $sql_nb_jours=affiche_decimal($resultat2["p_nb_jours"]) ;
                 $sql_commentaire=$resultat2["p_commentaire"] ;
                 $sql_type=$resultat2["p_type"] ;
@@ -1758,33 +1734,33 @@ class Fonctions
                 $casecocher2 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--REFUSE\">";
                 $text_refus  = "<input type=\"text\" name=\"tab_text_refus[$sql_num]\" size=\"20\" max=\"100\">";
 
-                echo '<tr class="'.($i?'i':'p').'">';
-                echo "<td>$sql_date_deb_fr _ $demi_j_deb</td>\n";
-                echo "<td>$sql_date_fin_fr _ $demi_j_fin</td>\n";
-                echo "<td>$sql_nb_jours</td>\n";
-                echo "<td>$sql_commentaire</td>\n";
-                echo "<td>".$tab_type_all_abs[$sql_type]['libelle']."</td>\n";
-                echo "<td>$casecocher1</td>\n";
-                echo "<td>$casecocher2</td>\n";
-                echo "<td>$text_refus</td>\n";
-                if($_SESSION['config']['affiche_date_traitement'])
-                {
-                    if(empty($sql_date_traitement))
-                        echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_date_demande<br>". _('divers_traitement') ." : pas traité</td>\n" ;
-                    else
-                        echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_date_demande<br>". _('divers_traitement') ." : $sql_date_traitement</td>\n" ;
+                $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+                $return .= '<td>' . $sql_date_deb_fr . '_' . $demi_j_deb . '</td>';
+                $return .= '<td>' . $sql_date_fin_fr . '_' . $demi_j_fin . '</td>';
+                $return .= '<td>' . $sql_nb_jours . '</td>';
+                $return .= '<td>' . $sql_commentaire . '</td>';
+                $return .= '<td>' . $tab_type_all_abs[$sql_type]['libelle'] . '</td>';
+                $return .= '<td>' . $casecocher1 . '</td>';
+                $return .= '<td>' . $casecocher2 . '</td>';
+                $return .= '<td>' . $text_refus . '</td>';
+                if($_SESSION['config']['affiche_date_traitement']) {
+                    if(empty($sql_date_traitement)) {
+                        $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
+                    } else {
+                        $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_date_traitement . '</td>';
+                    }
                 }
-                echo "</tr>\n";
+                $return .= '</tr>';
                 $i = !$i;
             }
-            echo "</tbody>";
-            echo "</table>\n\n";
+            $return .= '</tbody></table>';
 
-            echo "<input type=\"hidden\" name=\"user_login\" value=\"$user_login\">\n";
-            echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_submit') ."\">";
-            echo "<a class=\"btn\" href=\"$PHP_SELF?session=$session\">". _('form_cancel') ."</a>\n";
-            echo " </form> \n";
+            $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
+            $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
+            $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+            $return .= ' </form>';
         }
+        return $return;
     }
 
     //affiche l'état des demandes du user (avec le formulaire pour le responsable)
@@ -1792,6 +1768,7 @@ class Fonctions
     {
         $PHP_SELF=$_SERVER['PHP_SELF']; ;
         $session=session_id();
+        $return = '';
 
         // Récupération des informations
         $sql2 = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement, p_num " .
@@ -1801,51 +1778,48 @@ class Fonctions
         $ReqLog2 = \includes\SQL::query($sql2);
 
         $count2=$ReqLog2->num_rows;
-        if($count2==0)
-        {
-            echo "<p><strong>". _('resp_traite_user_aucune_demande') ."</strong></p>\n";
-        }
-        else
-        {
+        if($count2==0) {
+            $return .= '<p><strong>' . _('resp_traite_user_aucune_demande') . '</strong></p>';
+        } else {
             // recup dans un tableau des types de conges
             $tab_type_all_abs = recup_tableau_tout_types_abs();
 
             // AFFICHAGE TABLEAU
-            echo " <form action=\"$PHP_SELF?session=$session&onglet=traite_user\" method=\"POST\"> \n";
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
             //echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\" width=\"80%\">\n";
-            echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\">\n";
-            echo "<tr align=\"center\">\n";
-            echo "<td>". _('divers_debut_maj_1') ."</td>\n";
-            echo "<td>". _('divers_fin_maj_1') ."</td>\n";
-            echo "<td>". _('divers_nb_jours_pris_maj_1') ."</td>\n";
-            echo "<td>". _('divers_comment_maj_1') ."</td>\n";
-            echo "<td>". _('divers_type_maj_1') ."</td>\n";
-            echo "<td>". _('divers_accepter_maj_1') ."</td>\n";
-            echo "<td>". _('divers_refuser_maj_1') ."</td>\n";
-            echo "<td>". _('resp_traite_user_motif_refus') ."</td>\n";
-            if($_SESSION['config']['affiche_date_traitement'])
-            {
-                echo "<td>". _('divers_date_traitement') ."</td>\n" ;
+            $return .= '<table cellpadding="2" class="table table-hover table-responsive table-condensed table-striped">';
+            $return .= '<tr align="center">';
+            $return .= '<td>' . _('divers_debut_maj_1') . '</td>';
+            $return .= '<td>' . _('divers_fin_maj_1') . '</td>';
+            $return .= '<td>' . _('divers_nb_jours_pris_maj_1') . '</td>';
+            $return .= '<td>' . _('divers_comment_maj_1') . '</td>';
+            $return .= '<td>' . _('divers_type_maj_1') . '</td>';
+            $return .= '<td>' . _('divers_accepter_maj_1') . '</td>';
+            $return .= '<td>' . _('divers_refuser_maj_1') . '</td>';
+            $return .= '<td>' . _('resp_traite_user_motif_refus') . '</td>';
+            if($_SESSION['config']['affiche_date_traitement']) {
+                $return .= '<td>' . _('divers_date_traitement') . '</td>';
             }
-            echo "</tr>\n";
+            $return .= '</tr>';
 
             $tab_checkbox=array();
-            while ($resultat2 = $ReqLog2->fetch_array())
-            {
+            while ($resultat2 = $ReqLog2->fetch_array()) {
                 $sql_date_deb = $resultat2["p_date_deb"];
                 $sql_date_deb_fr = eng_date_to_fr($resultat2["p_date_deb"]) ;
                 $sql_demi_jour_deb=$resultat2["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am")
+                if($sql_demi_jour_deb=="am") {
                     $demi_j_deb =  _('divers_am_short') ;
-                else
+                } else {
                     $demi_j_deb =  _('divers_pm_short') ;
+                }
                 $sql_date_fin = $resultat2["p_date_fin"];
                 $sql_date_fin_fr = eng_date_to_fr($resultat2["p_date_fin"]) ;
                 $sql_demi_jour_fin=$resultat2["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am")
+                if($sql_demi_jour_fin=="am") {
                     $demi_j_fin =  _('divers_am_short') ;
-                else
+                } else {
                     $demi_j_fin =  _('divers_pm_short') ;
+                }
                 $sql_nb_jours=affiche_decimal($resultat2["p_nb_jours"]) ;
                 $sql_commentaire=$resultat2["p_commentaire"] ;
                 $sql_type=$resultat2["p_type"] ;
@@ -1857,60 +1831,61 @@ class Fonctions
                 $chaine_bouton_radio = "$user_login--$sql_nb_jours--$sql_type--$sql_date_deb--$sql_demi_jour_deb--$sql_date_fin--$sql_demi_jour_fin";
 
                 // si le user fait l'objet d'une double validation on a pas le meme resultat sur le bouton !
-                if($tab_user['double_valid'] == "Y")
-                {
+                if($tab_user['double_valid'] == "Y") {
                     /*******************************/
                     /* verif si le resp est grand_responsable pour ce user*/
-                    if(in_array($_SESSION['userlogin'], $tab_grd_resp)) // si user_login est dans le tableau des grand responsable
+                    if(in_array($_SESSION['userlogin'], $tab_grd_resp)) { // si user_login est dans le tableau des grand responsable
                         $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
-                    else
+                    } else {
                         $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--VALID\">";
-                }
-                else
+                    }
+                } else {
                     $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
+                }
 
                 $boutonradio2 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--REFUSE\">";
 
                 $text_refus  = "<input type=\"text\" name=\"tab_text_refus[$sql_num]\" size=\"20\" max=\"100\">";
 
-                echo "<tr align=\"center\">\n";
-                echo "<td>$sql_date_deb_fr _ $demi_j_deb</td>\n";
-                echo "<td>$sql_date_fin_fr _ $demi_j_fin</td>\n";
-                echo "<td>$sql_nb_jours</td>\n";
-                echo "<td>$sql_commentaire</td>\n";
-                echo "<td>".$tab_type_all_abs[$sql_type]['libelle']."</td>\n";
-                echo "<td>$boutonradio1</td>\n";
-                echo "<td>$boutonradio2</td>\n";
-                echo "<td>$text_refus</td>\n";
-                echo "<td>$sql_date_demande</td>\n";
+                $return .= '<tr align="center">';
+                $return .= '<td>' . $sql_date_deb_fr . '_' . $demi_j_deb . '</td>';
+                $return .= '<td>' . $sql_date_fin_fr . '_' . $demi_j_fin . '</td>';
+                $return .= '<td>' . $sql_nb_jours . '</td>';
+                $return .= '<td>' . $sql_commentaire . '</td>';
+                $return .= '<td>' . $tab_type_all_abs[$sql_type]['libelle'] . '</td>';
+                $return .= '<td>' . $boutonradio1 . '</td>';
+                $return .= '<td>' . $boutonradio2 . '</td>';
+                $return .= '<td>' . $text_refus . '</td>';
+                $return .= '<td>' . $sql_date_demande . '</td>';
 
-                if($_SESSION['config']['affiche_date_traitement'])
-                {
-                    if(empty($sql_date_traitement))
-                        echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_date_demande<br>". _('divers_traitement') ." : pas traité</td>\n" ;
-                    else
-                        echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_date_demande<br>". _('divers_traitement') ." : $sql_date_traitement</td>\n" ;
+                if($_SESSION['config']['affiche_date_traitement']) {
+                    if(empty($sql_date_traitement)) {
+                        $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
+                    } else {
+                        $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_date_traitement . '</td>';
+                    }
                 }
 
-                echo "</tr>\n";
+                $return .= '</tr>';
             }
-            echo "</table>\n\n";
+            $return .= '</table>';
 
-            echo "<input type=\"hidden\" name=\"user_login\" value=\"$user_login\">\n";
-            echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_submit') ."\">";
-            echo "<a class=\"btn\" href=\"$PHP_SELF?session=$session\">". _('form_cancel') ."</a>\n";
-            echo " </form> \n";
+            $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
+            $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
+            $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+            $return .= '</form>';
         }
+        return $return;
     }
 
     public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date,  $DEBUG)
     {
         $PHP_SELF=$_SERVER['PHP_SELF']; ;
         $session=session_id();
+        $return = '';
 
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
-        if(!isset($_SESSION["tab_j_feries"]))
-        {
+        if(!isset($_SESSION["tab_j_feries"])) {
             init_tab_jours_feries();
             //print_r($GLOBALS["tab_j_feries"]);   // verif DEBUG
         }
@@ -1921,24 +1896,29 @@ class Fonctions
         $list_group_dbl_valid_du_resp = get_list_groupes_double_valid_du_resp($_SESSION['userlogin'],  $DEBUG);
         $tab_user=array();
         $tab_user = recup_infos_du_user($user_login, $list_group_dbl_valid_du_resp,  $DEBUG);
-        if( $DEBUG ) { echo"tab_user =<br>\n"; print_r($tab_user); echo "<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'tab_user =<br>' . var_export($tab_user) . '<br>';
+        }
 
         $list_all_users_du_resp=get_list_all_users_du_resp($_SESSION['userlogin'],  $DEBUG);
-        if( $DEBUG ) { echo"list_all_users_du_resp = $list_all_users_du_resp<br>\n"; }
+        if( $DEBUG ) {
+            $return .= 'list_all_users_du_resp = ' . $list_all_users_du_resp . '<br>';
+        }
 
         // recup des grd resp du user
         $tab_grd_resp=array();
-        if($_SESSION['config']['double_validation_conges'])
-        {
+        if($_SESSION['config']['double_validation_conges']) {
             get_tab_grd_resp_du_user($user_login, $tab_grd_resp,  $DEBUG);
-            if( $DEBUG ) { echo"tab_grd_resp =<br>\n"; print_r($tab_grd_resp); echo "<br>\n"; }
+            if( $DEBUG ) {
+                $return .= 'tab_grd_resp =<br>' . var_export($tab_grd_resp) . '<br>';
+            }
         }
 
-	include ROOT_PATH .'fonctions_javascript.php' ;
+        include_once ROOT_PATH . 'fonctions_javascript.php' ;
         /********************/
         /* Titre */
         /********************/
-        echo "<h1>".$tab_user['prenom']." ".$tab_user['nom']."</h1>\n\n";
+        $return .= '<h1>' . $tab_user['prenom'] . ' ' . $tab_user['nom'] . '</h1>';
 
 
         /********************/
@@ -1946,69 +1926,70 @@ class Fonctions
         /********************/
         // AFFICHAGE TABLEAU
         // affichage du tableau récapitulatif des solde de congés d'un user
-        echo affiche_tableau_bilan_conges_user($user_login);
-        echo "<hr/>\n";
+        $return .= affiche_tableau_bilan_conges_user($user_login);
+        $return .= '<hr/>';
 
         /*************************/
         /* SAISIE NOUVEAU CONGES */
         /*************************/
         // dans le cas ou les users ne peuvent pas saisir de demande, le responsable saisi les congès :
-        if( !$_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['resp_saisie_mission'] )
-        {
-
+        if( !$_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['resp_saisie_mission'] ) {
             // si les mois et année ne sont pas renseignés, on prend ceux du jour
-            if($year_calendrier_saisie_debut==0)
+            if($year_calendrier_saisie_debut==0) {
                 $year_calendrier_saisie_debut=date("Y");
-            if($mois_calendrier_saisie_debut==0)
+            }
+            if($mois_calendrier_saisie_debut==0) {
                 $mois_calendrier_saisie_debut=date("m");
-            if($year_calendrier_saisie_fin==0)
+            }
+            if($year_calendrier_saisie_fin==0) {
                 $year_calendrier_saisie_fin=date("Y");
-            if($mois_calendrier_saisie_fin==0)
+            }
+            if($mois_calendrier_saisie_fin==0) {
                 $mois_calendrier_saisie_fin=date("m");
-            if( $DEBUG ) { echo "$mois_calendrier_saisie_debut  $year_calendrier_saisie_debut  -  $mois_calendrier_saisie_fin  $year_calendrier_saisie_fin<br>\n"; }
+            }
+            if( $DEBUG ) {
+                $return .= $mois_calendrier_saisie_debut .  $year_calendrier_saisie_debut . ' - ' . $mois_calendrier_saisie_fin . $year_calendrier_saisie_fin . '<br>';
+            }
 
-            echo "<h2>". _('resp_traite_user_new_conges') ."</h2>\n";
+            $return .= '<h2>' . _('resp_traite_user_new_conges') . '</h2>';
 
             //affiche le formulaire de saisie d'une nouvelle demande de conges ou d'un  nouveau conges
             $onglet = "traite_user";
-            echo saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet);
+            $return .= saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet);
 
-            echo "<hr/>\n";
+            $return .= '<hr/>';
         }
 
         /*********************/
         /* Etat des Demandes */
         /*********************/
-        if($_SESSION['config']['user_saisie_demande'])
-        {
+        if($_SESSION['config']['user_saisie_demande']) {
             //verif si le user est bien un user du resp (et pas seulement du grand resp)
-            if(strstr($list_all_users_du_resp, "'$user_login'")!=FALSE)
-            {
-                echo "<h2>". _('resp_traite_user_etat_demandes') ."</h2>\n";
+            if(strstr($list_all_users_du_resp, "'$user_login'")!=FALSE) {
+                $return .= '<h2>' . _('resp_traite_user_etat_demandes') . '</h2>';
 
                 //affiche l'état des demandes du user (avec le formulaire pour le responsable)
-                \responsable\Fonctions::affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp,  $DEBUG);
+                $return .= \responsable\Fonctions::affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp,  $DEBUG);
 
-                echo "<hr/>\n";
+                $return .= '<hr/>';
             }
         }
 
         /*********************/
         /* Etat des Demandes en attente de 2ieme validation */
         /*********************/
-        if($_SESSION['config']['double_validation_conges'])
-        {
+        if($_SESSION['config']['double_validation_conges']) {
             /*******************************/
             /* verif si le resp est grand_responsable pour ce user*/
 
             if(in_array($_SESSION['userlogin'], $tab_grd_resp)) // si resp_login est dans le tableau
             {
-                echo "<h2>". _('resp_traite_user_etat_demandes_2_valid') ."</h2>\n";
+                $return .= '<h2>' . _('resp_traite_user_etat_demandes_2_valid') . '</h2>';
 
                 //affiche l'état des demande en attente de 2ieme valid du user (avec le formulaire pour le responsable)
-                \responsable\Fonctions::affiche_etat_demande_2_valid_user_for_resp($user_login,  $DEBUG);
+                $return .= \responsable\Fonctions::affiche_etat_demande_2_valid_user_for_resp($user_login,  $DEBUG);
 
-                echo "<hr/>\n";
+                $return .= '<hr/>';
             }
         }
 
@@ -2017,8 +1998,8 @@ class Fonctions
         /*******************/
         //affiche l'état des conges du user (avec le formulaire pour le responsable)
         $onglet = "traite_user";
-        \responsable\Fonctions::affiche_etat_conges_user_for_resp($user_login,  $year_affichage, $tri_date, $onglet, $DEBUG);
-
+        $return .= \responsable\Fonctions::affiche_etat_conges_user_for_resp($user_login,  $year_affichage, $tri_date, $onglet, $DEBUG);
+        return $return;
     }
 
     /**
@@ -2046,11 +2027,13 @@ class Fonctions
         $new_demi_jour_deb = getpost_variable('new_demi_jour_deb') ;
         $new_fin = getpost_variable('new_fin') ;
         $new_demi_jour_fin = getpost_variable('new_demi_jour_fin') ;
+        $return = '';
 
-        if($_SESSION['config']['disable_saise_champ_nb_jours_pris'])  // zone de texte en readonly et grisée
+        if($_SESSION['config']['disable_saise_champ_nb_jours_pris']) { // zone de texte en readonly et grisée
             $new_nb_jours = compter($user_login, '', $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $comment,  $DEBUG);
-        else
+        } else {
             $new_nb_jours = getpost_variable('new_nb_jours') ;
+        }
 
         $new_comment = getpost_variable('new_comment') ;
         $new_type = getpost_variable('new_type') ;
@@ -2067,34 +2050,29 @@ class Fonctions
 
 
         // si une annulation de conges a été selectionée :
-        if($tab_checkbox_annule!="")
-        {
-            \responsable\Fonctions::annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul,  $DEBUG);
+        if($tab_checkbox_annule!="") {
+            $return .= \responsable\Fonctions::annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul,  $DEBUG);
         }
         // si le traitement des demandes a été selectionée :
-        elseif($tab_radio_traite_demande!="")
-        {
-            \responsable\Fonctions::traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus,  $DEBUG);
+        elseif($tab_radio_traite_demande!="") {
+            $return .= \responsable\Fonctions::traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus,  $DEBUG);
         }
         // si un nouveau conges ou absence a été saisi pour un user :
-        elseif($new_demande_conges==1)
-        {
-            \responsable\Fonctions::new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type,  $DEBUG);
+        elseif($new_demande_conges==1) {
+            $return .= \responsable\Fonctions::new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type,  $DEBUG);
+        } else {
+            $return .= \responsable\Fonctions::affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date,  $DEBUG);
         }
-        else
-        {
-            \responsable\Fonctions::affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date,  $DEBUG);
-        }
+        return $return;
     }
 
     public static function traite_all_demande_en_cours( $tab_bt_radio, $tab_text_refus, $DEBUG=FALSE)
     {
-
         $PHP_SELF=$_SERVER['PHP_SELF'];
         $session=session_id();
+        $return = '';
 
-        while($elem_tableau = each($tab_bt_radio))
-        {
+        while($elem_tableau = each($tab_bt_radio)) {
             $champs = explode("--", $elem_tableau['value']);
             $user_login=$champs[0];
             $user_nb_jours_pris=$champs[1];
@@ -2107,11 +2085,10 @@ class Fonctions
 
             $numero=$elem_tableau['key'];
             $numero_int=(int) $numero;
-            echo "$numero---$user_login---$user_nb_jours_pris---$reponse<br>\n";
+            $return .= $numero . '---' . $user_login . '---' . $user_nb_jours_pris . '---' . $reponse . '<br>';
 
             /* Modification de la table conges_periode */
-            if(strcmp($reponse, "VALID")==0)
-            {
+            if(strcmp($reponse, "VALID")==0) {
                 /* UPDATE table "conges_periode" */
                 $sql1 = 'UPDATE conges_periode SET p_etat=\'valid\', p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
                 /* On valide l'UPDATE dans la table "conges_periode" ! */
@@ -2122,13 +2099,13 @@ class Fonctions
                     log_action($numero_int, "valid", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $reponse",  $DEBUG);
 
                     //envoi d'un mail d'alerte au user et au responsable du resp (pour double validation) (si demandé dans config de libertempo)
-                    if($_SESSION['config']['mail_prem_valid_conges_alerte_user'])
+                    if($_SESSION['config']['mail_prem_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "valid_conges",  $DEBUG);
+                    }
                 }
             }
 
-            if(strcmp($reponse, "OK")==0)
-            {
+            if(strcmp($reponse, "OK")==0) {
                 /* UPDATE table "conges_periode" */
                 $sql1 = 'UPDATE conges_periode SET p_etat="ok", p_date_traitement=NOW() WHERE p_num="'.\includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
                 /* On valide l'UPDATE dans la table "conges_periode" ! */
@@ -2142,12 +2119,11 @@ class Fonctions
                     soustrait_solde_et_reliquat_user($user_login, $numero_int, $user_nb_jours_pris, $type_abs, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin, $DEBUG);
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_valid_conges_alerte_user'])
+                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "accept_conges",  $DEBUG);
+                    }
                 }
-            }
-            elseif(strcmp($reponse, "not_OK")==0)
-            {
+            } elseif(strcmp($reponse, "not_OK")==0) {
                 // recup du motif de refus
                 $motif_refus=addslashes($tab_text_refus[$numero_int]);
                 $sql1 = 'UPDATE conges_periode SET p_etat=\'refus\', p_motif_refus=\''.$motif_refus.'\', p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
@@ -2161,25 +2137,24 @@ class Fonctions
 
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_refus_conges_alerte_user'])
+                    if($_SESSION['config']['mail_refus_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges",  $DEBUG);
+                    }
                 }
             }
         }
 
-        if( $DEBUG )
-        {
-            echo "<form action=\"$PHP_SELF?sesssion=$session&onglet=traitement_demande\" method=\"POST\">\n" ;
-            echo "<input type=\"hidden\" name=\"session\" value=\"$session\">\n";
-            echo "<input class=\"btn\" type=\"submit\" value=\"". _('form_ok') ."\">\n";
-            echo "</form>\n" ;
-        }
-        else
-        {
-            echo  _('form_modif_ok') ."<br><br> \n";
+        if( $DEBUG ) {
+            $return .= '<form action="' . $PHP_SELF . '?sesssion=' . $session . '&onglet=traitement_demande" method="POST">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
+            $return .= '<input class="btn" type="submit" value="' . _('form_ok') . '">';
+            $return .= '</form>';
+        } else {
+            $return .= _('form_modif_ok') . '<br><br>';
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=$PHP_SELF?session=$session&onglet=traitement_demandes\">";
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF  . '?session=' . $session . '&onglet=traitement_demandes">';
         }
+        return $return;
     }
 
     public static function affiche_all_demandes_en_cours($tab_type_conges,  $DEBUG=FALSE)
@@ -2189,13 +2164,15 @@ class Fonctions
         $session=session_id() ;
         $count1=0;
         $count2=0;
+        $return = '';
 
         $tab_type_all_abs = recup_tableau_tout_types_abs();
 
         // recup du tableau des types de conges (seulement les conges exceptionnels)
         $tab_type_conges_exceptionnels=array();
-        if ($_SESSION['config']['gestion_conges_exceptionnels'])
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
             $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels( $DEBUG);
+        }
 
         /*********************************/
         // Récupération des informations
@@ -2203,57 +2180,52 @@ class Fonctions
 
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est responsable
         $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin'],  $DEBUG);
-        if( $DEBUG ) { echo "tab_all_users_du_resp :<br>\n"; print_r($tab_all_users_du_resp); echo "<br><br>\n";}
+        if( $DEBUG ) {
+            $return .= 'tab_all_users_du_resp :<br>' . var_export($tab_all_users_du_resp, true) . '<br><br>';
+        }
 
         // si tableau des users du resp n'est pas vide
-        if( count($tab_all_users_du_resp) !=0 )
-        {
+        if( count($tab_all_users_du_resp) !=0 ) {
             // constitution de la liste (séparé par des virgules) des logins ...
             $list_users_du_resp="";
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user)
-            {
-                if($list_users_du_resp=="")
+            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+                if($list_users_du_resp=="") {
                     $list_users_du_resp= "'$current_login'" ;
-                else
+                } else {
                     $list_users_du_resp=$list_users_du_resp.", '$current_login'" ;
+                }
             }
         }
 
 
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est GRAND responsable
-        if( $_SESSION['config']['double_validation_conges'] )
-        {
+        if( $_SESSION['config']['double_validation_conges'] ) {
             $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin'],  $DEBUG);
 
             // si tableau des users du grand resp n'est pas vide
-            if( count($tab_all_users_du_grand_resp)!=0 )
-            {
+            if( count($tab_all_users_du_grand_resp)!=0 ) {
                 // constitution de la liste (séparé par des virgules) des logins ...
                 $list_users_du_grand_resp="";
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user)
-                {
-                    if($list_users_du_grand_resp=="")
+                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+                    if($list_users_du_grand_resp=="") {
                         $list_users_du_grand_resp= "'$current_login'" ;
-                    else
+                    } else {
                         $list_users_du_grand_resp=$list_users_du_grand_resp.", '$current_login'" ;
+                    }
                 }
             }
         }
 
         /*********************************/
 
-
-
-
-        echo " <form action=\"$PHP_SELF?session=$session&onglet=traitement_demandes\" method=\"POST\"> \n" ;
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traitement_demandes" method="POST">';
 
         /*********************************/
         /* TABLEAU DES DEMANDES DES USERS DONT ON EST LE RESP */
         /*********************************/
 
         // si tableau des users du resp n'est pas vide
-        if( count($tab_all_users_du_resp)!=0 )
-        {
+        if( count($tab_all_users_du_resp)!=0 ) {
 
             // Récup des demandes en cours pour les users dont $_SESSION['userlogin'] est responsable :
             $sql1 = "SELECT p_num, p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement FROM conges_periode ";
@@ -2264,22 +2236,20 @@ class Fonctions
             $ReqLog1 = \includes\SQL::query($sql1) ;
 
             $count1=$ReqLog1->num_rows;
-            if($count1!=0)
-            {
+            if($count1!=0) {
                 // AFFICHAGE TABLEAU DES DEMANDES EN COURS
 
-                echo "<h3>". _('resp_traite_demandes_titre_tableau_1') ."</h3>\n" ;
-
-                echo "<table cellpadding=\"2\" class=\"table table-hover table-responsive table-condensed table-striped\">\n" ;
-                echo "<thead>\n" ;
-                echo "<tr>\n" ;
-                echo "<th>". _('divers_nom_maj_1') ."<br>". _('divers_prenom_maj_1') ."</th>\n" ;
-                echo "<th>". _('divers_quotite_maj_1') ."</th>" ;
-                echo "<th>". _('divers_type_maj_1') ."</th>\n" ;
-                echo "<th>". _('divers_debut_maj_1') ."</th>\n" ;
-                echo "<th>". _('divers_fin_maj_1') ."</th>\n" ;
-                echo "<th>". _('divers_comment_maj_1') ."</th>\n" ;
-                echo "<th>". _('resp_traite_demandes_nb_jours') ."</th>";
+                $return .= '<h3>' . _('resp_traite_demandes_titre_tableau_1') . '</h3>';
+                $return .= '<table cellpadding="2" class="table table-hover table-responsive table-condensed table-striped">';
+                $return .= '<thead>';
+                $return .= '<tr>';
+                $return .= '<th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_fin_maj_1') . '</th>' ;
+                $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+                $return .= '<th>' . _('resp_traite_demandes_nb_jours') . '</th>';
                 // foreach($tab_type_conges as $id_conges => $libelle)
                 // {
                 // 	echo "<th>". _('divers_solde_maj_1') ."<br>$libelle</th>" ;
@@ -2289,23 +2259,21 @@ class Fonctions
                 // {
                 // 	echo "<th>". _('divers_solde_maj_1') ."<br>$libelle</th>" ;
                 // }
-                echo "<th>". _('divers_solde') ."</th>\n" ;
-                echo "<th>". _('divers_accepter_maj_1') ."</th>\n" ;
-                echo "<th>". _('divers_refuser_maj_1') ."</th>\n" ;
-                echo "<th>". _('resp_traite_demandes_attente') ."</th>\n" ;
-                echo "<th>". _('resp_traite_demandes_motif_refus') ."</th>\n" ;
-                if($_SESSION['config']['affiche_date_traitement'])
-                {
-                    echo "<th>". _('divers_date_traitement') ."</th>\n" ;
+                $return .= '<th>' . _('divers_solde') . '</th>';
+                $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
+                $return .= '<th>' . _('resp_traite_demandes_attente') . '</th>' ;
+                $return .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
+                if($_SESSION['config']['affiche_date_traitement']) {
+                    $return .= '<th>' . _('divers_date_traitement') . '</th>';
                 }
-                echo "</tr>\n";
-                echo "</thead>\n" ;
-                echo "<tbody>\n" ;
+                $return .= '</tr>';
+                $return .= '</thead>';
+                $return .= '<tbody>';
 
                 $i = true;
                 $tab_bt_radio=array();
-                while ($resultat1 = $ReqLog1->fetch_array())
-                {
+                while ($resultat1 = $ReqLog1->fetch_array()) {
                     /** sur la ligne ,   **/
                     /** le 1er bouton radio est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--OK"> */
                     /**  et le 2ieme est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--not_OK"> */
@@ -2331,28 +2299,28 @@ class Fonctions
                     $chaine_bouton_radio = "$sql_p_login--$sql_p_nb_jours--$sql_p_type--$sql_p_date_deb--$sql_p_demi_jour_deb--$sql_p_date_fin--$sql_p_demi_jour_fin";
 
                     // si le user fait l'objet d'une double validation on a pas le meme resultat sur le bouton !
-                    if($tab_all_users_du_resp[$sql_p_login]['double_valid'] == "Y")
-                    {
+                    if($tab_all_users_du_resp[$sql_p_login]['double_valid'] == "Y") {
                         // si on est a la fois resp et grand resp
-                        if( (count($tab_all_users_du_grand_resp)!=0 ) && (array_key_exists($sql_p_login, $tab_all_users_du_grand_resp)) )
+                        if( (count($tab_all_users_du_grand_resp)!=0 ) && (array_key_exists($sql_p_login, $tab_all_users_du_grand_resp)) ) {
                             $boutonradio1="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--OK\">";
-                        else  //on est QUe resp
+                        } else { //on est QUe resp
                             $boutonradio1="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--VALID\">";
-                    }
-                    else
+                        }
+                    } else {
                         $boutonradio1="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--OK\">";
+                    }
 
                     $boutonradio2="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--not_OK\">";
                     $boutonradio3="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--RIEN\" checked>";
 
                     $text_refus="<input class=\"form-control\" type=\"text\" name=\"tab_text_refus[$sql_p_num]\" size=\"20\" max=\"100\">";
 
-                    echo '<tr class="'.($i?'i':'p').'">';
-                    echo "<td><b>".$tab_all_users_du_resp[$sql_p_login]['nom']."</b><br>".$tab_all_users_du_resp[$sql_p_login]['prenom']."</td><td>".$tab_all_users_du_resp[$sql_p_login]['quotite']."%</td>";
-                    echo "<td>".$tab_type_all_abs[$sql_p_type]['libelle']."</td>\n";
-                    echo "<td>$sql_p_date_deb_fr <span class=\"demi\">$demi_j_deb</span></td><td>$sql_p_date_fin_fr <span class=\"demi\">$demi_j_fin</span></td><td>$sql_p_commentaire</td><td><b>$sql_p_nb_jours</b></td>";
+                    $return .= '<tr class="'.($i?'i':'p').'">';
+                    $return .= '<td><b>' . $tab_all_users_du_resp[$sql_p_login]['nom'] . '</b><br>' . $tab_all_users_du_resp[$sql_p_login]['prenom'] . '</td><td>' . $tab_all_users_du_resp[$sql_p_login]['quotite'] . '%</td>';
+                    $return .= '<td>' . $tab_type_all_abs[$sql_p_type]['libelle'] . '</td>';
+                    $return .= '<td>' . $sql_p_date_deb_fr . '<span class="demi">' . $demi_j_deb . '</span></td><td>' . $sql_p_date_fin_fr . '<span class="demi">' . $demi_j_fin . '</span></td><td>' . $sql_p_commentaire . '</td><td><b>' . $sql_p_nb_jours . '</b></td>';
                     $tab_conges=$tab_all_users_du_resp[$sql_p_login]['conges'];
-                    echo "<td>".$tab_conges[$tab_type_all_abs[$sql_p_type]['libelle']]['solde']."</td>";
+                    $return .= '<td>' . $tab_conges[$tab_type_all_abs[$sql_p_type]['libelle']]['solde'] . '</td>';
                     // foreach($tab_type_conges as $id_conges => $libelle)
                     // {
                     // 	echo "<td>".$tab_conges[$libelle]['solde']."</td>";
@@ -2363,20 +2331,20 @@ class Fonctions
                     // 	echo "<td>".$tab_conges[$libelle]['solde']."</td>";
                     // }
                     // echo "<td>".$tab_type_all_abs[$sql_p_type]['libelle']."</td>\n";
-                    echo "<td>$boutonradio1</td><td>$boutonradio2</td><td>$boutonradio3</td><td>$text_refus</td>\n";
-                    if($_SESSION['config']['affiche_date_traitement'])
-                    {
-                        if($sql_p_date_demande == NULL)
-                            echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : $sql_p_date_traitement</td>\n" ;
-                        else
-                            echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : pas traité</td>\n" ;
+                    $return .= '<td>' . $boutonradio1 . '</td><td>' . $boutonradio2 . '</td><td>' . $boutonradio3 . '</td><td>' . $text_refus . '</td>';
+                    if($_SESSION['config']['affiche_date_traitement']) {
+                        if($sql_p_date_demande == NULL) {
+                            $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
+                        } else {
+                            $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
+                        }
                     }
 
-                    echo "</tr>\n" ;
+                    $return .= '</tr>';
                     $i = !$i;
                 } // while
-                echo "</tbody>\n" ;
-                echo "</table>\n\n" ;
+                $return .= '</tbody>';
+                $return .= '</table>';
             } //if($count1!=0)
         } //if( count($tab_all_users_du_resp)!=0 )
 
@@ -2385,12 +2353,10 @@ class Fonctions
         /* TABLEAU DES DEMANDES DES USERS DONT ON EST LE GRAND RESP */
         /*********************************/
 
-        if($_SESSION['config']['double_validation_conges'])
-        {
+        if($_SESSION['config']['double_validation_conges']) {
 
             // si tableau des users du grand resp n'est pas vide
-            if( count($tab_all_users_du_grand_resp)!=0 )
-            {
+            if( count($tab_all_users_du_grand_resp)!=0 ) {
 
                 // Récup des demandes en cours pour les users dont $_SESSION['userlogin'] est GRAND responsable :
                 $sql2 = "SELECT p_num, p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement FROM conges_periode ";
@@ -2401,40 +2367,38 @@ class Fonctions
                 $ReqLog2 = \includes\SQL::query($sql2) ;
 
                 $count2=$ReqLog2->num_rows;
-                if($count2!=0)
-                {
+                if($count2!=0) {
                     // AFFICHAGE TABLEAU DES DEMANDES EN COURS POUR DEUXIEME VALIDATION
 
-                    echo "<h3>". _('resp_traite_demandes_titre_tableau_2') ."</h3>\n" ;
+                    $return .= '<h3>' . _('resp_traite_demandes_titre_tableau_2') . '</h3>';
 
-                    echo "<table class=\"table table-hover table-responsive table-condensed table-striped\">\n" ;
-                    echo "<thead>\n" ;
-                    echo "<tr>\n" ;
-                    echo "<th><b>". _('divers_nom_maj_1') ."</b><br>". _('divers_prenom_maj_1') ."</th>\n" ;
-                    echo "<th>". _('divers_quotite_maj_1') ."</th>" ;
-                    echo "<th>". _('divers_debut_maj_1') ."</th>\n" ;
-                    echo "<th>". _('divers_fin_maj_1') ."</th>\n" ;
-                    echo "<th>". _('divers_comment_maj_1') ."</th>\n" ;
-                    echo "<th>". _('resp_traite_demandes_nb_jours') ."</th>";
-                    foreach($tab_type_conges as $id_conges => $libelle)
-                        echo "<th>". _('divers_solde_maj_1') ."<br>$libelle</th>" ;
-                    echo "<th>". _('divers_type_maj_1') ."</th>\n" ;
-                    echo "<th>". _('divers_accepter_maj_1') ."</th>\n" ;
-                    echo "<th>". _('divers_refuser_maj_1') ."</th>\n" ;
-                    echo "<th>". _('resp_traite_demandes_attente') ."</th>\n" ;
-                    echo "<th>". _('resp_traite_demandes_motif_refus') ."</th>\n" ;
-                    if($_SESSION['config']['affiche_date_traitement'])
-                    {
-                        echo "<th>". _('divers_date_traitement') ."</th>\n" ;
+                    $return .= '<table class="table table-hover table-responsive table-condensed table-striped">';
+                    $return .= '<thead>';
+                    $return .= '<tr>';
+                    $return .= '<th><b>' . _('divers_nom_maj_1') . '</b><br>' . _('divers_prenom_maj_1') . '</th>';
+                    $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
+                    $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
+                    $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
+                    $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+                    $return .= '<th>' . _('resp_traite_demandes_nb_jours') . '</th>';
+                    foreach($tab_type_conges as $id_conges => $libelle) {
+                        $return .= '<th>' . _('divers_solde_maj_1') . '<br>' . $libelle . '</th>';
                     }
-                    echo "</tr>\n";
-                    echo "</thead>\n" ;
-                    echo "<tbody>\n" ;
+                    $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+                    $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
+                    $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
+                    $return .= '<th>' . _('resp_traite_demandes_attente') . '</th>';
+                    $return .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
+                    if($_SESSION['config']['affiche_date_traitement']) {
+                        $return .= '<th>' . _('divers_date_traitement') . '</th>';
+                    }
+                    $return .= '</tr>';
+                    $return .= '</thead>';
+                    $return .= '<tbody>';
 
                     $i = true;
                     $tab_bt_radio=array();
-                    while ($resultat2 = $ReqLog2->fetch_array())
-                    {
+                    while ($resultat2 = $ReqLog2->fetch_array()) {
                         /** sur la ligne ,   **/
                         /** le 1er bouton radio est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--OK"> */
                         /**  et le 2ieme est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--not_OK"> */
@@ -2465,40 +2429,39 @@ class Fonctions
 
                         $text_refus="<input class=\"form-control\" type=\"text\" name=\"tab_text_refus[$sql_p_num]\" size=\"20\" max=\"100\">";
 
-                        echo '<tr class="'.($i?'i':'p').'">';
-                        echo "<td><strong>".$tab_all_users_du_grand_resp[$sql_p_login]['nom']."</strong><br>".$tab_all_users_du_grand_resp[$sql_p_login]['prenom']."</td><td>".$tab_all_users_du_grand_resp[$sql_p_login]['quotite']."%</td>";
-                        echo "<td>$sql_p_date_deb_fr <span class=\"demi\">$demi_j_deb<span></td><td>$sql_p_date_fin_fr <span class=\"demi\">$demi_j_fin</span></td><td>$sql_p_commentaire</td><td><b>$sql_p_nb_jours</b></td>";
+                        $return .= '<tr class="'.($i?'i':'p').'">';
+                        $return .= '<td><strong>' . $tab_all_users_du_grand_resp[$sql_p_login]['nom'] . '</strong><br>' . $tab_all_users_du_grand_resp[$sql_p_login]['prenom'] . '</td><td>' . $tab_all_users_du_grand_resp[$sql_p_login]['quotite'] . '%</td>';
+                        $return .= '<td>' . $sql_p_date_deb_fr . '<span class="demi">' . $demi_j_deb . '<span></td><td>' . $sql_p_date_fin_fr . '<span class="demi">' . $demi_j_fin . '</span></td><td>' . $sql_p_commentaire . '</td><td><b>' . $sql_p_nb_jours . '</b></td>';
                         $tab_conges=$tab_all_users_du_grand_resp[$sql_p_login]['conges'];
-                        foreach($tab_type_conges as $id_conges => $libelle)
-                        {
-                            echo "<td>".$tab_conges[$libelle]['solde']."</td>";
+                        foreach($tab_type_conges as $id_conges => $libelle) {
+                            $return .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
                         }
-                        echo "<td>".$tab_type_all_abs[$sql_p_type]['libelle']."</td>";
-                        echo "<td>$boutonradio1</td><td>$boutonradio2</td><td>$boutonradio3</td><td>$text_refus</td>\n";
-                        if($_SESSION['config']['affiche_date_traitement'])
-                        {
-                            echo "<td class=\"histo-left\">". _('divers_demande') ." : $sql_p_date_demande<br>". _('divers_traitement') ." : $sql_p_date_traitement</td>\n" ;
+                        $return .= '<td>' . $tab_type_all_abs[$sql_p_type]['libelle'] . '</td>';
+                        $return .= '<td>' . $boutonradio1 . '</td><td>' . $boutonradio2 . '</td><td>' . $boutonradio3 . '</td><td>' . $text_refus . '</td>';
+                        if($_SESSION['config']['affiche_date_traitement']) {
+                            $return .= '<td class="histo-left">' . _('divers_demande') . ' : '. $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
                         }
 
-                        echo "</tr>\n" ;
+                        $return .= '</tr>';
                         $i = !$i;
                     } //while
-                    echo "</tbody>\n" ;
-                    echo "</table>\n\n" ;
+                    $return .= '</tbody>';
+                    $retur .= '</table>';
                 } //if($count2!=0)
             } //if( count($tab_all_users_du_grand_resp)!=0 )
         } //if($_SESSION['config']['double_validation_conges'])
 
-        echo "<br>\n";
+        $return .= '<br>';
 
-        if(($count1==0) && ($count2==0))
-            echo "<strong>". _('resp_traite_demandes_aucune_demande') ."</strong>\n";
-        else {
-            echo "<hr/>\n";
-            echo "<input class=\"btn btn-success\" type=\"submit\" value=\"". _('form_submit') ."\">\n" ;
+        if(($count1==0) && ($count2==0)) {
+            $return .= '<strong>' . _('resp_traite_demandes_aucune_demande') . '</strong>';
+        } else {
+            $return .= '<hr/>';
+            $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
         }
 
-        echo " </form> \n" ;
+        $return .= '</form>';
+        return $return;
     }
 
     /**
@@ -2513,16 +2476,18 @@ class Fonctions
         //var pour resp_traite_demande_all.php
         $tab_bt_radio   = getpost_variable('tab_bt_radio');
         $tab_text_refus = getpost_variable('tab_text_refus');
-
+        $return = '';
 
         // titre
-        echo "<h1>". _('resp_traite_demandes_titre') ."</h1>";
+        $return .= '<h1>' . _('resp_traite_demandes_titre') . '</h1>';
 
 
         // si le tableau des bouton radio des demandes est vide , on affiche les demandes en cours
-        if($tab_bt_radio=="")
-            \responsable\Fonctions::affiche_all_demandes_en_cours($tab_type_cong,  $DEBUG);
-        else
-            \responsable\Fonctions::traite_all_demande_en_cours( $tab_bt_radio, $tab_text_refus, $DEBUG);
+        if($tab_bt_radio=="") {
+            $return .= \responsable\Fonctions::affiche_all_demandes_en_cours($tab_type_cong,  $DEBUG);
+        } else {
+            $return .= \responsable\Fonctions::traite_all_demande_en_cours( $tab_bt_radio, $tab_text_refus, $DEBUG);
+        }
+        return $return;
     }
 }

--- a/responsable/resp_ajout_conges.php
+++ b/responsable/resp_ajout_conges.php
@@ -3,20 +3,20 @@
 Libertempo : Gestion Interactive des Congés
 Copyright (C) 2015 (Wouldsmina)Copyright (C) 2015 (Prytoegrian)Copyright (C) 2005 (cedric chauvineau)
 
-Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les 
+Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
 termes de la Licence Publique Générale GNU publiée par la Free Software Foundation.
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE, 
-ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation 
+Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE,
+ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation
 dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pour plus de détails.
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps 
-que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation, 
+Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
+que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
 *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU General Public License as published by the Free Software Foundation; either 
+of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
@@ -24,4 +24,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-\responsable\Fonctions::ajoutCongesModule($tab_type_cong, $DEBUG);
+echo \responsable\Fonctions::ajoutCongesModule($tab_type_cong, $DEBUG);

--- a/responsable/resp_cloture_exercice.php
+++ b/responsable/resp_cloture_exercice.php
@@ -3,20 +3,20 @@
 Libertempo : Gestion Interactive des Congés
 Copyright (C) 2015 (Wouldsmina)Copyright (C) 2015 (Prytoegrian)Copyright (C) 2005 (cedric chauvineau)
 
-Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les 
+Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
 termes de la Licence Publique Générale GNU publiée par la Free Software Foundation.
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE, 
-ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation 
+Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE,
+ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation
 dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pour plus de détails.
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps 
-que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation, 
+Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
+que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
 *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU General Public License as published by the Free Software Foundation; either 
+of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
@@ -24,5 +24,5 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-\responsable\Fonctions::clotureExerciceModule($DEBUG);
-
+echo \responsable\Fonctions::clotureExerciceModule($DEBUG);
+bottom();

--- a/responsable/resp_page_principale.php
+++ b/responsable/resp_page_principale.php
@@ -26,4 +26,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-\responsable\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session, $DEBUG);
+echo \responsable\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session, $DEBUG);

--- a/responsable/resp_traite_user.php
+++ b/responsable/resp_traite_user.php
@@ -24,4 +24,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-\responsable\Fonctions::traiteUserModule($DEBUG);
+echo \responsable\Fonctions::traiteUserModule($DEBUG);

--- a/responsable/resp_traitement_demandes.php
+++ b/responsable/resp_traitement_demandes.php
@@ -3,20 +3,20 @@
 Libertempo : Gestion Interactive des Congés
 Copyright (C) 2015 (Wouldsmina)Copyright (C) 2015 (Prytoegrian)Copyright (C) 2005 (cedric chauvineau)
 
-Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les 
+Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
 termes de la Licence Publique Générale GNU publiée par la Free Software Foundation.
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE, 
-ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation 
+Ce programme est distribué car potentiellement utile, mais SANS AUCUNE GARANTIE,
+ni explicite ni implicite, y compris les garanties de commercialisation ou d'adaptation
 dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pour plus de détails.
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps 
-que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation, 
+Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
+que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
 *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
-of the GNU General Public License as published by the Free Software Foundation; either 
+of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
@@ -24,4 +24,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-\responsable\Fonctions::traitementDemandesModule($tab_type_cong, $DEBUG);
+echo \responsable\Fonctions::traitementDemandesModule($tab_type_cong, $DEBUG);


### PR DESCRIPTION
Pour #63, suite #76 et #89.

Là encore, les echo disparaissent au profit d'un stockage, étape nécessaire pour avoir de vraies vues. Comme pour les précédentes PR, j'en ai profité pour faire un petit formatage PSR2 ie. accolade accolée pour les structures de flow (if, while, etc.) ainsi que rendre obligatoire la présence d'accolades et virer tous les « \n » qui ne servent à rien vu qu'on est pas en cli.

Un diff plus lisible peut être trouvé [ici](https://github.com/wouldsmina/Libertempo/pull/95/files?w=0), pas pour responsable/Fonction par contre. Je crois comprendre que c'est la transformation des tab sur un aussi gros nombre de lignes qu'il aime pas.