### PR TITLE
1.8.1

### DIFF
--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1031,7 +1031,7 @@ function get_list_all_users_du_resp($resp_login)
     }
 
     $sql1=$sql1." ) " ;
-    $sql1 = $sql1." ORDER BY u_nom " ;
+    $sql1 = $sql1." ORDER BY u_login " ;
     $ReqLog1 = \includes\SQL::query($sql1);
 
     while ($resultat1 = $ReqLog1->fetch_array())
@@ -1060,7 +1060,7 @@ function get_list_all_users_du_resp($resp_login)
         }
 
         $sql_2=$sql_2." ) " ;
-        $sql_2 = $sql_2." ORDER BY u_nom " ;
+        $sql_2 = $sql_2." ORDER BY u_login " ;
 
         $ReqLog_2 = \includes\SQL::query($sql_2);
 

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1096,7 +1096,7 @@ function get_list_users_du_groupe($group_id)
     $sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = '.intval($group_id).' ORDER BY gu_login ';
     $ReqLog1 = \includes\SQL::query($sql1);
     while ($resultat1 = $ReqLog1->fetch_array())
-        $list_users[] = '"'.\includes\SQL::quote($resultat1["gu_login"]).'"';
+        $list_users[] = "'".\includes\SQL::quote($resultat1["gu_login"])."'";
 
     $list_users = implode(' , ', $list_users);
     return $list_users;

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -1282,17 +1282,17 @@ class Fonctions
         foreach($tab_champ_saisie as $user_name => $tab_conges)   // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
         {
           foreach($tab_conges as $id_conges => $user_nb_jours_ajout) {
-            $valid=verif_saisie_decimal($user_nb_jours_ajout_float);   //verif la bonne saisie du nombre décimal
+            $valid=verif_saisie_decimal($user_nb_jours_ajout);   //verif la bonne saisie du nombre décimal
             if($valid) {
-              if($user_nb_jours_ajout_float!=0) {
+              if($user_nb_jours_ajout!=0) {
                 /* Modification de la table conges_users */
-                $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde+'.$user_nb_jours_ajout_float.' WHERE su_login="'. \includes\SQL::quote($user_name).'" AND su_abs_id = "'. \includes\SQL::quote($id_conges).'";';
+                $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde+'.$user_nb_jours_ajout.' WHERE su_login="'. \includes\SQL::quote($user_name).'" AND su_abs_id = "'. \includes\SQL::quote($id_conges).'";';
                 /* On valide l'UPDATE dans la table ! */
                 $ReqLog1 = \includes\SQL::query($sql1) ;
 
                 // on insert l'ajout de conges dans la table periode
                 $commentaire =  _('resp_ajout_conges_comment_periode_user') ;
-                \hr\Fonctions::insert_ajout_dans_periode($user_name, $user_nb_jours_ajout_float, $id_conges, $commentaire);
+                \hr\Fonctions::insert_ajout_dans_periode($user_name, $user_nb_jours_ajout, $id_conges, $commentaire);
               }
             }
           }

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -402,7 +402,7 @@ function authentification_passwd_conges_CAS()
 
 
     // Vérification SSL
-    if(isset($config_CAS_CACERT))
+    if(!empty($config_CAS_CACERT))
         phpCAS::setCasServerCACert ($config_CAS_CACERT);
     else
         phpCAS::setNoCasServerValidation();

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -172,6 +172,7 @@ class Fonctions {
         // affichage de la liste des versions ...
         echo "<select name=\"version\">\n";
         echo "<option value=\"0\">". _('install_installed_version') ."</option>\n";
+        echo "<option value=\"1.8\">v1.8</option>\n"; 
         echo "<option value=\"1.7.0\">v1.7.0</option>\n"; 
         echo "<option value=\"1.6.0\">v1.6.x</option>\n";
         echo "<option value=\"1.5.1\">v1.5.x</option>\n";
@@ -322,29 +323,27 @@ class Fonctions {
                 $start_version=$installed_version ;
 
             //on lance l'execution (include) des scripts d'upgrade l'un après l'autre jusqu a la version voulue ($config_php_conges_version) ..
-            if(($start_version=="1.5.0")||($start_version=="1.5.1"))
-            {
+            if(($start_version=="1.5.0")||($start_version=="1.5.1")) {
                 $file_upgrade='upgrade_from_v1.5.0.php';
                 $new_installed_version="1.6.0";
                 // execute le script php d'upgrade de la version1.5.0 (vers la suivante (1.6.0))
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?version=$new_installed_version&lang=$lang\">";
-            }
-            elseif($start_version=="1.6.0")
-            {
+            } elseif($start_version=="1.6.0") {
                 $file_upgrade='upgrade_from_v1.6.0.php';
                 $new_installed_version="1.7.0";
                 // execute le script php d'upgrade de la version1.6.0 (vers la suivante (1.7.0))
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?version=$new_installed_version&lang=$lang\">";
-            }
-            elseif($start_version=="1.7.0") 
-	    {
+            } elseif($start_version=="1.7.0") {
 		$file_upgrade='upgrade_from_v1.7.0.php';
 		$new_installed_version="1.8";
 		// execute le script php d'upgrade de la version1.7.0 (vers la suivante (1.8))
 		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?version=$new_installed_version&lang=$lang\">";
-	    } 
-            else
-            {
+	    } elseif($start_version=="1.8") {
+		$file_upgrade='upgrade_from_v1.8.php';
+		$new_installed_version="1.8.1";
+		// execute le script php d'upgrade de la version1.7.0 (vers la suivante (1.8))
+		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?version=$new_installed_version&lang=$lang\">";
+	    } else {
                     echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=5&version=$new_installed_version&lang=$lang\">";
             }
 

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -341,10 +341,10 @@ class Fonctions {
 	    } elseif($start_version=="1.8") {
 		$file_upgrade='upgrade_from_v1.8.php';
 		$new_installed_version="1.8.1";
-		// execute le script php d'upgrade de la version1.7.0 (vers la suivante (1.8))
+		// execute le script php d'upgrade de la version1.8 (vers la suivante (1.8.1))
 		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?version=$new_installed_version&lang=$lang\">";
 	    } else {
-                    echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=5&version=$new_installed_version&lang=$lang\">";
+                    echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=3&version=$start_version&lang=$lang\">";
             }
 
         }

--- a/install/sql/php_conges_v1.8.1.sql
+++ b/install/sql/php_conges_v1.8.1.sql
@@ -1,0 +1,455 @@
+#
+# Base de données: `db_conges`
+#
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_appli`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_appli` (
+  `appli_variable` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `appli_valeur` varchar(200) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  PRIMARY KEY (`appli_variable`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_artt`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_artt` (
+  `a_login` varbinary(99) NOT NULL DEFAULT '',
+  `sem_imp_lu_am` varchar(10) DEFAULT NULL,
+  `sem_imp_lu_pm` varchar(10) DEFAULT NULL,
+  `sem_imp_ma_am` varchar(10) DEFAULT NULL,
+  `sem_imp_ma_pm` varchar(10) DEFAULT NULL,
+  `sem_imp_me_am` varchar(10) DEFAULT NULL,
+  `sem_imp_me_pm` varchar(10) DEFAULT NULL,
+  `sem_imp_je_am` varchar(10) DEFAULT NULL,
+  `sem_imp_je_pm` varchar(10) DEFAULT NULL,
+  `sem_imp_ve_am` varchar(10) DEFAULT NULL,
+  `sem_imp_ve_pm` varchar(10) DEFAULT NULL,
+  `sem_imp_sa_am` varchar(10) DEFAULT NULL,
+  `sem_imp_sa_pm` varchar(10) DEFAULT NULL,
+  `sem_imp_di_am` varchar(10) DEFAULT NULL,
+  `sem_imp_di_pm` varchar(10) DEFAULT NULL,
+  `sem_p_lu_am` varchar(10) DEFAULT NULL,
+  `sem_p_lu_pm` varchar(10) DEFAULT NULL,
+  `sem_p_ma_am` varchar(10) DEFAULT NULL,
+  `sem_p_ma_pm` varchar(10) DEFAULT NULL,
+  `sem_p_me_am` varchar(10) DEFAULT NULL,
+  `sem_p_me_pm` varchar(10) DEFAULT NULL,
+  `sem_p_je_am` varchar(10) DEFAULT NULL,
+  `sem_p_je_pm` varchar(10) DEFAULT NULL,
+  `sem_p_ve_am` varchar(10) DEFAULT NULL,
+  `sem_p_ve_pm` varchar(10) DEFAULT NULL,
+  `sem_p_sa_am` varchar(10) DEFAULT NULL,
+  `sem_p_sa_pm` varchar(10) DEFAULT NULL,
+  `sem_p_di_am` varchar(10) DEFAULT NULL,
+  `sem_p_di_pm` varchar(10) DEFAULT NULL,
+  `a_date_debut_grille` date NOT NULL DEFAULT '0000-00-00',
+  `a_date_fin_grille` date NOT NULL DEFAULT '9999-12-31',
+  PRIMARY KEY (`a_login`,`a_date_fin_grille`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_config`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_config` (
+  `conf_nom` varchar(100) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `conf_valeur` varchar(200) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
+  `conf_groupe` varchar(200) NOT NULL DEFAULT '',
+  `conf_type` varchar(200) NOT NULL DEFAULT 'texte',
+  `conf_commentaire` text NOT NULL,
+  PRIMARY KEY (`conf_nom`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_echange_rtt`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_echange_rtt` (
+  `e_login` varbinary(99) NOT NULL DEFAULT '',
+  `e_date_jour` date NOT NULL DEFAULT '0000-00-00',
+  `e_absence` enum('N','J','M','A') NOT NULL DEFAULT 'N',
+  `e_presence` enum('N','J','M','A') NOT NULL DEFAULT 'N',
+  `e_comment` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`e_login`,`e_date_jour`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_edition_papier`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_edition_papier` (
+  `ep_id` int(11) NOT NULL AUTO_INCREMENT,
+  `ep_login` varbinary(99) NOT NULL DEFAULT '',
+  `ep_date` date NOT NULL DEFAULT '0000-00-00',
+  `ep_num_for_user` int(5) unsigned NOT NULL DEFAULT '1',
+  PRIMARY KEY (`ep_id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=143 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_groupe`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_groupe` (
+  `g_gid` int(11) NOT NULL AUTO_INCREMENT,
+  `g_groupename` varchar(50) NOT NULL DEFAULT '',
+  `g_comment` varchar(250) DEFAULT NULL,
+  `g_double_valid` enum('Y','N') NOT NULL DEFAULT 'N',
+  PRIMARY KEY (`g_gid`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=40 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_groupe_grd_resp`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_groupe_grd_resp` (
+  `ggr_gid` int(11) NOT NULL DEFAULT '0',
+  `ggr_login` varbinary(99) NOT NULL DEFAULT ''
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_groupe_resp`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_groupe_resp` (
+  `gr_gid` int(11) NOT NULL DEFAULT '0',
+  `gr_login` varbinary(99) NOT NULL DEFAULT ''
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_groupe_users`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_groupe_users` (
+  `gu_gid` int(11) NOT NULL DEFAULT '0',
+  `gu_login` varbinary(99) NOT NULL DEFAULT '',
+  UNIQUE KEY `gu_gid` (`gu_gid`,`gu_login`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_jours_feries`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_jours_feries` (
+  `jf_date` date NOT NULL DEFAULT '0000-00-00',
+  PRIMARY KEY (`jf_date`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_jours_fermeture`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_jours_fermeture` (
+  `jf_id` int(5) NOT NULL,
+  `jf_gid` int(11) NOT NULL DEFAULT '0',
+  `jf_date` date NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_logs`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_logs` (
+  `log_id` int(11) NOT NULL AUTO_INCREMENT,
+  `log_p_num` int(5) unsigned NOT NULL,
+  `log_user_login_par` varbinary(99) NOT NULL DEFAULT '',
+  `log_user_login_pour` varbinary(99) NOT NULL DEFAULT '',
+  `log_etat` varchar(16) NOT NULL DEFAULT '',
+  `log_comment` text,
+  `log_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`log_id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=8966 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_mail`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_mail` (
+  `mail_nom` varchar(100) NOT NULL,
+  `mail_subject` text,
+  `mail_body` text,
+  UNIQUE KEY `mail_nom` (`mail_nom`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_periode`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_periode` (
+  `p_login` varbinary(99) NOT NULL DEFAULT '',
+  `p_date_deb` date NOT NULL DEFAULT '0000-00-00',
+  `p_demi_jour_deb` enum('am','pm') NOT NULL DEFAULT 'am',
+  `p_date_fin` date NOT NULL DEFAULT '0000-00-00',
+  `p_demi_jour_fin` enum('am','pm') NOT NULL DEFAULT 'pm',
+  `p_nb_jours` decimal(5,2) NOT NULL DEFAULT '0.00',
+  `p_commentaire` varchar(50) DEFAULT NULL,
+  `p_type` int(2) unsigned NOT NULL DEFAULT '1',
+  `p_etat` enum('ok','valid','demande','ajout','refus','annul') NOT NULL DEFAULT 'demande',
+  `p_edition_id` int(11) DEFAULT NULL,
+  `p_motif_refus` varchar(110) DEFAULT NULL,
+  `p_date_demande` datetime DEFAULT NULL,
+  `p_date_traitement` datetime DEFAULT NULL,
+  `p_fermeture_id` int(5) DEFAULT NULL,
+  `p_num` int(5) unsigned NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`p_num`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=2061 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_plugins`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_plugins` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `p_name` varchar(250) COLLATE utf8_unicode_ci NOT NULL COMMENT 'Plugin name',
+  `p_is_active` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Plugin activated ?',
+  `p_is_install` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Plugin is installed ?',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=14 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_plugin_cet`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_plugin_cet` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pc_jours_demandes` decimal(5,2) DEFAULT NULL COMMENT 'Number of days requested to supply the CET',
+  `pc_requested_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `pc_comments` text COLLATE utf8_unicode_ci,
+  `pc_u_login` varbinary(99) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `pc_u_login` (`pc_u_login`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=2 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_solde_edition`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_solde_edition` (
+  `se_id_edition` int(11) NOT NULL,
+  `se_id_absence` int(2) NOT NULL,
+  `se_solde` decimal(4,2) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_solde_user`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_solde_user` (
+  `su_login` varbinary(99) NOT NULL DEFAULT '',
+  `su_abs_id` int(2) unsigned NOT NULL DEFAULT '0',
+  `su_nb_an` decimal(5,2) NOT NULL DEFAULT '0.00',
+  `su_solde` decimal(5,2) NOT NULL DEFAULT '0.00',
+  `su_reliquat` decimal(5,2) NOT NULL DEFAULT '0.00',
+  PRIMARY KEY (`su_login`,`su_abs_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_type_absence`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_type_absence` (
+  `ta_id` int(2) unsigned NOT NULL AUTO_INCREMENT,
+  `ta_type` enum('conges','absences','conges_exceptionnels') NOT NULL DEFAULT 'conges',
+  `ta_libelle` varchar(20) NOT NULL DEFAULT '',
+  `ta_short_libelle` char(3) NOT NULL DEFAULT '',
+  PRIMARY KEY (`ta_id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=7 ;
+
+# --------------------------------------------------------
+
+#
+# Structure de la table `conges_users`
+#
+
+CREATE TABLE IF NOT EXISTS `conges_users` (
+  `u_login` varbinary(99) NOT NULL DEFAULT '',
+  `u_nom` varchar(30) NOT NULL DEFAULT '',
+  `u_prenom` varchar(30) NOT NULL DEFAULT '',
+  `u_is_resp` enum('Y','N') NOT NULL DEFAULT 'N',
+  `u_resp_login` varbinary(99) DEFAULT NULL,
+  `u_is_admin` enum('Y','N') NOT NULL DEFAULT 'N',
+  `u_is_hr` enum('Y','N') NOT NULL DEFAULT 'N',
+  `u_is_active` enum('Y','N') NOT NULL DEFAULT 'Y',
+  `u_see_all` enum('Y','N') NOT NULL DEFAULT 'N',
+  `u_passwd` varchar(64) NOT NULL DEFAULT '',
+  `u_quotite` int(3) DEFAULT '100',
+  `u_email` varchar(100) DEFAULT NULL,
+  `u_num_exercice` int(2) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`u_login`),
+  KEY `u_login` (`u_login`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
+#
+# Contenu de la table `conges_appli`
+#
+
+INSERT IGNORE INTO `conges_appli` VALUES ('num_exercice', '1');
+INSERT IGNORE INTO `conges_appli` VALUES ('date_limite_reliquats', '0');
+INSERT IGNORE INTO `conges_appli` VALUES ('semaine_bgcolor', '#FFFFFF');
+INSERT IGNORE INTO `conges_appli` VALUES ('week_end_bgcolor', '#BFBFBF');
+INSERT IGNORE INTO `conges_appli` VALUES ('temps_partiel_bgcolor', '#FFFFC4');
+INSERT IGNORE INTO `conges_appli` VALUES ('conges_bgcolor', '#DEDEDE');
+INSERT IGNORE INTO `conges_appli` VALUES ('demande_conges_bgcolor', '#E7C4C4');
+INSERT IGNORE INTO `conges_appli` VALUES ('absence_autre_bgcolor', '#D3FFB6');
+INSERT IGNORE INTO `conges_appli` VALUES ('fermeture_bgcolor', '#7B9DE6');
+
+# --------------------------------------------------------
+
+#
+# Contenu de la table `conges_artt`
+#
+
+INSERT IGNORE INTO `conges_artt` VALUES ('admin', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '0000-00-00', '9999-12-31');
+INSERT IGNORE INTO `conges_artt` VALUES ('conges', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '0000-00-00', '9999-12-31');
+
+# --------------------------------------------------------
+
+#
+# Contenu de la table `conges_users`
+#
+
+INSERT IGNORE INTO `conges_users` VALUES ('admin', 'Libertempo', 'admin', 'N', 'admin', 'Y', 'N','Y','N', '636d61cf9094a62a81836f3737d9c0da', 100, NULL, 0);
+
+#
+# Contenu de la table `conges_config`
+#
+
+INSERT IGNORE INTO `conges_config` VALUES ('installed_version', '0', '00_libertempo', 'texte', 'config_comment_installed_version');
+INSERT IGNORE INTO `conges_config` VALUES ('lang', 'fr', '00_libertempo', 'enum=fr/test', 'config_comment_lang');
+
+INSERT IGNORE INTO `conges_config` VALUES ('URL_ACCUEIL_CONGES', 'http://mon-serveur/mon-chemin/libertempo', '01_Serveur Web', 'texte', 'config_comment_URL_ACCUEIL_CONGES');
+
+INSERT IGNORE INTO `conges_config` VALUES ('auth', 'TRUE', '04_Authentification', 'boolean', 'config_comment_auth');
+INSERT IGNORE INTO `conges_config` VALUES ('how_to_connect_user', 'dbconges', '04_Authentification', 'enum=dbconges/ldap/CAS', 'config_comment_how_to_connect_user');
+INSERT IGNORE INTO `conges_config` VALUES ('export_users_from_ldap', 'FALSE', '04_Authentification', 'boolean', 'config_comment_export_users_from_ldap');
+INSERT IGNORE INTO `conges_config` VALUES ('consult_calendrier_sans_auth', 'FALSE', '04_Authentification', 'boolean', 'config_comment_consult_calendrier_sans_auth');
+
+INSERT IGNORE INTO `conges_config` VALUES ('user_saisie_demande', 'TRUE', '05_Utilisateur', 'boolean', 'config_comment_user_saisie_demande');
+INSERT IGNORE INTO `conges_config` VALUES ('user_affiche_calendrier', 'TRUE', '05_Utilisateur', 'boolean', 'config_comment_user_affiche_calendrier');
+INSERT IGNORE INTO `conges_config` VALUES ('user_saisie_mission', 'TRUE', '05_Utilisateur', 'boolean', 'config_comment_user_saisie_mission');
+INSERT IGNORE INTO `conges_config` VALUES ('user_ch_passwd', 'TRUE', '05_Utilisateur', 'boolean', 'config_comment_user_ch_passwd');
+
+INSERT IGNORE INTO `conges_config` VALUES ('resp_affiche_calendrier', 'TRUE', '06_Responsable', 'boolean', 'config_comment_resp_affiche_calendrier');
+INSERT IGNORE INTO `conges_config` VALUES ('resp_saisie_mission', 'FALSE', '06_Responsable', 'boolean', 'config_comment_resp_saisie_mission');
+INSERT IGNORE INTO `conges_config` VALUES ('resp_ajoute_conges', 'TRUE', '06_Responsable', 'boolean', 'config_comment_resp_ajoute_conges');
+INSERT IGNORE INTO `conges_config` VALUES ('gestion_cas_absence_responsable', 'FALSE', '06_Responsable', 'boolean', 'config_comment_gestion_cas_absence_responsable');
+INSERT IGNORE INTO `conges_config` VALUES ('print_disable_users',  'FALSE',  '06_Responsable',  'Boolean',  'config_comment_print_disable_users');
+
+INSERT IGNORE INTO `conges_config` VALUES ('admin_see_all', 'FALSE', '07_Administrateur', 'boolean', 'config_comment_admin_see_all');
+INSERT IGNORE INTO `conges_config` VALUES ('admin_change_passwd', 'TRUE', '07_Administrateur', 'boolean', 'config_comment_admin_change_passwd');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_bouton_config_pour_admin', 'FALSE', '07_Administrateur', 'boolean', 'config_comment_affiche_bouton_config_pour_admin');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_bouton_config_absence_pour_admin', 'FALSE', '07_Administrateur', 'boolean', 'config_comment_affiche_bouton_config_absence_pour_admin');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_bouton_config_mail_pour_admin', 'FALSE', '07_Administrateur', 'boolean', 'config_comment_affiche_bouton_config_mail_pour_admin');
+
+INSERT IGNORE INTO `conges_config` VALUES ('mail_new_demande_alerte_resp', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_new_demande_alerte_resp');
+INSERT IGNORE INTO `conges_config` VALUES ('mail_valid_conges_alerte_user', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_valid_conges_alerte_user');
+INSERT IGNORE INTO `conges_config` VALUES ('mail_prem_valid_conges_alerte_user', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_prem_valid_conges_alerte_user');
+INSERT IGNORE INTO `conges_config` VALUES ('mail_refus_conges_alerte_user', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_refus_conges_alerte_user');
+INSERT IGNORE INTO `conges_config` VALUES ('mail_annul_conges_alerte_user', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_annul_conges_alerte_user');
+INSERT IGNORE INTO `conges_config` VALUES ('mail_modif_demande_alerte_resp', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_modif_demande_alerte_resp');
+INSERT IGNORE INTO `conges_config` VALUES ('mail_supp_demande_alerte_resp', 'FALSE', '08_Mail', 'boolean', 'config_comment_mail_supp_demande_alerte_resp');
+INSERT IGNORE INTO `conges_config` VALUES ('where_to_find_user_email', 'dbconges', '08_Mail', 'enum=dbconges/ldap', 'config_comment_where_to_find_user_email');
+
+INSERT IGNORE INTO `conges_config` VALUES ('samedi_travail', 'FALSE', '09_jours ouvrables', 'boolean', 'config_comment_samedi_travail');
+INSERT IGNORE INTO `conges_config` VALUES ('dimanche_travail', 'FALSE', '09_jours ouvrables', 'boolean', 'config_comment_dimanche_travail');
+
+INSERT IGNORE INTO `conges_config` VALUES ('gestion_groupes', 'FALSE', '10_Gestion par groupes', 'boolean', 'config_comment_gestion_groupes');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_groupe_in_calendrier', 'FALSE', '10_Gestion par groupes', 'boolean', 'config_comment_affiche_groupe_in_calendrier');
+INSERT IGNORE INTO `conges_config` VALUES ('calendrier_select_all_groups', 'FALSE', '10_Gestion par groupes', 'boolean', 'config_comment_calendrier_select_all_groups');
+INSERT IGNORE INTO `conges_config` VALUES ('fermeture_par_groupe', 'FALSE', '10_Gestion par groupes', 'boolean', 'config_comment_fermeture_par_groupe');
+
+INSERT IGNORE INTO `conges_config` VALUES ('editions_papier', 'TRUE', '11_Editions papier', 'boolean', 'config_comment_editions_papier');
+INSERT IGNORE INTO `conges_config` VALUES ('texte_haut_edition_papier', '- Libertempo : édition des congés -', '11_Editions papier', 'texte', 'config_comment_texte_haut_edition_papier');
+INSERT IGNORE INTO `conges_config` VALUES ('texte_bas_edition_papier', '- édité par Libertempo -', '11_Editions papier', 'texte', 'config_comment_texte_bas_edition_papier');
+
+INSERT IGNORE INTO `conges_config` VALUES ('user_echange_rtt', 'FALSE', '12_Fonctionnement de l\'Etablissement', 'boolean', 'config_comment_user_echange_rtt');
+INSERT IGNORE INTO `conges_config` VALUES ('double_validation_conges', 'FALSE', '12_Fonctionnement de l\'Etablissement', 'boolean', 'config_comment_double_validation_conges');
+INSERT IGNORE INTO `conges_config` VALUES ('grand_resp_ajout_conges', 'FALSE', '12_Fonctionnement de l\'Etablissement', 'boolean', 'config_comment_grand_resp_ajout_conges');
+INSERT IGNORE INTO `conges_config` VALUES ('gestion_conges_exceptionnels', 'FALSE', '12_Fonctionnement de l\'Etablissement', 'boolean', 'config_comment_gestion_conges_exceptionnels');
+INSERT IGNORE INTO `conges_config` VALUES ('solde_toujours_positif', 'FALSE', '12_Fonctionnement de l\'Etablissement', 'boolean', 'config_comment_solde_toujours_positif');
+INSERT IGNORE INTO `conges_config` VALUES ('autorise_reliquats_exercice', 'TRUE', '12_Fonctionnement de l\'Etablissement', 'boolean', 'config_comment_autorise_reliquats_exercice');
+INSERT IGNORE INTO `conges_config` VALUES ('nb_maxi_jours_reliquats', '0', '12_Fonctionnement de l\'Etablissement', 'texte', 'config_comment_nb_maxi_jours_reliquats');
+INSERT IGNORE INTO `conges_config` VALUES ('jour_mois_limite_reliquats', '0', '12_Fonctionnement de l\'Etablissement', 'texte', 'config_comment_jour_mois_limite_reliquats');
+
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_bouton_calcul_nb_jours_pris', 'TRUE', '05_Utilisateur', 'boolean', 'config_comment_affiche_bouton_calcul_nb_jours_pris');
+INSERT IGNORE INTO `conges_config` VALUES ('rempli_auto_champ_nb_jours_pris', 'TRUE', '05_Utilisateur', 'boolean', 'config_comment_rempli_auto_champ_nb_jours_pris');
+INSERT IGNORE INTO `conges_config` VALUES ('disable_saise_champ_nb_jours_pris', 'FALSE', '05_Utilisateur', 'boolean', 'config_comment_disable_saise_champ_nb_jours_pris');
+INSERT IGNORE INTO `conges_config` VALUES ('interdit_saisie_periode_date_passee', 'FALSE', '05_Utilisateur', 'boolean', 'config_comment_interdit_saisie_periode_date_passee');
+INSERT IGNORE INTO `conges_config` VALUES ('interdit_modif_demande', 'FALSE', '05_Utilisateur', 'boolean', 'config_comment_interdit_modif_demande');
+INSERT IGNORE INTO `conges_config` VALUES ('duree_session', '1800', '13_Divers', 'texte', 'config_comment_duree_session');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_date_traitement', 'FALSE', '13_Divers', 'boolean', 'config_comment_affiche_date_traitement');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_soldes_calendrier', 'TRUE', '13_Divers', 'boolean', 'config_comment_affiche_soldes_calendrier');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_demandes_dans_calendrier', 'FALSE', '13_Divers', 'boolean', 'config_comment_affiche_demandes_dans_calendrier');
+INSERT IGNORE INTO `conges_config` VALUES ('affiche_jours_current_month_calendrier',  'FALSE',  '13_Divers',  'boolean',  'config_comment_affiche_jours_current_month_calendrier');
+INSERT IGNORE INTO `conges_config` VALUES ('calcul_auto_jours_feries_france', 'FALSE', '13_Divers', 'boolean', 'config_comment_calcul_auto_jours_feries_france');
+
+INSERT IGNORE INTO `conges_config` (`conf_nom`, `conf_valeur`, `conf_groupe`, `conf_type`, `conf_commentaire`) VALUES ('export_ical', 'TRUE', '15_ical', 'boolean', 'config_comment__export_ical'),
+('export_ical_salt', 'Jao%iT}', '15_ical', 'texte', 'config_comment_export_ical_salt');
+
+#
+# Contenu de la table `conges_type_absence`
+###############################################
+
+INSERT IGNORE INTO `conges_type_absence` VALUES (1, 'conges', 'congés payés', 'cp');
+INSERT IGNORE INTO `conges_type_absence` VALUES (2, 'conges', 'rtt', 'rtt');
+INSERT IGNORE INTO `conges_type_absence` VALUES (3, 'absences', 'formation', 'fo');
+INSERT IGNORE INTO `conges_type_absence` VALUES (4, 'absences', 'misson', 'mi');
+INSERT IGNORE INTO `conges_type_absence` VALUES (5, 'absences', 'autre', 'ab');
+INSERT IGNORE INTO `conges_type_absence` VALUES (6, 'absences', 'malade', 'mal');
+
+#
+# Contenu de la table `conges_mail`
+#
+
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_new_demande', 'APPLI CONGES - Demande de congés', ' __SENDER_NAME__ a solicité une demande de congés dans l''application de gestion des congés.\r\n\r\nMerci de consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_new_demande_resp_absent', 'APPLI CONGES - Demande de congés', ' __SENDER_NAME__ a solicité une demande de congés dans l''application de gestion des congés.\r\n\r\nEn votre absence, cette demande a été transférée à votre (vos) propre(s) responsable(s)./\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_valid_conges', 'APPLI CONGES - Congés accepté', ' __SENDER_NAME__ a enregistré/accepté un congés pour vous dans l''application de gestion des congés.\r\n\r\nMerci de consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_refus_conges', 'APPLI CONGES - Congés refusé', ' __SENDER_NAME__ a refusé une demande de congés pour vous dans l''application de gestion des congés.\r\n\r\nMerci de consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_annul_conges', 'APPLI CONGES - Congés annulé', ' __SENDER_NAME__ a annulé un de vos congés dans l''application de gestion des congés.\r\n\r\nMerci de consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_prem_valid_conges', 'APPLI CONGES - Congés validé', ' __SENDER_NAME__ a validé (première validation) un congés pour vous dans l''application de gestion des congés.\r\n\Il doit maintenant être accepté en deuxième validation.\r\n\r\nMerci de consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_new_absence_conges', 'APPLI CONGES - Nouvelle absence', ' __SENDER_NAME__ vous informe qu\'il sera absent. Ce type de congés ne necéssite pas de validation. Vous pouvez consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique. ');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_modif_demande_conges', 'APPLI CONGES - Modification demande', ' __SENDER_NAME__ à modifié une demande non traité. Vous pouvez consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_supp_demande_conges', 'APPLI CONGES - Suppression demande', ' __SENDER_NAME__ à supprimé une demande non traité. Vous pouvez consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
+

--- a/install/upgrade_from_v1.7.0.php
+++ b/install/upgrade_from_v1.7.0.php
@@ -102,4 +102,4 @@ $alter_solde="ALTER TABLE conges_solde_user MODIFY `su_reliquat` DECIMAL(5,2) NO
 $res_alter_solde=\includes\SQL::query($alter_solde);
 
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)
-echo "<a href=\"mise_a_jour.php?etape=3&version=$version&lang=$lang\">upgrade_from_v1.7.0  OK</a><br>\n";
+echo "<a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">upgrade_from_v1.7.0  OK</a><br>\n";

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -53,13 +53,13 @@ $upd_user_resp = "UPDATE conges_users SET u_resp_login = NULL WHERE u_login = 'c
 $res_upd_user_resp=\includes\SQL::query($upd_user_resp);
 
 //suppression des artt de conges
-$del_conges_artt = "DELETE FROM conges_artt WHERE gr_login = 'conges';";
+$del_conges_artt = "DELETE FROM conges_artt WHERE a_login = 'conges';";
 $res_del_conges_artt = \includes\SQL::query($del_conges_artt);
 
 //suppression du user conges
 $del_conges_usr="DELETE FROM conges_users WHERE u_login = 'conges';";
 $res_del_conges_usr=\includes\SQL::query($del_conges_usr);
 
-
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)
-echo "<a href=\"mise_a_jour.php?etape=3&version=$version&lang=$lang\">upgrade_from_v1.8  OK</a><br>\n";
+echo "<a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">upgrade_from_v1.8  OK</a><br>\n";
+

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -54,11 +54,11 @@ $res_upd_user_resp=\includes\SQL::query($upd_user_resp);
 
 //suppression des artt de conges
 $del_conges_artt = "DELETE FROM conges_artt WHERE gr_login = 'conges';";
-$res_del_conges_acl = \includes\SQL::query($del_conges_acl);
+$res_del_conges_artt = \includes\SQL::query($del_conges_artt);
 
 //suppression du user conges
 $del_conges_usr="DELETE FROM conges_users WHERE u_login = 'conges';";
-$res_del_conges_acl=\includes\SQL::query($del_conges_acl);
+$res_del_conges_usr=\includes\SQL::query($del_conges_usr);
 
 
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -25,7 +25,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
-define('_PHP_CONGES', 1);
 define('ROOT_PATH', '../');
 include ROOT_PATH . 'define.php';
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -1,5 +1,5 @@
 <?php
-/************************************************************************************************
+/*************************************************************************************************
 Libertempo : Gestion Interactive des Congés
 Copyright (C) 2015 (Wouldsmina)
 Copyright (C) 2015 (Prytoegrian)
@@ -25,12 +25,41 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *************************************************************************************************/
 
+define('_PHP_CONGES', 1);
+define('ROOT_PATH', '../');
+include ROOT_PATH . 'define.php';
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
-// site et numero de version de PHP_CONGES
-// ne pas toucher ces variables SVP ;-)
-$config_php_conges_version="1.8.1";
-$config_url_site_web_php_conges="http://Libertempo.tuxfamily.org";
-// ne pas toucher ces variables SVP ;-)
+/*******************************************************************/
+// SCRIPT DE MIGRATION DE LA VERSION 1.8 vers 1.8.1
+/*******************************************************************/
+include ROOT_PATH .'fonctions_conges.php' ;
+include INCLUDE_PATH .'fonction.php';
+
+$PHP_SELF=$_SERVER['PHP_SELF'];
+
+$version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : "")) ;
+$lang = (isset($_GET['lang']) ? $_GET['lang'] : (isset($_POST['lang']) ? $_POST['lang'] : "")) ;
+
+//suppression des droits de conges
+$del_conges_acl = "DELETE FROM conges_groupe_resp WHERE gr_login = 'conges';";
+$res_del_conges_acl = \includes\SQL::query($del_conges_acl);
+
+$del_conges_acl = "DELETE FROM conges_groupe_grd_resp WHERE gr_login = 'conges';";
+$res_del_conges_acl=\includes\SQL::query($del_conges_acl);
+
+//modifications des users ayant comme responsable conges
+$upd_user_resp = "UPDATE conges_users SET u_resp_login = NULL WHERE u_login = 'conges';";
+$res_upd_user_resp=\includes\SQL::query($upd_user_resp);
+
+//suppression des artt de conges
+$del_conges_artt = "DELETE FROM conges_artt WHERE gr_login = 'conges';";
+$res_del_conges_acl = \includes\SQL::query($del_conges_acl);
+
+//suppression du user conges
+$del_conges_usr="DELETE FROM conges_users WHERE u_login = 'conges';";
+$res_del_conges_acl=\includes\SQL::query($del_conges_acl);
 
 
+// on renvoit à la page mise_a_jour.php (là d'ou on vient)
+echo "<a href=\"mise_a_jour.php?etape=3&version=$version&lang=$lang\">upgrade_from_v1.8  OK</a><br>\n";

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -45,7 +45,7 @@ $lang = (isset($_GET['lang']) ? $_GET['lang'] : (isset($_POST['lang']) ? $_POST[
 $del_conges_acl = "DELETE FROM conges_groupe_resp WHERE gr_login = 'conges';";
 $res_del_conges_acl = \includes\SQL::query($del_conges_acl);
 
-$del_conges_acl = "DELETE FROM conges_groupe_grd_resp WHERE gr_login = 'conges';";
+$del_conges_acl = "DELETE FROM conges_groupe_grd_resp WHERE ggr_login = 'conges';";
 $res_del_conges_acl=\includes\SQL::query($del_conges_acl);
 
 //modifications des users ayant comme responsable conges

--- a/template/reboot/template_define.php
+++ b/template/reboot/template_define.php
@@ -1,5 +1,5 @@
 <?php
 
-define('BOTTOM_TEXT','Libertempo 1.8 Quinnis');
+define('BOTTOM_TEXT','Libertempo 1.8.1 Quinnis');
 
 

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -95,7 +95,7 @@ class Fonctions
         if( $valid ) {
             if( in_array(\utilisateur\Fonctions::get_type_abs($new_type) , array('conges','conges_exceptionnels') ) ) {
                 $resp_du_user = get_tab_resp_du_user($_SESSION['userlogin']);
-                if (array_key_exists('conges', $resp_du_user)||empty($resp_du_user)) {
+                if ((1 === count($resp_du_user) && isset($resp_du_user['conges']))||empty($resp_du_user)) {
                     $new_etat = 'ok' ;
                     soustrait_solde_et_reliquat_user($_SESSION['userlogin'], "", $new_nb_jours, $new_type, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin);
                 } else {


### PR DESCRIPTION
Cette petite montée en version viens corriger quelques bugs constatés pour quelques utilisateurs de Libertempo : 

- à l'issue d'une upgrade depuis php_conges et à condition d'avoir utilisé le compte virtuel 'conges', toutes les demandes sont automatiquement validées. #157 
- les utilisateurs du CAS rencontrent une erreur après upgrade/installation. 
- PHP7/MySQL5.7 : il n'est plus possible de faire un `order by` sur un champ non contenu dans le `SELECT` si la clause `DISTINCT` est employée.

@Prytoegrian si tu as besoin d'une base 1.5.1 "peuplée" pour tester, fais moi signe ;)
