### PR TITLE
Précisions sur le debug

### DIFF
--- a/define.php
+++ b/define.php
@@ -37,7 +37,9 @@ if (!defined( 'DEFINE_INCLUDE' )) {
             // no break;
         case ENV_TEST:
             \Kint::enabled(true);
-            error_reporting(E_ALL & ~E_NOTICE);
+            if (ENV === ENV_TEST) {
+                error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
+            }
             ini_set("display_errors", 1);
 
             /**

--- a/define.php
+++ b/define.php
@@ -33,11 +33,16 @@ if (!defined( 'DEFINE_INCLUDE' )) {
     switch (ENV) {
         case ENV_DEV:
             error_reporting(-1);
-            ini_set("display_errors", 1);
             \Kint::enabled(true);
             // no break;
         case ENV_TEST:
             \Kint::enabled(true);
+            error_reporting(E_ALL & ~E_NOTICE);
+            ini_set("display_errors", 1);
+
+            /**
+             * Logue les variables à déboguer
+             */
             function debug()
             {
                 global $debug;
@@ -51,6 +56,9 @@ if (!defined( 'DEFINE_INCLUDE' )) {
                 global $debug;
                 if (empty($debug)) {
                     return;
+                }
+                if (!is_dir(DEBUG_SYSPATH)) {
+                    mkdir(DEBUG_SYSPATH);
                 }
                 $file = fopen(DEBUG_SYSPATH . 'dbg-' . date('Y-m-d') . '.html', 'wb');
                 if (!is_resource($file)) {


### PR DESCRIPTION
Statut : 
* [x] Terminée

Suite de la conversation à #123 (merci @Shadok) + référence à un ticket que je ne trouve plus où un utilisateur n'avait pas les erreurs affichées.

* Le répertoire « debug » est maintenant créé à la volée s'il n'existe pas,
* Nous forçons désormais un état de reportage d'erreur dans `ENV_TEST` afin de les aider à nous reporter les erreurs