### PR TITLE
[Heures additionnelles/repos] Notifications

### DIFF
--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -86,7 +86,7 @@ abstract Class ANotification {
                 $return[] = $mail->Send();
             }
         }
-        return !in_array("false", $return)
+        return !in_array(false, $return);
     }
 
     /**
@@ -107,7 +107,7 @@ abstract Class ANotification {
     protected function getContenu($id) {
         $data = $this->getData($id);
         $notifContent = [];
-        switch ($this->data['statut']) {
+        switch ($data['statut']) {
             case \App\Models\AHeure::STATUT_DEMANDE:
                 $NotifContent[] = $this->getContenuDemande($data);
                 break;

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -26,11 +26,9 @@ abstract Class ANotification {
      * @return boolean
      */
     public function send() {
+
     $return = [];
-        if(!$this->canSend()){
-            return true;
-        }
-        
+
         // init du mail
         $mail = new \PHPMailer();
 
@@ -115,7 +113,12 @@ abstract Class ANotification {
     }
     
     protected function canSend($optionName) {
-        return $_SESSION['config'][$optionName];
+        if(isset($_SESSION['config'][$optionName])){
+            return $_SESSION['config'][$optionName];
+        } else {
+            // @todo : faire une exeption
+            return false;
+        }
     }
 
 }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -21,6 +21,7 @@ abstract Class ANotification {
      * 
      */
     public function __construct($id) {
+        $id = (int)$id;
         if(is_int($id)){
             $this->contenuNotification = $this->getContenu($id);
         } else {
@@ -80,8 +81,8 @@ abstract Class ANotification {
                 }
                 $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
         
-                $mail->Subject = $notification['sujet'];
-                $mail->Body = $notification['message'];
+                $mail->Subject = utf8_decode ( $notification['sujet'] );
+                $mail->Body = utf8_decode ( $notification['message'] );
 
                 $return[] = $mail->Send();
             }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -13,6 +13,14 @@ abstract Class ANotification {
     protected $Notification;
     protected $envoiMail;
 
+    /**
+     * 
+     * implémente les informations de la demande d'heure
+     * ainsi que du contenu du mail
+     * 
+     * @param int $id
+     * 
+     */
     public function __construct($id) {
         $this->data = $this->getData($id);
         $this->Notification = $this->getNotificationContent();
@@ -21,7 +29,7 @@ abstract Class ANotification {
 
     /**
      * 
-     * Transmet la notification par mail
+     * Transmet les notifications par mail
      * 
      * @return boolean
      */
@@ -79,14 +87,19 @@ abstract Class ANotification {
         return $return;
     }
 
+    /**
+     * récupère les données de l'évenemment
+     * 
+     * @todo déplacer la requete vers le protocontroller
+     * @param int $id
+     * 
+     * @return array
+     */
     abstract protected function getData($id);
 
     /**
-     * construction de la notification
-     * @todo isoler l'option d'envoi d'un mail dans une méthode
-     * après avoir réduit les différentes options des mails
+     * selection du contenu de la notification
      * 
-     * @param array $data
      * @return array
      */
     protected function getNotificationContent() {
@@ -112,6 +125,14 @@ abstract Class ANotification {
         return $NotifContent;
     }
     
+    /**
+     * Controle de l'option d'envoi de mails selon la notification
+     * 
+     * @param string $optionName
+     * @return boolean
+     * @throws Exception
+     * 
+     */
     protected function canSend($optionName) {
         if(isset($_SESSION['config'][$optionName])){
             return $_SESSION['config'][$optionName];

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -75,7 +75,8 @@ abstract Class ANotification {
         foreach ($this->contenuNotification as $notification){
             if($this->canSend($notification['config'])){
                 $mail->ClearAddresses();
-                $mail->From = $notification['expediteur'];
+                $mail->From = $notification['expediteur']['mail'];
+                $mail->FromName = $notification['expediteur']['nom'];
                 foreach ($notification['destinataire'] as $destinataire) {
                     $mail->AddAddress($destinataire);
                 }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -86,7 +86,11 @@ abstract Class ANotification {
                 $return[] = $mail->Send();
             }
         }
-        return $return;
+        if (in_array("false", $return)){
+            return (bool)FALSE;
+        } else {
+            return (bool)TRUE;
+        }
     }
 
     /**

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -62,7 +62,7 @@ abstract Class ANotification {
         }
         
         foreach ($this->Notification as $notification){
-            if(!$this->canSend($notification['config'])){
+            if($this->canSend($notification['config'])){
                 $mail->ClearAddresses();
                 $mail->From = $notification['expediteur'];
                 foreach ($notification['destinataire'] as $destinataire) {
@@ -116,7 +116,7 @@ abstract Class ANotification {
         if(isset($_SESSION['config'][$optionName])){
             return $_SESSION['config'][$optionName];
         } else {
-            // @todo : faire une exeption
+            throw new Exception('Option introuvable');
             return false;
         }
     }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -73,6 +73,9 @@ abstract Class ANotification {
         }
         
         foreach ($this->contenuNotification as $notification){
+            if (empty($notification['destinataire'][0])) {
+                continue;
+            }
             if($this->canSend($notification['config'])){
                 $mail->ClearAddresses();
                 $mail->From = $notification['expediteur']['mail'];

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -86,11 +86,7 @@ abstract Class ANotification {
                 $return[] = $mail->Send();
             }
         }
-        if (in_array("false", $return)){
-            return (bool)FALSE;
-        } else {
-            return (bool)TRUE;
-        }
+        return !in_array("false", $return)
     }
 
     /**

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -9,9 +9,9 @@ namespace App\Libraries;
  */
 abstract Class ANotification {
 
-    private $data;
-    private $Notification;
-    private $envoiMail;
+    protected $data;
+    protected $Notification;
+    protected $envoiMail;
 
     public function __construct($id) {
         $this->data = $this->getData($id);
@@ -69,7 +69,6 @@ abstract Class ANotification {
         foreach ($notification['destinataire'] as $destinataire) {
             $mail->AddAddress($destinataire);
         }
-        $mail->AddAddress($notification['destinataire']);
         $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
         
         $mail->Subject = $notification['sujet'];
@@ -77,7 +76,6 @@ abstract Class ANotification {
 
         $return[] = $mail->Send();
         }
-        
         return $return;
     }
 

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -64,17 +64,19 @@ abstract Class ANotification {
         }
         
         foreach ($this->Notification as $notification){
-        $mail->ClearAddresses();
-        $mail->From = $notification['expediteur'];
-        foreach ($notification['destinataire'] as $destinataire) {
-            $mail->AddAddress($destinataire);
-        }
-        $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
+            if(!$this->canSend($notification['config'])){
+                $mail->ClearAddresses();
+                $mail->From = $notification['expediteur'];
+                foreach ($notification['destinataire'] as $destinataire) {
+                    $mail->AddAddress($destinataire);
+                }
+                $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
         
-        $mail->Subject = $notification['sujet'];
-        $mail->Body = $notification['message'];
+                $mail->Subject = $notification['sujet'];
+                $mail->Body = $notification['message'];
 
-        $return[] = $mail->Send();
+                $return[] = $mail->Send();
+            }
         }
         return $return;
     }
@@ -112,25 +114,8 @@ abstract Class ANotification {
         return $NotifContent;
     }
     
-    protected function canSend() {
-        switch ($this->data['statut']) {
-            case \App\Models\Heure\Additionnelle::STATUT_DEMANDE:
-                $this->envoiMail = $_SESSION['config']['mail_new_demande_alerte_resp'];
-                break;
-            case \App\Models\Heure\Additionnelle::STATUT_PREMIERE_VALIDATION:
-                $this->envoiMail = $_SESSION['config']['mail_prem_valid_conges_alerte_user'];
-                break;
-            case \App\Models\Heure\Additionnelle::STATUT_VALIDATION_FINALE:
-                $this->envoiMail = $_SESSION['config']['mail_valid_conges_alerte_user'];
-                break;
-            case \App\Models\Heure\Additionnelle::STATUT_REFUS:
-                $this->envoiMail = $_SESSION['config']['mail_valid_conges_alerte_user'];
-                break;
-            case \App\Models\Heure\Additionnelle::STATUT_ANNUL:
-                $this->envoiMail = $_SESSION['config']['mail_supp_demande_alerte_resp'];
-                break;
-        }
-        return $this->envoiMail;
+    protected function canSend($optionName) {
+        return $_SESSION['config'][$optionName];
     }
 
 }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Libraries;
+
+/**
+ * Objet de gestion des notifications
+ * 
+ * 
+ */
+abstract Class ANotification {
+
+    private $data;
+    private $Notification;
+    private $envoiMail;
+
+    public function __construct($id) {
+        $this->data = $this->getData($id);
+        $this->Notification = $this->getNotificationContent();
+    }
+
+
+    /**
+     * 
+     * Transmet la notification par mail
+     * 
+     * @return boolean
+     */
+    public function send() {
+    $return = [];
+        if(!$this->canSend()){
+            return true;
+        }
+        
+        // init du mail
+        $mail = new \PHPMailer();
+
+        if (file_exists(CONFIG_PATH . 'config_SMTP.php')) {
+            include CONFIG_PATH . 'config_SMTP.php';
+
+            if (!empty($config_SMTP_host)) {
+                $mail->IsSMTP();
+                $mail->Host = $config_SMTP_host;
+                $mail->Port = $config_SMTP_port;
+
+                if (!empty($config_SMTP_user)) {
+                    $mail->SMTPAuth = true;
+                    $mail->Username = $config_SMTP_user;
+                    $mail->Password = $config_SMTP_pwd;
+                }
+                if (!empty($config_SMTP_sec)) {
+                    $mail->SMTPSecure = $config_SMTP_sec;
+                } else {
+                    $mail->SMTPAutoTLS = false;
+                }
+            }
+        } else {
+            if (file_exists('/usr/sbin/sendmail')) {
+                $mail->IsSendmail();   // send message using the $Sendmail program
+            } elseif (file_exists('/var/qmail/bin/sendmail')) {
+                $mail->IsQmail(); // send message using the qmail MTA
+            } else {
+                $mail->IsMail(); // send message using PHP mail() function
+            }
+        }
+        
+        foreach ($this->Notification as $notification){
+        $mail->ClearAddresses();
+        $mail->From = $notification['expediteur'];
+        foreach ($notification['destinataire'] as $destinataire) {
+            $mail->AddAddress($destinataire);
+        }
+        $mail->AddAddress($notification['destinataire']);
+        $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
+        
+        $mail->Subject = $notification['sujet'];
+        $mail->Body = $notification['message'];
+
+        $return[] = $mail->Send();
+        }
+        
+        return $return;
+    }
+
+    abstract protected function getData($id);
+
+    /**
+     * construction de la notification
+     * @todo isoler l'option d'envoi d'un mail dans une méthode
+     * après avoir réduit les différentes options des mails
+     * 
+     * @param array $data
+     * @return array
+     */
+    protected function getNotificationContent() {
+        $notifContent = [];
+        switch ($this->data['statut']) {
+            case \App\Models\Heure\Additionnelle::STATUT_DEMANDE:
+                $NotifContent[] = $this->getNotificationDemande();
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_PREMIERE_VALIDATION:
+                $NotifContent[] = $this->getNotificationEmployePremiereValidation();
+                $NotifContent[] = $this->getNotificationGrandResponsablePremiereValidation();
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_VALIDATION_FINALE:
+                $NotifContent[] = $this->getNotificationValidationFinale();
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_REFUS:
+                $NotifContent[] = $this->getNotificationRefus();
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_ANNUL:
+                $NotifContent[] = $this->getNotificationAnnulation();
+                break;
+        }
+        return $NotifContent;
+    }
+    
+    protected function canSend() {
+        switch ($this->data['statut']) {
+            case \App\Models\Heure\Additionnelle::STATUT_DEMANDE:
+                $this->envoiMail = $_SESSION['config']['mail_new_demande_alerte_resp'];
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_PREMIERE_VALIDATION:
+                $this->envoiMail = $_SESSION['config']['mail_prem_valid_conges_alerte_user'];
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_VALIDATION_FINALE:
+                $this->envoiMail = $_SESSION['config']['mail_valid_conges_alerte_user'];
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_REFUS:
+                $this->envoiMail = $_SESSION['config']['mail_valid_conges_alerte_user'];
+                break;
+            case \App\Models\Heure\Additionnelle::STATUT_ANNUL:
+                $this->envoiMail = $_SESSION['config']['mail_supp_demande_alerte_resp'];
+                break;
+        }
+        return $this->envoiMail;
+    }
+
+}

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -111,7 +111,6 @@ abstract Class ANotification {
      */
     protected function getContenu($id) {
         $data = $this->getData($id);
-        $notifContent = [];
         switch ($data['statut']) {
             case \App\Models\AHeure::STATUT_DEMANDE:
                 $NotifContent[] = $this->getContenuDemande($data);

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -38,9 +38,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
     protected function getContenuDemande($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure additionnelle";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
@@ -57,8 +59,9 @@ Class Additionnelle extends \App\Libraries\ANotification {
     protected function getContenuEmployePremierValidation($data) {
 
         $return['sujet'] = "[CONGES] Première validation d'heure additionnelle";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure additionnelle du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .". Il doit maintenant être traité en deuxième validation.";
@@ -73,10 +76,10 @@ Class Additionnelle extends \App\Libraries\ANotification {
     protected function getContenuValidationFinale($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure additionnelle validée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
@@ -90,8 +93,9 @@ Class Additionnelle extends \App\Libraries\ANotification {
     protected function getContenuRefus($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure additionnelle refusée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
         $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
@@ -110,9 +114,10 @@ Class Additionnelle extends \App\Libraries\ANotification {
     protected function getContenuAnnulation($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure additionnelle annulée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
@@ -128,10 +133,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
      */
     protected function getContenuGrandResponsablePremiereValidation($data) {
         $return['sujet'] = "[CONGES] Demande d'heure additionnelle";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -12,6 +12,8 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
     /**
      * récupère les données de l'évenemment
+     * 
+     * @todo déplacer la requete vers le protocontroller
      * @param int $id
      * 
      * @return array
@@ -52,7 +54,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." a ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
@@ -65,7 +67,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé votre demande d'heure additionnelle du ... . Il doit maintenant être traité en deuxième validation.";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure additionnelle du  ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .". Il doit maintenant être traité en deuxième validation.";
 
         $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
@@ -73,13 +75,13 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
     protected function getNotificationValidationFinale() {
 
-        $return['sujet'] = "Demande d'heure additionnelle validé";
+        $return['sujet'] = "Demande d'heure additionnelle validée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ... de ... à ... .";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
 
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
@@ -87,12 +89,12 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
     protected function getNotificationRefus() {
 
-        $return['sujet'] = "Demande d'heure additionnelle refusé";
+        $return['sujet'] = "Demande d'heure additionnelle refusée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a refusé la demande d'heure additionnelle du ... de ... à ... .";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
 
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
@@ -108,9 +110,25 @@ Class Additionnelle extends \App\Libraries\ANotification {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulée la demande d'heure additionnelle du ... de ... à ... commentaire_refus.";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure additionnelle du  ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
 
         $return['config'] = 'mail_supp_demande_alerte_resp';
+        return $return;
+    }
+    
+    protected function getNotificationGrandResponsablePremiereValidation() {
+        $return['sujet'] = "Demande d'heure additionnelle";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($this->data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        foreach ($responsables as $responsable) {
+            $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
+        }
+
+    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure additionnelle de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
+
+        $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
     }
 }

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -37,7 +37,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
      */
     protected function getContenuDemande($data) {
 
-        $return['sujet'] = "Demande d'heure additionnelle";
+        $return['sujet'] = "[CONGES] Demande d'heure additionnelle";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
@@ -56,7 +56,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
      */
     protected function getContenuEmployePremierValidation($data) {
 
-        $return['sujet'] = "Première validation d'heure additionnelle";
+        $return['sujet'] = "[CONGES] Première validation d'heure additionnelle";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
@@ -72,7 +72,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
      */
     protected function getContenuValidationFinale($data) {
 
-        $return['sujet'] = "Demande d'heure additionnelle validée";
+        $return['sujet'] = "[CONGES] Demande d'heure additionnelle validée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
@@ -89,7 +89,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
      */
     protected function getContenuRefus($data) {
 
-        $return['sujet'] = "Demande d'heure additionnelle refusée";
+        $return['sujet'] = "[CONGES] Demande d'heure additionnelle refusée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
@@ -109,7 +109,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
      */
     protected function getContenuAnnulation($data) {
 
-        $return['sujet'] = "Demande d'heure additionnelle annulée";
+        $return['sujet'] = "[CONGES] Demande d'heure additionnelle annulée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
@@ -127,7 +127,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
      * {@inheritDoc}
      */
     protected function getContenuGrandResponsablePremiereValidation($data) {
-        $return['sujet'] = "Demande d'heure additionnelle";
+        $return['sujet'] = "[CONGES] Demande d'heure additionnelle";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -9,14 +9,8 @@ namespace App\Libraries\Notification;
  */
 Class Additionnelle extends \App\Libraries\ANotification {
 
-
     /**
-     * récupère les données de l'évenemment
-     * 
-     * @todo déplacer la requete vers le protocontroller
-     * @param int $id
-     * 
-     * @return array
+     * {@inheritDoc}
      */
     protected function getData($id) {
 
@@ -39,7 +33,8 @@ Class Additionnelle extends \App\Libraries\ANotification {
     }
 
     /**
-     * notification nouvelle demande
+     * notification d'une nouvelle demande d'heures additionnelles
+     * au responsable du demandeur
      * 
      * @param array $data
      * @return array
@@ -60,6 +55,13 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
 
+    /**
+     * notification d'une première validation 
+     * au demandeur d'heures additionnelles
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationEmployePremierValidation() {
 
         $return['sujet'] = "Première validation d'heure additionnelle";
@@ -73,6 +75,13 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
 
+    /**
+     * notification d'une validation finale
+     * au demandeur d'heures additionnelles
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationValidationFinale() {
 
         $return['sujet'] = "Demande d'heure additionnelle validée";
@@ -86,7 +95,14 @@ Class Additionnelle extends \App\Libraries\ANotification {
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-
+    
+    /**
+     * notification d'un refus
+     * au demandeur d'heures additionnelles
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationRefus() {
 
         $return['sujet'] = "Demande d'heure additionnelle refusée";
@@ -103,7 +119,14 @@ Class Additionnelle extends \App\Libraries\ANotification {
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-
+    
+    /**
+     * notification d'une annulation par le demandeur
+     * à son responsable
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationAnnulation() {
 
         $return['sujet'] = "Demande d'heure additionnelle annulée";
@@ -120,6 +143,13 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
     
+    /**
+     * notification d'une première validation
+     * au grand responsable du demandeur d'heures additionnelles
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationGrandResponsablePremiereValidation() {
         $return['sujet'] = "Demande d'heure additionnelle";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -96,6 +96,10 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
         $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
 
+        if(!is_null($infoResp['comment_refus'])){
+            $return['message'] .= "\nCommentaire : " . $infoResp['comment_refus'];
+        }
+        
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -20,7 +20,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
         $sql = \includes\SQL::singleton();
         $req = 'SELECT *
                 FROM heure_additionnelle
-                WHERE id_heure =' . $id;
+                WHERE id_heure =' . (int) $id;
 
         $data = $sql->query($req)->fetch_array();
         
@@ -33,87 +33,71 @@ Class Additionnelle extends \App\Libraries\ANotification {
     }
 
     /**
-     * notification d'une nouvelle demande d'heures additionnelles
-     * au responsable du demandeur
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationDemande() {
+    protected function getContenuDemande($data) {
 
         $return['sujet'] = "Demande d'heure additionnelle";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
     }
 
     /**
-     * notification d'une première validation 
-     * au demandeur d'heures additionnelles
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationEmployePremierValidation() {
+    protected function getContenuEmployePremierValidation($data) {
 
         $return['sujet'] = "Première validation d'heure additionnelle";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure additionnelle du  ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .". Il doit maintenant être traité en deuxième validation.";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure additionnelle du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .". Il doit maintenant être traité en deuxième validation.";
 
         $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
     }
 
     /**
-     * notification d'une validation finale
-     * au demandeur d'heures additionnelles
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationValidationFinale() {
+    protected function getContenuValidationFinale($data) {
 
         $return['sujet'] = "Demande d'heure additionnelle validée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
     
     /**
-     * notification d'un refus
-     * au demandeur d'heures additionnelles
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationRefus() {
+    protected function getContenuRefus($data) {
 
         $return['sujet'] = "Demande d'heure additionnelle refusée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
-        if(!is_null($this->data['comment_refus'])){
-            $return['message'] .= "\nCommentaire : " . $this->data['comment_refus'];
+        if(!is_null($data['comment_refus'])){
+            $return['message'] .= "\nCommentaire : " . $data['comment_refus'];
         }
         
         $return['config'] = 'mail_valid_conges_alerte_user';
@@ -121,46 +105,38 @@ Class Additionnelle extends \App\Libraries\ANotification {
     }
     
     /**
-     * notification d'une annulation par le demandeur
-     * à son responsable
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationAnnulation() {
+    protected function getContenuAnnulation($data) {
 
         $return['sujet'] = "Demande d'heure additionnelle annulée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure additionnelle du  ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure additionnelle du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
         $return['config'] = 'mail_supp_demande_alerte_resp';
         return $return;
     }
     
     /**
-     * notification d'une première validation
-     * au grand responsable du demandeur d'heures additionnelles
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationGrandResponsablePremiereValidation() {
+    protected function getContenuGrandResponsablePremiereValidation($data) {
         $return['sujet'] = "Demande d'heure additionnelle";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($this->data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure additionnelle de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
+    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure additionnelle de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -96,8 +96,8 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
         $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
 
-        if(!is_null($infoResp['comment_refus'])){
-            $return['message'] .= "\nCommentaire : " . $infoResp['comment_refus'];
+        if(!is_null($this->data['comment_refus'])){
+            $return['message'] .= "\nCommentaire : " . $this->data['comment_refus'];
         }
         
         $return['config'] = 'mail_valid_conges_alerte_user';

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -27,7 +27,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
                 WHERE id_heure =' . $id;
 
         $data = $sql->query($req)->fetch_array();
-
+        
+        $data['jour']   = date('d/m/Y', $data['debut']);
+        $data['debut']  = date('H\:i', $data['debut']);
+        $data['fin']    = date('H\:i', $data['fin']);
+        $data['duree']    = \App\Helpers\Formatter::Timestamp2Duree($data['duree']);
 
         return $data;
     }
@@ -48,8 +52,9 @@ Class Additionnelle extends \App\Libraries\ANotification {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ... du ... au ... soit ... heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." a ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
 
+        $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
     }
 
@@ -62,6 +67,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé votre demande d'heure additionnelle du ... . Il doit maintenant être traité en deuxième validation.";
 
+        $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
     }
 
@@ -75,6 +81,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ... de ... à ... .";
 
+        $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
 
@@ -87,6 +94,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a refusé la demande d'heure additionnelle du ... de ... à ... .";
 
+        $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
 
@@ -102,6 +110,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulée la demande d'heure additionnelle du ... de ... à ... commentaire_refus.";
 
+        $return['config'] = 'mail_supp_demande_alerte_resp';
         return $return;
     }
 }

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Libraries\Notification;
+
+/**
+ * Objet de gestion des notifications
+ * 
+ * 
+ */
+Class Additionnelle extends \App\Libraries\ANotification {
+
+
+    /**
+     * récupère les données de l'évenemment
+     * @param int $id
+     * 
+     * @return array
+     */
+    protected function getData($id) {
+
+        if (empty($id)) {
+            return [];
+        }
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT *
+                FROM heure_additionnelle
+                WHERE id_heure =' . $id;
+
+        $data = $sql->query($req)->fetch_array();
+
+
+        return $data;
+    }
+
+    /**
+     * notification nouvelle demande
+     * 
+     * @param array $data
+     * @return array
+     */
+    protected function getNotificationDemande() {
+
+        $return['sujet'] = "Demande d'heure additionnelle";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        foreach ($responsables as $responsable) {
+            $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
+        }
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ... du ... au ... soit ... heure(s). Vous devez traiter cette demande";
+
+        return $return;
+    }
+
+    private function getNotificationEmployePremierValidation() {
+
+        $return['sujet'] = "Première validation d'heure additionnelle";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé votre demande d'heure additionnelle du ... . Il doit maintenant être traité en deuxième validation.";
+
+        return $return;
+    }
+
+    private function getNotificationValidationFinale() {
+
+        $return['sujet'] = "Demande d'heure additionnelle validé";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ... de ... à ... .";
+
+        return $return;
+    }
+
+    private function getNotificationRefus() {
+
+        $return['sujet'] = "Demande d'heure additionnelle refusé";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a refusé la demande d'heure additionnelle du ... de ... à ... .";
+
+        return $return;
+    }
+
+    private function getNotificationAnnulation() {
+
+        $return['sujet'] = "Demande d'heure additionnelle annulée";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        foreach ($responsables as $responsable) {
+            $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
+        }
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulée la demande d'heure additionnelle du ... de ... à ... commentaire_refus.";
+
+        return $return;
+    }
+}

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -53,11 +53,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
 
-    private function getNotificationEmployePremierValidation() {
+    protected function getNotificationEmployePremierValidation() {
 
         $return['sujet'] = "Première validation d'heure additionnelle";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé votre demande d'heure additionnelle du ... . Il doit maintenant être traité en deuxième validation.";
@@ -65,11 +65,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
 
-    private function getNotificationValidationFinale() {
+    protected function getNotificationValidationFinale() {
 
         $return['sujet'] = "Demande d'heure additionnelle validé";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
 
@@ -78,11 +78,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
 
-    private function getNotificationRefus() {
+    protected function getNotificationRefus() {
 
         $return['sujet'] = "Demande d'heure additionnelle refusé";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a refusé la demande d'heure additionnelle du ... de ... à ... .";
@@ -90,7 +90,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
         return $return;
     }
 
-    private function getNotificationAnnulation() {
+    protected function getNotificationAnnulation() {
 
         $return['sujet'] = "Demande d'heure additionnelle annulée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -11,12 +11,7 @@ Class Repos extends \App\Libraries\ANotification {
 
 
     /**
-     * récupère les données de l'évenemment
-     * 
-     * @todo déplacer la requete vers le protocontroller
-     * @param int $id
-     * 
-     * @return array
+     * {@inheritDoc}
      */
     protected function getData($id) {
 
@@ -39,7 +34,8 @@ Class Repos extends \App\Libraries\ANotification {
     }
 
     /**
-     * notification nouvelle demande
+     * notification d'une nouvelle demande d'heures de repos
+     * au responsable du demandeur
      * 
      * @param array $data
      * @return array
@@ -60,6 +56,13 @@ Class Repos extends \App\Libraries\ANotification {
         return $return;
     }
 
+    /**
+     * notification d'une première validation 
+     * au demandeur d'heures de repos
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationEmployePremierValidation() {
 
         $return['sujet'] = "Première validation d'heure de repos";
@@ -72,7 +75,14 @@ Class Repos extends \App\Libraries\ANotification {
         $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
     }
-
+    
+    /**
+     * notification d'une validation finale
+     * au demandeur d'heures de repos
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationValidationFinale() {
 
         $return['sujet'] = "Demande d'heure de repos validée";
@@ -86,7 +96,14 @@ Class Repos extends \App\Libraries\ANotification {
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-
+    
+    /**
+     * notification d'un refus
+     * au demandeur d'heures de refus
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationRefus() {
 
         $return['sujet'] = "Demande d'heure de repos refusée";
@@ -103,7 +120,14 @@ Class Repos extends \App\Libraries\ANotification {
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-
+    
+    /**
+     * notification d'une annulation par le demandeur
+     * à son responsable
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationAnnulation() {
 
         $return['sujet'] = "Demande d'heure de repos annulée";
@@ -120,6 +144,13 @@ Class Repos extends \App\Libraries\ANotification {
         return $return;
     }
     
+    /**
+     * notification d'une première validation
+     * au grand responsable du demandeur d'heures de repos
+     * 
+     * @param array $data
+     * @return array
+     */
     protected function getNotificationGrandResponsablePremiereValidation() {
         $return['sujet'] = "Demande d'heure de repos";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -38,7 +38,7 @@ Class Repos extends \App\Libraries\ANotification {
      */
     protected function getContenuDemande($data) {
 
-        $return['sujet'] = "Demande d'heure de repos";
+        $return['sujet'] = "[CONGES] Demande d'heure de repos";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
@@ -57,7 +57,7 @@ Class Repos extends \App\Libraries\ANotification {
      */
     protected function getContenuEmployePremierValidation($data) {
 
-        $return['sujet'] = "Première validation d'heure de repos";
+        $return['sujet'] = "[CONGES] Première validation d'heure de repos";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
@@ -73,7 +73,7 @@ Class Repos extends \App\Libraries\ANotification {
      */
     protected function getContenuValidationFinale($data) {
 
-        $return['sujet'] = "Demande d'heure de repos validée";
+        $return['sujet'] = "[CONGES] Demande d'heure de repos validée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
@@ -90,7 +90,7 @@ Class Repos extends \App\Libraries\ANotification {
      */
     protected function getContenuRefus($data) {
 
-        $return['sujet'] = "Demande d'heure de repos refusée";
+        $return['sujet'] = "[CONGES] Demande d'heure de repos refusée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
@@ -110,7 +110,7 @@ Class Repos extends \App\Libraries\ANotification {
      */
     protected function getContenuAnnulation($data) {
 
-        $return['sujet'] = "Demande d'heure de repos annulée";
+        $return['sujet'] = "[CONGES] Demande d'heure de repos annulée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
@@ -128,7 +128,7 @@ Class Repos extends \App\Libraries\ANotification {
      * {@inheritDoc}
      */
     protected function getContenuGrandResponsablePremiereValidation($data) {
-        $return['sujet'] = "Demande d'heure de repos";
+        $return['sujet'] = "[CONGES] Demande d'heure de repos";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -39,9 +39,11 @@ Class Repos extends \App\Libraries\ANotification {
     protected function getContenuDemande($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure de repos";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
@@ -58,8 +60,10 @@ Class Repos extends \App\Libraries\ANotification {
     protected function getContenuEmployePremierValidation($data) {
 
         $return['sujet'] = "[CONGES] Première validation d'heure de repos";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure de repos du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .". Il doit maintenant être traité en deuxième validation.";
@@ -74,10 +78,10 @@ Class Repos extends \App\Libraries\ANotification {
     protected function getContenuValidationFinale($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure de repos validée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure de repos du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
@@ -91,8 +95,9 @@ Class Repos extends \App\Libraries\ANotification {
     protected function getContenuRefus($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure de repos refusée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
         $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure de repos du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
@@ -111,9 +116,10 @@ Class Repos extends \App\Libraries\ANotification {
     protected function getContenuAnnulation($data) {
 
         $return['sujet'] = "[CONGES] Demande d'heure de repos annulée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
         $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
@@ -129,10 +135,12 @@ Class Repos extends \App\Libraries\ANotification {
      */
     protected function getContenuGrandResponsablePremiereValidation($data) {
         $return['sujet'] = "[CONGES] Demande d'heure de repos";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
+
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -96,8 +96,8 @@ Class Repos extends \App\Libraries\ANotification {
 
         $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure de repos du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
 
-        if(!is_null($infoResp['comment_refus'])){
-            $return['message'] .= "\nCommentaire : " . $infoResp['comment_refus'];
+        if(!is_null($this->data['comment_refus'])){
+            $return['message'] .= "\nCommentaire : " . $this->data['comment_refus'];
         }
         
         $return['config'] = 'mail_valid_conges_alerte_user';

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -21,7 +21,7 @@ Class Repos extends \App\Libraries\ANotification {
         $sql = \includes\SQL::singleton();
         $req = 'SELECT *
                 FROM heure_repos
-                WHERE id_heure =' . $id;
+                WHERE id_heure =' . (int) $id;
 
         $data = $sql->query($req)->fetch_array();
         
@@ -34,87 +34,71 @@ Class Repos extends \App\Libraries\ANotification {
     }
 
     /**
-     * notification d'une nouvelle demande d'heures de repos
-     * au responsable du demandeur
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationDemande() {
+    protected function getContenuDemande($data) {
 
         $return['sujet'] = "Demande d'heure de repos";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure de repos pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure de repos pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
     }
 
     /**
-     * notification d'une première validation 
-     * au demandeur d'heures de repos
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationEmployePremierValidation() {
+    protected function getContenuEmployePremierValidation($data) {
 
         $return['sujet'] = "Première validation d'heure de repos";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure de repos du  ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .". Il doit maintenant être traité en deuxième validation.";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure de repos du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .". Il doit maintenant être traité en deuxième validation.";
 
         $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
     }
     
     /**
-     * notification d'une validation finale
-     * au demandeur d'heures de repos
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationValidationFinale() {
+    protected function getContenuValidationFinale($data) {
 
         $return['sujet'] = "Demande d'heure de repos validée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure de repos du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure de repos du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
     
     /**
-     * notification d'un refus
-     * au demandeur d'heures de refus
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationRefus() {
+    protected function getContenuRefus($data) {
 
         $return['sujet'] = "Demande d'heure de repos refusée";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure de repos du ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure de repos du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
-        if(!is_null($this->data['comment_refus'])){
-            $return['message'] .= "\nCommentaire : " . $this->data['comment_refus'];
+        if(!is_null($data['comment_refus'])){
+            $return['message'] .= "\nCommentaire : " . $data['comment_refus'];
         }
         
         $return['config'] = 'mail_valid_conges_alerte_user';
@@ -122,46 +106,38 @@ Class Repos extends \App\Libraries\ANotification {
     }
     
     /**
-     * notification d'une annulation par le demandeur
-     * à son responsable
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationAnnulation() {
+    protected function getContenuAnnulation($data) {
 
         $return['sujet'] = "Demande d'heure de repos annulée";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure de repos du  ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure de repos du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
 
         $return['config'] = 'mail_supp_demande_alerte_resp';
         return $return;
     }
     
     /**
-     * notification d'une première validation
-     * au grand responsable du demandeur d'heures de repos
-     * 
-     * @param array $data
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getNotificationGrandResponsablePremiereValidation() {
+    protected function getContenuGrandResponsablePremiereValidation($data) {
         $return['sujet'] = "Demande d'heure de repos";
         $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($this->data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure de repos de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $this->data['jour'] ." de ". $this->data['debut'] ." à ". $this->data['fin'] ." soit ". $this->data['duree'] ." heure(s). Vous devez traiter cette demande";
+    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure de repos de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;

--- a/App/Libraries/Notification/repos.php
+++ b/App/Libraries/Notification/repos.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Libraries\Notification;
+
+/**
+ * Objet de gestion des notifications
+ * 
+ * 
+ */
+Class Repos extends \App\Libraries\ANotification {
+
+    /**
+     * récupère les données de l'évenemment
+     * @param int $id
+     * 
+     * @return array
+     */
+    protected function getData($id) {
+
+        if (empty($id)) {
+            return [];
+        }
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT *
+                FROM heure_repos
+                WHERE id_heure =' . $id;
+
+        $data = $sql->query($req)->fetch_array();
+
+
+        return $data;
+    }
+
+    /**
+     * notification nouvelle demande
+     * 
+     * @param array $data
+     * @return array
+     */
+    protected function getNotificationDemande() {
+
+        $return['sujet'] = "Demande d'heure de repos";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        foreach ($responsables as $responsable) {
+            $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
+        }
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a solicité une demande d'heure de repos dans l'application de gestion des congés.";
+
+        return $return;
+    }
+
+    private function getNotificationEmployePremierValidation() {
+
+        $return['sujet'] = "Première validation d'heure de repos";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé (première validation) une demande d'heure de repos pour vous dans l'application de gestion des congés. Il doit maintenant être accepté en deuxième validation.";
+
+        return $return;
+    }
+
+    private function getNotificationValidationFinale() {
+
+        $return['sujet'] = "Demande d'heure de repos validé";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté une demande d'heure de repos pour vous dans l'application de gestion des congés.";
+
+        return $return;
+    }
+
+    private function getNotificationRefus() {
+
+        $return['sujet'] = "Demande d'heure de repos refusé";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a refusé une demande d'heure de repos pour vous dans l'application de gestion des congés.";
+
+        return $return;
+    }
+
+    private function getNotificationAnnulation() {
+
+        $return['sujet'] = "Demande d'heure de repos annulée";
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
+        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($this->data['login']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($this->data['login']);
+        foreach ($responsables as $responsable) {
+            $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
+        }
+
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulée une demande d'heure de repos.";
+
+        return $return;
+    }
+}

--- a/App/Libraries/Notification/repos.php
+++ b/App/Libraries/Notification/repos.php
@@ -55,8 +55,8 @@ Class Repos extends \App\Libraries\ANotification {
     private function getNotificationEmployePremierValidation() {
 
         $return['sujet'] = "Première validation d'heure de repos";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé (première validation) une demande d'heure de repos pour vous dans l'application de gestion des congés. Il doit maintenant être accepté en deuxième validation.";
@@ -67,8 +67,8 @@ Class Repos extends \App\Libraries\ANotification {
     private function getNotificationValidationFinale() {
 
         $return['sujet'] = "Demande d'heure de repos validé";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
 
@@ -80,8 +80,8 @@ Class Repos extends \App\Libraries\ANotification {
     private function getNotificationRefus() {
 
         $return['sujet'] = "Demande d'heure de repos refusé";
-        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['login']);
+        $return['expediteur'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
+        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($this->data['login']);
 
         $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a refusé une demande d'heure de repos pour vous dans l'application de gestion des congés.";

--- a/App/ProtoControllers/Employe/AHeure.php
+++ b/App/ProtoControllers/Employe/AHeure.php
@@ -34,7 +34,7 @@ abstract class AHeure
      *
      * @return int
      */
-    protected function post(array $post, array &$errorsLst, &$notice)
+    protected function postHtmlCommon(array $post, array &$errorsLst, &$notice)
     {
         $user = $_SESSION['userlogin'];
         if (!empty($post['_METHOD'])) {
@@ -56,18 +56,21 @@ abstract class AHeure
                     break;
             }
         } else {
-            if (!$this->hasErreurs($post, $user, $errorsLst)) {
-                $data = $this->dataModel2Db($post, $user);
-                $id   = $this->insert($data, $user);
-                if (0 < $id) {
-                    return $id;
-                }
-            }
-
-            return NIL_INT;
+            return $this->post($post, $errorsLst, $user);
         }
     }
 
+    /**
+    * Créé une demande d'heures
+    *
+    * @param array  $post
+    * @param array  &$errorsLst
+    * @param string $user
+    *
+    * @return int
+    */
+    abstract protected function post(array $post, array &$errorsLst, $user);
+    
     /**
      * Supprime une demande d'heures
      *

--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -156,7 +156,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
         if (!$this->hasErreurs($post, $user, $errorsLst)) {
             $data = $this->dataModel2Db($post, $user);
             $id   = $this->insert($data, $user);
-            log_action($idHeure, 'demande', '', 'demande d\'heure additionnelle ' . $id);
+            log_action($id, 'demande', '', 'demande d\'heure additionnelle ' . $id);
             $return = $id;
             $notif = new \App\Libraries\Notification\Additionnelle($id);
             if (!$notif->send()) {

--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -150,7 +150,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
     {
         if (!$this->hasErreurs($post, $user, $errorsLst)) {
             $data = $this->dataModel2Db($post, $user);
-            $id   = $this->insert($data, $user, $idHeure);
+            $id   = $this->insert($data, $user);
             log_action($idHeure, 'demande', '', 'demande d\'heure additionnelle ' . $id);
             $notif = new \App\Libraries\Notification\Additionnelle($id);
             $send = $notif->send();

--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -122,7 +122,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
             $return = $id;
             
             $notif = new \App\Libraries\Notification\Additionnelle($id);
-            if(!$notif-send()) {
+            if(!$notif->send()) {
                 $errorsLst['email'] = _('erreur_envoi_mail');
                 $return = NIL_INT;
             }
@@ -265,7 +265,6 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
                     $message = '<div class="alert alert-danger">' . _('erreur_recommencer') . ' :<ul>' . $errors . '</ul></div>';
                 }
             } elseif ('DELETE' === $_POST['_METHOD'] && !empty($notice)) {
-                log_action(0, '', '', 'Annulation de l\'heure additionnelle ' . $_POST['id_heure']);
                 $message = '<div class="alert alert-info">' .  $notice . '.</div>';
             } else {
                 log_action(0, '', '', 'Récupération de l\'heure additionnelle ' . $_POST['id_heure']);

--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -300,7 +300,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
                 $jour   = date('d/m/Y', $additionnelle['debut']);
                 $debut  = date('H\:i', $additionnelle['debut']);
                 $fin    = date('H\:i', $additionnelle['fin']);
-                $duree  = date('H\:i', $additionnelle['duree']);
+                $duree  = \App\Helpers\Formatter::Timestamp2Duree($additionnelle['duree']);
                 $statut = AHeure::statusText($additionnelle['statut']);
                 $comment = \includes\SQL::quote($additionnelle['comment']);
                 if (AHeure::STATUT_DEMANDE == $additionnelle['statut']) {

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -104,7 +104,6 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         <input class="form-control" style="width:45%" type="text" id="' . $finId . '"  value="' . $valueFin . '" name="fin_heure"></div></td><td><input class="form-control" type="text" name="comment" value="'.$comment.'" size="20" maxlength="100"></td></tr>';
         $childTable .= '</tbody>';
         $childTable .= '<script type="text/javascript">generateTimePicker("' . $debutId . '");generateTimePicker("' . $finId . '");</script>';
-
         $table->addChild($childTable);
         ob_start();
         $table->render();
@@ -196,7 +195,6 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         $horodateDebut = \App\Helpers\Formatter::hour2Time(date('H\:i', $debut));
         $horodateFin   = \App\Helpers\Formatter::hour2Time(date('H\:i', $fin));
         $reelleDuree   = 0;
-
         /* Double foreach pour lisser les créneaux matin / après midi sur le même plan */
         foreach ($planningJour as $creneaux) {
             foreach ($creneaux as $creneau) {
@@ -206,9 +204,10 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                 if ($horodateDebut <= $creneauDebut) {
                     if ($horodateFin <= $creneauDebut) {
                         // On ne cumule rien
+                        
                         break;
                     } elseif ($horodateFin > $creneauDebut && $horodateFin <= $creneauFin) {
-                        $reelleDuree += $fin - $creneauDebut;
+                        $reelleDuree += $fin - $debut;
                     } else {
                         /* $horodateFin > $creneauFin */
                         $reelleDuree += $creneauFin - $creneauDebut;
@@ -224,7 +223,6 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                 }
             }
         }
-
         return $reelleDuree;
     }
 

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -140,8 +140,8 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
     {
         if (!$this->hasErreurs($post, $user, $errorsLst)) {
             $data = $this->dataModel2Db($post, $user);
-            $id   = $this->insert($data, $user, $idHeure);
-            log_action($idHeure, 'demande', '', 'demande d\'heure de repos ' . $id);
+            $id   = $this->insert($data, $user);
+            log_action($id, 'demande', '', 'demande d\'heure de repos ' . $id);
             $notif = new \App\Libraries\Notification\repos($id);
             $send = $notif->send();
 

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -143,7 +143,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
             $data = $this->dataModel2Db($post, $user);
             $id   = $this->insert($data, $user);
             log_action($id, 'demande', '', 'demande d\'heure de repos ' . $id);
-            return $id;
+            $return = $id;
 
             $notif = new \App\Libraries\Notification\Repos($id);
             if (!$notif->send()) {

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -138,19 +138,20 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
      */
     protected function post(array $post, array &$errorsLst, $user)
     {
+        $return =NIL_INT;
         if (!$this->hasErreurs($post, $user, $errorsLst)) {
             $data = $this->dataModel2Db($post, $user);
             $id   = $this->insert($data, $user);
             log_action($id, 'demande', '', 'demande d\'heure de repos ' . $id);
-            $notif = new \App\Libraries\Notification\Repos($id);
-            $send = $notif->send();
-
-            if (false === $send) {
-                $errorsLst['email'] = _('erreur_envoi_mail');
-            }
             return $id;
+
+            $notif = new \App\Libraries\Notification\Repos($id);
+            if (!$notif->send()) {
+                $errorsLst['email'] = _('erreur_envoi_mail');
+                $return = NIL_INT;
+            }
         }
-        return NIL_INT;
+        return $return;
     }
 
     /**
@@ -232,18 +233,19 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
      */
     protected function delete($id, $user, array &$errorsLst, &$notice)
     {
+        $return = NIL_INT;
         if (NIL_INT !== $this->deleteSQL($id, $user, $errorsLst)) {
             log_action($id, 'annul', '', 'Annulation de la demande d\'heure de repos ' . $id);
             $notice = _('heure_repos_annulee');
-            $notif = new \App\Libraries\Notification\repos($id);
-            $send = $notif->send();
-
-            if (false === $send) {
-                $errorsLst['email'] = _('erreur_envoi_mail');
-            }
             return $id;
+
+            $notif = new \App\Libraries\Notification\repos($id);
+            if (!$notif->send()) {
+                $errorsLst['email'] = _('erreur_envoi_mail');
+                $return = NIL_INT;
+            }
         }
-        return NIL_INT;
+        return $return;
     }
 
     /**

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -305,7 +305,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                 $jour   = date('d/m/Y', $repos['debut']);
                 $debut  = date('H\:i', $repos['debut']);
                 $fin    = date('H\:i', $repos['fin']);
-                $duree  = date('H\:i', $repos['duree']);
+                $duree  = \App\Helpers\Formatter::Timestamp2Duree($repos['duree']);
                 $statut = AHeure::statusText($repos['statut']);
                 $comment = \includes\SQL::quote($repos['comment']);
                 if (AHeure::STATUT_DEMANDE == $repos['statut']) {

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -237,9 +237,9 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         if (NIL_INT !== $this->deleteSQL($id, $user, $errorsLst)) {
             log_action($id, 'annul', '', 'Annulation de la demande d\'heure de repos ' . $id);
             $notice = _('heure_repos_annulee');
-            return $id;
+            $return = $id;
 
-            $notif = new \App\Libraries\Notification\repos($id);
+            $notif = new \App\Libraries\Notification\Repos($id);
             if (!$notif->send()) {
                 $errorsLst['email'] = _('erreur_envoi_mail');
                 $return = NIL_INT;
@@ -266,7 +266,6 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                     $message = '<div class="alert alert-danger">' . _('erreur_recommencer') . ' :<ul>' . $errors . '</ul></div>';
                 }
             } elseif ('DELETE' === $_POST['_METHOD'] && !empty($notice)) {
-                log_action(0, '', '', 'Annulation de l\'heure de repos ' . $_POST['id_heure']);
                 $message = '<div class="alert alert-info">' .  $notice . '.</div>';
             } else {
                 log_action(0, '', '', 'Récupération de l\'heure de repos ' . $_POST['id_heure']);

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -207,7 +207,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                         
                         break;
                     } elseif ($horodateFin > $creneauDebut && $horodateFin <= $creneauFin) {
-                        $reelleDuree += $horodateFin - $horodateDebut;
+                        $reelleDuree += $horodateFin - $creneauDebut;
                     } else {
                         /* $horodateFin > $creneauFin */
                         $reelleDuree += $creneauFin - $creneauDebut;

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -207,7 +207,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                         
                         break;
                     } elseif ($horodateFin > $creneauDebut && $horodateFin <= $creneauFin) {
-                        $reelleDuree += $fin - $debut;
+                        $reelleDuree += $horodateFin - $horodateDebut;
                     } else {
                         /* $horodateFin > $creneauFin */
                         $reelleDuree += $creneauFin - $creneauDebut;

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -142,7 +142,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
             $data = $this->dataModel2Db($post, $user);
             $id   = $this->insert($data, $user);
             log_action($id, 'demande', '', 'demande d\'heure de repos ' . $id);
-            $notif = new \App\Libraries\Notification\repos($id);
+            $notif = new \App\Libraries\Notification\Repos($id);
             $send = $notif->send();
 
             if (false === $send) {

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -128,6 +128,39 @@ class Responsable
         
         return 0 < (int) $query->fetch_array()[0];
     }
+    
+    public static function getResponsablesUtilisateur($user) {
+        
+        $responsables = \App\ProtoControllers\Responsable::getResponsableGroupe(\App\ProtoControllers\Utilisateur::getGroupesId($user));
+        array_push($responsables,\App\ProtoControllers\Responsable::getResponsableDirect($user));
+
+        return $responsables;
+    }
+
+    public static function getResponsableDirect($user) {
+        
+        $resp = [];
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . $user . '"';
+        $res = $sql->query($req);
+        return $res->fetch_array()['u_resp_login'];
+        
+    }
+    
+    private function getResponsableGroupe(array $groupesId) {
+        
+        $responsable = [];
+        
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT gr_login FROM conges_groupe_resp WHERE gr_gid IN (\'' . implode(',', $groupesId) . '\')';
+        $res = $sql->query($req);
+
+         while ($data = $res->fetch_array()) {
+             $responsable[] = $data['gr_login'];
+         }
+         
+         return $responsable;
+    }
 
     /**
      * Vérifie si un utilisateur est bien le responsable d'un employé

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -128,7 +128,22 @@ class Responsable
         
         return 0 < (int) $query->fetch_array()[0];
     }
-    
+
+    public static function getLoginGrandResponsableUtilisateur($user) {
+        $groupesUser = [];
+        $groupesIdUser = \App\ProtoControllers\Utilisateur::getGroupesId($user);
+        
+        $grandResp = [];
+        $sql = \includes\SQL::singleton();
+        $req = 'select ggr_login FROM conges_groupe_grd_resp where ggr_gid  IN (\'' . implode(',', $groupesIdUser) . '\')';
+        $res = $sql->query($req);
+        
+        while ($data = $res->fetch_array()) {
+             $grandResp[] = $data['ggr_login'];
+        }
+        return $grandResp;
+    }
+
     public static function getResponsablesUtilisateur($user) {
         
         $responsables = \App\ProtoControllers\Responsable::getResponsableGroupe(\App\ProtoControllers\Utilisateur::getGroupesId($user));

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -162,7 +162,7 @@ class Responsable
         
     }
     
-    private function getResponsableGroupe(array $groupesId) {
+    private static function getResponsableGroupe(array $groupesId) {
         
         $responsable = [];
         

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -130,7 +130,6 @@ class Responsable
     }
 
     public static function getLoginGrandResponsableUtilisateur($user) {
-        $groupesUser = [];
         $groupesIdUser = \App\ProtoControllers\Utilisateur::getGroupesId($user);
         
         $grandResp = [];
@@ -147,8 +146,9 @@ class Responsable
     public static function getResponsablesUtilisateur($user) {
         
         $responsables = \App\ProtoControllers\Responsable::getResponsableGroupe(\App\ProtoControllers\Utilisateur::getGroupesId($user));
-        array_push($responsables,\App\ProtoControllers\Responsable::getResponsableDirect($user));
-
+        $responsables[] = \App\ProtoControllers\Responsable::getResponsableDirect($user);
+        $responsables = array_unique($responsables);
+        
         return $responsables;
     }
 
@@ -156,7 +156,7 @@ class Responsable
         
         $resp = [];
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . $user . '"';
+        $req = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . SQL::quote($user) . '"';
         $res = $sql->query($req);
         return $res->fetch_array()['u_resp_login'];
         

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -153,10 +153,9 @@ class Responsable
     }
 
     public static function getResponsableDirect($user) {
-        
         $resp = [];
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . SQL::quote($user) . '"';
+        $req = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . \includes\SQL::quote($user) . '"';
         $res = $sql->query($req);
         return $res->fetch_array()['u_resp_login'];
         

--- a/App/ProtoControllers/Responsable/ATraitement.php
+++ b/App/ProtoControllers/Responsable/ATraitement.php
@@ -116,7 +116,7 @@ abstract class ATraitement
             $sql->getPdoObj()->rollback();
             return NIL_INT;
         }
-        return $sql->affected_rows;
+        return $updateStatut;
     }
 
     /**

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -33,7 +33,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             } elseif (\App\ProtoControllers\Responsable::isGrandRespDeGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($infoDemandes[$id_heure]['login']))) {
                 $return = $this->putGrandResponsable($infoDemandes[$id_heure], $statut, $put, $errorLst);
             } else {
-                $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes['id_heure']['login'];
+                $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes[$id_heure]['login'];
                 $return = NIL_INT;
             }
         }

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -66,15 +66,14 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
             $return = NIL_INT;
         }
-        $errors = array_merge($errors, $localError);
         if( 0 < $return) {
             $notif = new \App\Libraries\Notification\Additionnelle($id_heure);
-            $send = $notif->send();
-
-            if (false === $send) {
+            if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+                $return = NIL_INT;
             }
         }
+        $errors = array_merge($errors, $localError);
         return $return;
     }
 
@@ -102,15 +101,14 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
             $return = NIL_INT;
         }
-        $errors = array_merge($errors, $localError);
         if( 0 < $return) {
             $notif = new \App\Libraries\Notification\Additionnelle($id);
-            $send = $notif->send();
-
-            if (false === $send) {
+            if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+                $return = NIL_INT;
             }
         }
+        $errors = array_merge($errors, $localError);
         return $return;
     }
 

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -67,6 +67,14 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $return = NIL_INT;
         }
         $errors = array_merge($errors, $localError);
+        if( 0 < $return) {
+            $notif = new \App\Libraries\Notification\Additionnelle($id);
+            $send = $notif->send();
+
+            if (false === $send) {
+                $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+            }
+        }
         return $return;
     }
 
@@ -95,6 +103,14 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $return = NIL_INT;
         }
         $errors = array_merge($errors, $localError);
+        if( 0 < $return) {
+            $notif = new \App\Libraries\Notification\Additionnelle($id);
+            $send = $notif->send();
+
+            if (false === $send) {
+                $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+            }
+        }
         return $return;
     }
 

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -68,7 +68,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         }
         $errors = array_merge($errors, $localError);
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Additionnelle($id);
+            $notif = new \App\Libraries\Notification\Additionnelle($id_heure);
             $send = $notif->send();
 
             if (false === $send) {

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -69,10 +69,9 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         
         if( 0 < $return) {
             $notif = new \App\Libraries\Notification\Repos($id_heure);
-            $send = $notif->send();
-
-            if (false === $send) {
+            if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+                $return = NIL_INT;
             }
         }
         $errors = array_merge($errors, $localError);

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -66,6 +66,15 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
             $return = NIL_INT;
         }
+        
+        if( 0 < $return) {
+            $notif = new \App\Libraries\Notification\Repos($id);
+            $send = $notif->send();
+
+            if (false === $send) {
+                $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+            }
+        }
         $errors = array_merge($errors, $localError);
         return $return;
     }
@@ -93,6 +102,15 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         } else {
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
             $return = NIL_INT;
+        }
+        
+        if( 0 < $return) {
+            $notif = new \App\Libraries\Notification\Repos($id);
+            $send = $notif->send();
+
+            if (false === $send) {
+                $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
+            }
         }
         $errors = array_merge($errors, $localError);
 

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -68,7 +68,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         }
         
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Repos($id);
+            $notif = new \App\Libraries\Notification\Repos($id_heure);
             $send = $notif->send();
 
             if (false === $send) {

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -33,7 +33,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
             } elseif (\App\ProtoControllers\Responsable::isGrandRespDeGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($infoDemandes[$id_heure]['login']))) {
                 $return = $this->putGrandResponsable($infoDemandes[$id_heure], $statut, $put, $errorLst);
             } else {
-                $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes['id_heure']['login'];
+                $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes[$id_heure]['login'];
                 $return = NIL_INT;
             }
         }

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -207,6 +207,19 @@ class Utilisateur
     }
 
     /**
+     * Récupère l'adresse email de l'utilisateur
+     * 
+     * @todo En attendant l'objet ldap utilisation de find_email_adress_for_user
+     * 
+     * @param string $login
+     * @return string $mail
+     */    
+    public static function getEmailUtilisateur($login)  {
+        require_once ROOT_PATH.'fonctions_conges.php';
+        return find_email_adress_for_user($login);
+    }
+    
+    /**
      * Vérifie si l'utilisateur a des congés en cours
      *
      * @param string $login

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -216,7 +216,7 @@ class Utilisateur
      */    
     public static function getEmailUtilisateur($login)  {
         require_once ROOT_PATH.'fonctions_conges.php';
-        return find_email_adress_for_user($login);
+        return find_email_adress_for_user($login)[1];
     }
     
     /**


### PR DESCRIPTION
Les notifications des congés ne sont pas du tout adaptées pour les heures. Cette PR vient combler ce manque, d'une part en permettant l'émission de notifications à chaque étape du workflow des heures, et d'autre part en préparant le terrain pour gérer les notifications des congés de la même façon.
Pour le moment, le contenu des notifications n'est pas modifiable en ligne. Ce sera dans une autre PR...

un point important : contrairement aux notifications des congés, le contenu des notifications d'heure additionnelle/repos est déduit du statut.

- [x] documenter!
- [x] prise en compte de la délégation en cas d'absence du responsable