### PR TITLE
Donner du contexte de traitement aux responsables

### DIFF
--- a/App/Libraries/Calendrier/BusinessCollection.php
+++ b/App/Libraries/Calendrier/BusinessCollection.php
@@ -35,6 +35,11 @@ class BusinessCollection
     private $utilisateur;
 
     /**
+     * @var bool Si l'utilisateur a la possiblité de voir les événements non encore validés final
+     */
+    private $canVoirEnTransit;
+
+    /**
     * @var bool Si la gestion des groupes est demandée
      */
     private $isGroupesGeres;
@@ -53,14 +58,21 @@ class BusinessCollection
      * @param bool $isGroupesGeres Si la gestion des groupes est demandée
      * @param int $groupeAConsulter Groupe dont on veut voir les événements
      */
-    public function __construct(\DateTimeInterface $dateDebut, \DateTimeInterface $dateFin, $utilisateur, $isGroupesGeres, $groupeAConsulter = NIL_INT)
-    {
+    public function __construct(
+        \DateTimeInterface $dateDebut,
+        \DateTimeInterface $dateFin,
+        $utilisateur,
+        $canVoirEnTransit,
+        $isGroupesGeres,
+        $groupeAConsulter = NIL_INT
+    ){
         $this->dateDebut = clone $dateDebut;
         /* Extension des bordures de dates */
         $this->dateDebut->modify('-1 week');
         $this->dateFin = clone $dateFin;
         $this->dateFin->modify('+1 week');
         $this->utilisateur = (string) $utilisateur;
+        $this->canVoirEnTransit = (bool) $canVoirEnTransit;
         $this->isGroupesGeres = (bool) $isGroupesGeres;
         $this->groupeAConsulter = (int) $groupeAConsulter;
     }
@@ -96,9 +108,9 @@ class BusinessCollection
             );
 
             if (!empty($utilisateursATrouver)) {
-                $conge = new Collection\Conge($this->dateDebut, $this->dateFin, $utilisateursATrouver);
-                $repos = new Collection\Heure\Repos($this->dateDebut, $this->dateFin, $utilisateursATrouver);
-                $additionnelle = new Collection\Heure\Additionnelle($this->dateDebut, $this->dateFin, $utilisateursATrouver);
+                $conge = new Collection\Conge($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
+                $repos = new Collection\Heure\Repos($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
+                $additionnelle = new Collection\Heure\Additionnelle($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
                 $this->evenements = array_merge(
                     $this->evenements,
                     $conge->getListe(),

--- a/App/Libraries/Calendrier/Collection/Heure/Additionnelle.php
+++ b/App/Libraries/Calendrier/Collection/Heure/Additionnelle.php
@@ -23,13 +23,23 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
     private $utilisateursATrouver;
 
     /**
+     * @var bool Si l'utilisateur a la possiblité de voir les événements non encore validés
+     */
+    private $canVoirEnTransit;
+
+    /**
      * {@inheritDoc}
      * @param array $utilisateursATrouver Liste d'utilisateurs dont on veut voir les heures additionnelles
      */
-    public function __construct(\DateTimeInterface $dateDebut, \DateTimeInterface $dateFin, array $utilisateursATrouver)
-    {
+    public function __construct(
+        \DateTimeInterface $dateDebut,
+        \DateTimeInterface $dateFin,
+        array $utilisateursATrouver,
+        $canVoirEnTransit
+    ) {
         parent::__construct($dateDebut, $dateFin);
         $this->utilisateursATrouver = $utilisateursATrouver;
+        $this->canVoirEnTransit = (bool) $canVoirEnTransit;
     }
 
     /**
@@ -38,10 +48,13 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
     public function getListe()
     {
         $heures = [];
-        $class = 'heure';
         foreach ($this->getListeSQL($this->getListeId()) as $heure) {
+            $class = 'heure heure_' . $heure['statut'];
             $nomComplet = \App\ProtoControllers\Utilisateur::getNomComplet($heure['u_prenom'],  $heure['u_nom'], true);
             $name = $nomComplet . ' - Heure(s) additionnelles';
+            if (\App\Models\AHeure::STATUT_VALIDATION_FINALE !== $heure['statut']) {
+                $name = '[En demande]  ' . $name;
+            }
             $dateDebut = new \DateTime();
             $dateDebut->setTimestamp($heure['debut']);
             $dateFin = new \DateTime();
@@ -70,13 +83,20 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
     private function getListeId()
     {
         $ids = [];
+        $etats[] = \App\Models\AHeure::STATUT_VALIDATION_FINALE;
+        if ($this->canVoirEnTransit) {
+            $etats = array_merge($etats, [
+                \App\Models\AHeure::STATUT_DEMANDE,
+                \App\Models\AHeure::STATUT_PREMIERE_VALIDATION
+            ]);
+        }
         $req = 'SELECT id_heure AS id
                 FROM heure_additionnelle
                 WHERE debut >= "' . $this->dateDebut->getTimestamp() . '"
                     AND debut <= "' . $this->dateFin->getTimestamp() . '"
                     AND duree > 0
                     AND login IN ("' . implode('","', $this->utilisateursATrouver) . '")
-                    AND statut = ' . \App\Models\AHeure::STATUT_VALIDATION_FINALE;
+                    AND statut IN ("' . implode('","', $etats) . '")';
         $sql = \includes\SQL::singleton();
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {

--- a/App/ProtoControllers/Calendrier.php
+++ b/App/ProtoControllers/Calendrier.php
@@ -215,6 +215,7 @@ final class Calendrier
             $this->dateDebut,
             $this->dateFin,
             $_SESSION['userlogin'],
+            $this->canSessionVoirEvenementEnTransit($_SESSION),
             $_SESSION['config']['gestion_groupes'],
             $this->idGroupe
         );
@@ -233,6 +234,13 @@ final class Calendrier
         }
 
         return $return;
+    }
+
+    private function canSessionVoirEvenementEnTransit(array $donnessUtilisateur)
+    {
+        return (isset($donnessUtilisateur['is_resp']) && 'Y' === $donnessUtilisateur['is_resp'])
+            || (isset($donnessUtilisateur['is_rh']) && 'Y' === $donnessUtilisateur['is_rh'])
+            || (isset($donnessUtilisateur['is_admin']) && 'Y' === $donnessUtilisateur['is_admin']);
     }
 
     /**

--- a/App/ProtoControllers/Responsable/ATraitement.php
+++ b/App/ProtoControllers/Responsable/ATraitement.php
@@ -35,24 +35,24 @@ abstract class ATraitement
 
     /**
      * Vérifie et traite une demande en tant que responsable
-     * 
+     *
      * @param array $infoDemande
      * @param int $statut
      * @param array $put
      * @param array $errors
-     * 
+     *
      * @return int
      */
     abstract protected function putResponsable(array $infoDemande, $statut, array $put, array &$errors);
 
     /**
      * Vérifie et traite une demande en tant que grand responsable
-     * 
+     *
      * @param array $infoDemande
      * @param int $statut
      * @param array $put
      * @param array $errors
-     * 
+     *
      * @return int
      */
     abstract protected function putGrandResponsable(array $infoDemande, $statut, array $put, array &$errors);
@@ -72,7 +72,7 @@ abstract class ATraitement
      * @param array $listId
      *
      * @return array $infoDemande
-     * 
+     *
      */
     abstract protected function getInfoDemandes(array $listId);
 
@@ -81,7 +81,7 @@ abstract class ATraitement
      *
      * @param array  $post
      * @param string $notice
-     * @param array $errorLst 
+     * @param array $errorLst
      *
      * @return int
      */
@@ -96,16 +96,16 @@ abstract class ATraitement
 
     /**
      * Traitement d'une validation avec modification du solde
-     * 
+     *
      * @param int $demandeId
-     * 
+     *
      * @return int
      */
     protected function putValidationFinale($demandeId)
     {
         $sql = \includes\SQL::singleton();
         $sql->getPdoObj()->begin_transaction();
-        
+
         $updateSolde = $this->updateSolde($demandeId);
         $updateStatut = $this->updateStatutValidationFinale($demandeId);
         if (0 < $updateSolde && 0 < $updateStatut) {
@@ -116,12 +116,12 @@ abstract class ATraitement
         }
         return $sql->affected_rows;
     }
-    
+
     /**
      * Retourne les demandes en cours d'un responsable
-     * 
+     *
      * @param string $resp login du responsable
-     * 
+     *
      * @return array $demandes
      */
     public function getDemandesResponsable($resp)
@@ -134,21 +134,22 @@ abstract class ATraitement
 
         return $demandes;
     }
-    
+
     /**
      * Retourne un tableau html des demandes à traiter
-     * 
+     *
      * @param array $demandes
-     * 
+     *
      * @return string
      */
     protected function getFormDemandes(array $demandes)
     {
         $i=true;
         $Table='';
-        
-        foreach ( $demandes as $demande ) {
-           $jour   = date('d/m/Y', $demande['debut']);
+        $session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
+
+        foreach ($demandes as $demande) {
+            $jour   = date('d/m/Y', $demande['debut']);
             $debut  = date('H\:i', $demande['debut']);
             $fin    = date('H\:i', $demande['fin']);
             $duree  = \App\Helpers\Formatter::Timestamp2Duree($demande['duree']);
@@ -162,19 +163,29 @@ abstract class ATraitement
             $Table .= '<td><input type="radio" name="demande['.$id.']" value="1"></td>';
             $Table .= '<td><input type="radio" name="demande['.$id.']" value="2"></td>';
             $Table .= '<td><input type="radio" name="demande['.$id.']" value="NULL" checked></td>';
+
+            /* Informations pour le positionnement du calendrier */
+            $dateDebut = new \DateTimeImmutable(date('Y-m', $demande['debut']) . '-01');
+            $paramsCalendrier = [
+                'session' => $session,
+                'vue' => \App\ProtoControllers\Calendrier::VUE_MOIS,
+                'begin' => $dateDebut->format('Y-m-d'),
+                'end' => $dateDebut->modify('+1 month')->format('Y-m-d'),
+            ];
+            $Table .= '<td><a href="' . ROOT_PATH . 'calendrier.php?' . http_build_query($paramsCalendrier) . '" title="' . _('consulter_calendrier_de_periode') . '"><i class="fa fa-lg fa-calendar" aria-hidden="true"></i></a></td>';
             $Table .= '<td><input class="form-control" type="text" name="comment_refus['.$id.']" size="20" maxlength="100"></td></tr>';
 
             $i = !$i;
-            }
-            
+        }
+
         return $Table;
     }
 
     /**
      * Retourne le détail des demandes à traiter en tant que grand responsable
-     * 
+     *
      * @param string $resp
-     * 
+     *
      * @return array $demandes
      */
     public function getDemandesGrandResponsable($resp)
@@ -190,10 +201,10 @@ abstract class ATraitement
 
     /**
      * Verifie si la demande n'a pas déja été traité
-     * 
+     *
      * @param string $statutDb
      * @param string $statut
-     * 
+     *
      * @return bool
      */
     public function isDemandeTraitable($statut)
@@ -203,16 +214,16 @@ abstract class ATraitement
 
     /**
      * Retourne le nombre de demande en cours d'un responsable
-     * 
+     *
      * @param $resp
-     * 
+     *
      * @return int
      */
     public function getNbDemandesATraiter($resp)
     {
         $demandesResp= $this->getIdDemandesResponsable($resp);
         $demandesGResp=  $this->getIdDemandesGrandResponsable($resp);
-        
+
         return count($demandesResp) + count($demandesGResp);
     }
 }

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -223,7 +223,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         $childTable .= '<th>' . _('duree') . '</th>';
         $childTable .= '<th>' . _('divers_solde') . '</th>';
         $childTable .= '<th>' . _('divers_comment_maj_1') . '</th>';
-        $childTable .= '<th>' . _('divers_accepter_maj_1') . '</th><th>' . _('divers_refuser_maj_1') . '</th><th>' . _('resp_traite_demandes_attente') . '</th>';
+        $childTable .= '<th>' . _('divers_accepter_maj_1') . '</th><th>' . _('divers_refuser_maj_1') . '</th><th>' . _('resp_traite_demandes_attente') . '</th><th></th>';
         $childTable .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
         $childTable .= '</tr></thead><tbody>';
 

--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -57,20 +57,20 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         $childTable .= '<th>' . _('divers_comment_maj_1') . '</th>';
         $childTable .= '<th>' . _('divers_accepter_maj_1') . '</th>';
         $childTable .= '<th>' . _('divers_refuser_maj_1') . '</th>';
-        $childTable .= '<th>' . _('resp_traite_demandes_attente') . '</th>';
+        $childTable .= '<th>' . _('resp_traite_demandes_attente') . '</th><th></th>';
         $childTable .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
         $childTable .= '</tr></thead><tbody>';
 
         $demandesResp = $this->getDemandesResponsable($_SESSION['userlogin']);
         $demandesGrandResp = $this->getDemandesGrandResponsable($_SESSION['userlogin']);
         if (empty($demandesResp) && empty($demandesGrandResp) ) {
-            $childTable .= '<tr><td colspan="11"><center>' . _('resp_traite_demandes_aucune_demande') . '</center></td></tr>';
+            $childTable .= '<tr><td colspan="12"><center>' . _('resp_traite_demandes_aucune_demande') . '</center></td></tr>';
         } else {
             if(!empty($demandesResp)) {
                 $childTable .= $this->getFormDemandes($demandesResp);
             }
             if (!empty($demandesGrandResp)) {
-                $childTable .='<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="11"><i>'._('resp_etat_users_titre_double_valid').'</i></td></tr>';
+                $childTable .='<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="12"><i>'._('resp_etat_users_titre_double_valid').'</i></td></tr>';
                 $childTable .= $this->getFormDemandes($demandesGrandResp);
 
             }
@@ -97,21 +97,22 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     {
         $i=true;
         $Table='';
+        $session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-        foreach ( $demandes as $demande ) {
+        foreach ($demandes as $demande) {
             $id = $demande['p_num'];
             $infoUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($demande['p_login']);
             $solde = \App\ProtoControllers\Utilisateur::getSoldeconge($demande['p_login'],$demande['p_type']);
             $type = $this->getTypeLabel($demande['p_type']);
             $debut = \App\Helpers\Formatter::dateIso2Fr($demande['p_date_deb']);
             $fin = \App\Helpers\Formatter::dateIso2Fr($demande['p_date_fin']);
-            if($demande['p_demi_jour_deb']=="am") {
+            if ($demande['p_demi_jour_deb']=="am") {
                 $demideb = _('form_am');
             }  else {
                 $demideb = _('form_pm');
             }
 
-            if($demande['p_demi_jour_fin']=="am") {
+            if ($demande['p_demi_jour_fin']=="am") {
                 $demifin = _('form_am');
             } else {
                 $demifin = _('form_pm');
@@ -126,9 +127,20 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
             $Table .= '<td><input type="radio" name="demande['.$id.']" value="1"></td>';
             $Table .= '<td><input type="radio" name="demande['.$id.']" value="2"></td>';
             $Table .= '<td><input type="radio" name="demande['.$id.']" value="NULL" checked></td>';
+
+            /* Informations pour le positionnement du calendrier */
+            list($anneeDebut, $moisDebut) = explode('-', $demande['p_date_deb']);
+            $dateDebut = new \DateTimeImmutable($anneeDebut . '-' . $moisDebut . '-01');
+            $paramsCalendrier = [
+                'session' => $session,
+                'vue' => \App\ProtoControllers\Calendrier::VUE_MOIS,
+                'begin' => $dateDebut->format('Y-m-d'),
+                'end' => $dateDebut->modify('+1 month')->format('Y-m-d'),
+            ];
+            $Table .= '<td><a href="' . ROOT_PATH . 'calendrier.php?' . http_build_query($paramsCalendrier) . '" title="' . _('consulter_calendrier_de_periode') . '"><i class="fa fa-lg fa-calendar" aria-hidden="true"></i></a></td>';
             $Table .= '<td><input class="form-control" type="text" name="comment_refus['.$id.']" size="20" maxlength="100"></td></tr>';
             $i = !$i;
-            }
+        }
 
         return $Table;
     }

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -223,14 +223,14 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         $childTable .= '<th>' . _('duree') . '</th>';
         $childTable .= '<th>' . _('divers_solde') . '</th>';
         $childTable .= '<th>' . _('divers_comment_maj_1') . '</th>';
-        $childTable .= '<th>' . _('divers_accepter_maj_1') . '</th><th>' . _('divers_refuser_maj_1') . '</th><th>' . _('resp_traite_demandes_attente') . '</th>';
+        $childTable .= '<th>' . _('divers_accepter_maj_1') . '</th><th>' . _('divers_refuser_maj_1') . '</th><th>' . _('resp_traite_demandes_attente') . '</th><th></th>';
         $childTable .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
         $childTable .= '</tr></thead><tbody>';
 
         $demandesResp = $this->getDemandesResponsable($_SESSION['userlogin']);
         $demandesGrandResp = $this->getDemandesGrandResponsable($_SESSION['userlogin']);
         if (empty($demandesResp) && empty($demandesGrandResp) ) {
-            $childTable .= '<tr><td colspan="11"><center>' . _('aucun_resultat') . '</center></td></tr>';
+            $childTable .= '<tr><td colspan="12"><center>' . _('aucun_resultat') . '</center></td></tr>';
         } else {
             if(!empty($demandesResp)) {
                 $childTable .= $this->getFormDemandes($demandesResp);

--- a/Public/Assets/Css/reboot.css
+++ b/Public/Assets/Css/reboot.css
@@ -795,6 +795,13 @@ div.calendrier div.celluleJour .event.conges {
     color: white;
 }
 
+div.calendrier div.celluleJour .event.conges_demande,
+div.calendrier div.celluleJour .event.conges_valid,
+div.calendrier div.celluleJour .event.heure_1,
+div.calendrier div.celluleJour .event.heure_2 {
+    opacity: 0.7;
+}
+
 div.calendrier div.event.conges .multijour {
     border-left: 0.675em solid #1ABC9C;
 }

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -1644,6 +1644,8 @@ class Fonctions
             $return .= '<td>' . _('resp_traite_user_motif_refus') . '</td>';
             if($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<td>' . _('divers_date_traitement') . '</td>';
+            } else {
+                $return .= '<td></td>';
             }
             $return .= '</tr>';
 
@@ -2142,5 +2144,5 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
         $table->render();
 
         return ob_get_clean();
-    }    
+    }
 }


### PR DESCRIPTION
```gherkin
En tant qu'employé responsable de la validation / refus des sorties
J'ai besoin d'avoir une vision des employés en poste sur les périodes de demandes de sorties
Afin d'accepter ou refuser une demande en fonction de ces critères
```

Les heures, le planning et le calendrier étant fait, nous avons eu besoin de faire cela aussi pour amener la fonctionnalité jusqu'au bout.
J'ai donc mis un petit calendrier dans la liste des sorties (congés / absences, heures, ...) à traiter pour avoir un accès rapide à la bonne période du calendrier.

Le prérequis qu'il a fallu faire cependant, c'est que les responsables voient les sorties en cours de demande dans le calendrier. J'espère que ça fera pas moche ou inutilisable.

![contextecalendrier](https://cloud.githubusercontent.com/assets/5312739/20454297/c7f46fba-ae3c-11e6-8b4a-9c25acd63b45.png)
