### PR TITLE
Securise la variable ['PHP_SELF']

### DIFF
--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -9,7 +9,7 @@ class Fonctions
     // modifie, pour un resp donné,  les groupes dont il est resp et grands_resp
     public static function modif_resp_groupes($choix_resp, &$checkbox_resp_group, &$checkbox_grd_resp_group)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -62,7 +62,7 @@ class Fonctions
     // affiche pour un resp des cases à cocher devant les groupes possibles pour les selectionner.
     public static function affiche_gestion_responsable_groupes($choix_resp, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -247,7 +247,7 @@ class Fonctions
     // affiche le tableau des responsables pour choisir sur lequel on va gerer les groupes dont il est resp
     public static function affiche_choix_responsable_groupes()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -304,7 +304,7 @@ class Fonctions
     // modifie, pour un groupe donné,  ses resp et grands_resp
     public static function modif_group_responsables($choix_group, &$checkbox_group_resp, &$checkbox_group_grd_resp)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -358,7 +358,7 @@ class Fonctions
     // affiche pour un groupe des cases à cocher devant les resp et grand_resp possibles pour les selectionner.
     public static function affiche_gestion_groupes_responsables($choix_group, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -530,7 +530,7 @@ class Fonctions
     // affiche le tableau des groupes pour choisir sur quel groupe on va gerer les responsables
     public static function affiche_choix_groupes_responsables()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -581,7 +581,7 @@ class Fonctions
     // affichage des pages de gestion des responsables des groupes
     public static function affiche_choix_gestion_groupes_responsables($choix_group, $choix_resp, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -642,7 +642,7 @@ class Fonctions
 
     public static function modif_user_groups($choix_user, &$checkbox_user_groups)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -666,7 +666,7 @@ class Fonctions
 
     public static function modif_group_users($choix_group, &$checkbox_group_users)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -701,7 +701,7 @@ class Fonctions
     }
 
     public static function affiche_gestion_groupes_users($choix_group, $onglet) {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -803,7 +803,7 @@ class Fonctions
 
     public static function affiche_choix_groupes_users()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -858,7 +858,7 @@ class Fonctions
 
     public static function affiche_gestion_user_groupes($choix_user, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -883,7 +883,7 @@ class Fonctions
 
     public static function affiche_choix_user_groupes()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1022,7 +1022,7 @@ class Fonctions
 
     public static function affiche_choix_gestion_groupes_users($choix_group, $choix_user, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return   = '';
 
         if( $choix_group!="" )     // si un groupe choisi : on affiche la gestion par groupe
@@ -1090,7 +1090,7 @@ class Fonctions
 
     public static function verif_new_param_group($new_group_name, $new_group_libelle)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1131,7 +1131,7 @@ class Fonctions
 
     public static function ajout_groupe($new_group_name, $new_group_libelle, $new_group_double_valid)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1164,7 +1164,7 @@ class Fonctions
 
     public static function affiche_gestion_groupes($new_group_name, $new_group_libelle, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1437,7 +1437,7 @@ class Fonctions
     public static function commit_update($u_login_to_update, $new_pwd1, $new_pwd2)
     {
 
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1471,7 +1471,7 @@ class Fonctions
 
     public static function modifier($u_login, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1691,7 +1691,7 @@ class Fonctions
 
     public static function restaure($fichier_restaure_name, $fichier_restaure_tmpname, $fichier_restaure_size, $fichier_restaure_error)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1751,7 +1751,7 @@ class Fonctions
     // RESTAURATION
     public static function choix_restaure()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1798,7 +1798,7 @@ class Fonctions
 
     public static function commit_sauvegarde($type_sauvegarde)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1836,7 +1836,7 @@ class Fonctions
 
     public static function sauve($type_sauvegarde)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1868,7 +1868,7 @@ class Fonctions
     // SAUVEGARDE
     public static function choix_sauvegarde()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1916,7 +1916,7 @@ class Fonctions
     // CHOIX
     public static function choix_save_restore()
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -1979,7 +1979,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $choix_action    = getpost_variable('choix_action');
         $type_sauvegarde = getpost_variable('type_sauvegarde');
@@ -2021,7 +2021,7 @@ class Fonctions
 
     public static function commit_update_groupe($group_to_update, $new_groupname, $new_comment, $new_double_valid)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
         $result   = TRUE;
@@ -2052,7 +2052,7 @@ class Fonctions
 
     public static function modifier_groupe($group, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -2167,7 +2167,7 @@ class Fonctions
     public static function commit_update_user($u_login_to_update, &$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, &$tab_new_reliquat, &$return)
     {
         $dataUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($u_login_to_update);
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $erreurs = [];
 
@@ -2320,7 +2320,7 @@ class Fonctions
 
     public static function modifier_user($u_login, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
         $soldeHeureId = uniqid();
@@ -2654,7 +2654,7 @@ class Fonctions
 
     public static function suppression_group($group_to_delete)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2688,7 +2688,7 @@ class Fonctions
 
     public static function confirmer($group, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -2774,7 +2774,7 @@ class Fonctions
 
     public static function suppression($u_login_to_delete)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -2810,7 +2810,7 @@ class Fonctions
 
     public static function confirmer_suppression($u_login, $onglet)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -3028,7 +3028,7 @@ class Fonctions
     // affichage du formulaire de saisie d'un nouveau user
     public static function affiche_formulaire_ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -3254,7 +3254,7 @@ class Fonctions
 
     public static function verif_new_param(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, &$return = null)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
 
@@ -3393,7 +3393,7 @@ class Fonctions
 
     public static function ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $checkbox_user_groups)
     {
-        $PHP_SELF = $_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
         $verifFalse = '';

--- a/admin/admin_index.php
+++ b/admin/admin_index.php
@@ -18,7 +18,7 @@ verif_droits_user($session, 'is_admin');
 /*************************************/
 // recup des parametres reçus :
 // SERVER
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = htmlentities(getpost_variable('onglet', 'admin-users'), ENT_QUOTES | ENT_HTML401);
 

--- a/calcul_nb_jours_pris.php
+++ b/calcul_nb_jours_pris.php
@@ -20,7 +20,7 @@ $p_num="";
 /*************************************/
 // recup des parametres reçus :
 // SERVER
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET  / POST
 $user       = getpost_variable('user') ;
 $date_debut = getpost_variable('date_debut') ;
@@ -37,7 +37,7 @@ if( ($user!="") && ($date_debut!="") && ($date_fin!="") && ($opt_debut!="") && (
 
 function affichage($user, $date_debut, $date_fin, $opt_debut, $opt_fin, $p_num="")
 {
-	$PHP_SELF=$_SERVER['PHP_SELF'];
+	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 	$session=session_id();
 	$comment="&nbsp;" ;
 

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -9,7 +9,7 @@ class Fonctions
 {
     public static function commit_vider_table_logs($session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         $sql_delete="TRUNCATE TABLE conges_logs ";
@@ -30,7 +30,7 @@ class Fonctions
 
     public static function confirmer_vider_table_logs($session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         $return .= '<center>';
@@ -47,7 +47,7 @@ class Fonctions
 
     public static function affichage($login_par, $session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         //requête qui récupère les logs
@@ -142,7 +142,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $action         = htmlentities(getpost_variable('action', ""), ENT_QUOTES | ENT_HTML401);
         $login_par      = htmlentities(getpost_variable('login_par', ""), ENT_QUOTES | ENT_HTML401);
@@ -165,7 +165,7 @@ class Fonctions
 
     public static function commit_modif($tab_new_values, $session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -193,7 +193,7 @@ class Fonctions
 
     public static function test_config($tab_new_values, $session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -220,7 +220,7 @@ class Fonctions
 
     public static function affichage_config_mail($tab_new_values, $session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -316,7 +316,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $action = getpost_variable('action') ;
         $tab_new_values = getpost_variable('tab_new_values');
@@ -376,7 +376,7 @@ class Fonctions
 
     public static function commit_ajout(&$tab_new_values, $session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -449,7 +449,7 @@ class Fonctions
 
     public static function commit_suppr($session, $id_to_update)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -477,7 +477,7 @@ class Fonctions
 
     public static function supprimer($session, $id_to_update)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -530,7 +530,7 @@ class Fonctions
 
     public static function commit_modif_absence(&$tab_new_values, $session, $id_to_update)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -583,7 +583,7 @@ class Fonctions
 
     public static function modifier(&$tab_new_values, $session, $id_to_update)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -646,7 +646,7 @@ class Fonctions
 
     public static function affichage_absence($tab_new_values,$session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -808,7 +808,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $action         = getpost_variable('action') ;
         $tab_new_values = getpost_variable('tab_new_values');
@@ -835,7 +835,7 @@ class Fonctions
 
     public static function commit_saisie(&$tab_new_values, $session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         if($session=="") {
@@ -913,7 +913,7 @@ class Fonctions
 
     public static function affichage_configuration($session)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         // affiche_bouton_retour($session);
@@ -1108,7 +1108,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $action         = getpost_variable('action') ;
         $tab_new_values = getpost_variable('tab_new_values');

--- a/config/index.php
+++ b/config/index.php
@@ -16,7 +16,7 @@ include_once ROOT_PATH .'fonctions_conges.php' ;
 $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
 include_once INCLUDE_PATH .'session.php';
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 $session=session_id();
 

--- a/edition/Fonctions.php
+++ b/edition/Fonctions.php
@@ -193,7 +193,7 @@ class Fonctions
 
     public static function affichage($login)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -236,7 +236,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $user_login = htmlentities(getpost_variable('user_login', $_SESSION['userlogin']), ENT_QUOTES | ENT_HTML401);
         $return = '';
@@ -1154,7 +1154,7 @@ class Fonctions
     public static function enregistrement_edition($login)
     {
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
         $tab_solde_user=array();
         $sql1 = 'SELECT su_abs_id, su_solde FROM conges_solde_user where su_login = "'. \includes\SQL::quote($login).'"';

--- a/export/Fonctions.php
+++ b/export/Fonctions.php
@@ -9,7 +9,7 @@ class Fonctions
 {
     public static function form_saisie($user, $date_debut, $date_fin)
     {
-    	$PHP_SELF=$_SERVER['PHP_SELF'];
+    	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
     	$session=session_id();
 
     	$date_today=date("d-m-Y");
@@ -50,7 +50,7 @@ class Fonctions
     	/*************************************/
     	// recup des parametres reçus :
     	// SERVER
-    	$PHP_SELF=$_SERVER['PHP_SELF'];
+    	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
     	// GET	/ POST
     	$action     = getpost_variable('action') ;
     	$user_login = getpost_variable('user_login') ;

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -67,7 +67,7 @@ function get_j_name_fr_2c($timestamp)
 
 function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet)
 {
-    $PHP_SELF=$_SERVER['PHP_SELF'];
+    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
     $session=session_id();
     $new_date_fin = date('d/m/Y');
     $return = '';

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -128,7 +128,7 @@ class Fonctions
 
     public static function traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -192,7 +192,7 @@ class Fonctions
     public static function affiche_all_demandes_en_cours($tab_type_conges)
     {
         $return = '';
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $count1=0;
         $count2=0;
@@ -391,7 +391,7 @@ class Fonctions
 
     public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -443,7 +443,7 @@ class Fonctions
 
     public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id();
         $return = '';
 
@@ -527,7 +527,7 @@ class Fonctions
 
     public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -577,7 +577,7 @@ class Fonctions
     //affiche l'état des conges du user (avec le formulaire pour le responsable)
     public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -725,7 +725,7 @@ class Fonctions
     //affiche l'état des demande en attente de 2ieme validation du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_2_valid_user_for_resp($user_login)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -826,7 +826,7 @@ class Fonctions
     //affiche l'état des demande du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -946,7 +946,7 @@ class Fonctions
 
     public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id();
         $return = '';
 
@@ -1148,7 +1148,7 @@ class Fonctions
     public static function ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
 
         // recup de la liste des users d'un groupe donné
@@ -1202,7 +1202,7 @@ class Fonctions
 
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -1256,7 +1256,7 @@ class Fonctions
 
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1282,7 +1282,7 @@ class Fonctions
 
     public static function affichage_saisie_globale_groupe($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -1340,7 +1340,7 @@ class Fonctions
 
     public static function affichage_saisie_globale_pour_tous($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -1379,7 +1379,7 @@ class Fonctions
 
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -1500,7 +1500,7 @@ class Fonctions
 
     public static function saisie_ajout( $tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -1663,7 +1663,7 @@ class Fonctions
 
     public static function commit_saisie($tab_checkbox_j_chome)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1694,7 +1694,7 @@ class Fonctions
 
     public static function confirm_saisie($tab_checkbox_j_chome)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1833,7 +1833,7 @@ class Fonctions
 
     public static function saisie($year_calendrier_saisie)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1893,7 +1893,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $choix_action                 = getpost_variable('choix_action');
         $year_calendrier_saisie        = getpost_variable('year_calendrier_saisie', 0);
@@ -1956,7 +1956,7 @@ class Fonctions
     // cloture / debut d'exercice pour TOUS les users d'un groupe'
     public static function cloture_globale_groupe($group_id, $tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1976,7 +1976,7 @@ class Fonctions
     // cloture / debut d'exercice pour TOUS les users du resp (ou grand resp)
     public static function cloture_globale($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2097,7 +2097,7 @@ class Fonctions
     // cloture / debut d'exercice user par user pour les users du resp (ou grand resp)
     public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2121,7 +2121,7 @@ class Fonctions
 
     public static function affichage_cloture_globale_groupe($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -2179,7 +2179,7 @@ class Fonctions
 
     public static function affichage_cloture_globale_pour_tous($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -2245,7 +2245,7 @@ class Fonctions
 
     public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -2311,7 +2311,7 @@ class Fonctions
 
     public static function saisie_cloture( $tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -2628,7 +2628,7 @@ class Fonctions
 
     public static function commit_annul_fermeture($fermeture_id, $groupe_id)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2701,7 +2701,7 @@ class Fonctions
 
     public static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2790,7 +2790,7 @@ class Fonctions
 
     public static function confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2877,7 +2877,7 @@ class Fonctions
 
     public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -2916,7 +2916,7 @@ class Fonctions
 
     public static function saisie_groupe_fermeture()
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -3023,7 +3023,7 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // SERVER
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $choix_action         = getpost_variable('choix_action');
         $year                 = getpost_variable('year', 0);

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -18,7 +18,7 @@ verif_droits_user($session, "is_hr");
 /*************************************/
 // recup des parametres reçus :
 // SERVER
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet', "page_principale");
 

--- a/imprim_calendrier.php
+++ b/imprim_calendrier.php
@@ -16,7 +16,7 @@ include_once INCLUDE_PATH .'session.php';
 	/*************************************/
 	// recup des parametres reçus :
 	// SERVER
-	$PHP_SELF=$_SERVER['PHP_SELF'];
+	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 	// GET	/ POST
 	$action     = getpost_variable('action') ;
 	$new_mois = getpost_variable('new_mois', date("m")) ;
@@ -32,7 +32,7 @@ include_once INCLUDE_PATH .'session.php';
 
 function form_saisie($action, $new_mois, $new_year)
 {
-	$PHP_SELF=$_SERVER['PHP_SELF'];
+	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 	$session=session_id();
 
 	header_popup();

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -266,7 +266,7 @@ function session_delete($session)
 //
 function session_saisie_user_password($erreur, $session_username, $session_password)
 {
-   $PHP_SELF=$_SERVER['PHP_SELF'];
+   $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
     $config_php_conges_version      = $_SESSION['config']['php_conges_version'];
     $config_url_site_web_php_conges = $_SESSION['config']['url_site_web_php_conges'];

--- a/includes/plugins/cet/plugin_active.php
+++ b/includes/plugins/cet/plugin_active.php
@@ -2,7 +2,7 @@
 include_once ROOT_PATH . 'define.php';
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 if($session=="")
     $URL = "$PHP_SELF";

--- a/includes/plugins/cet/plugin_inactive.php
+++ b/includes/plugins/cet/plugin_inactive.php
@@ -2,7 +2,7 @@
 include ROOT_PATH . 'define.php';
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 $timeout=2 ; // refresh après maj.
 
 if(!isset($session) || $session == "")

--- a/includes/plugins/cet/plugin_install.php
+++ b/includes/plugins/cet/plugin_install.php
@@ -2,7 +2,7 @@
 include_once ROOT_PATH . 'define.php';
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 $timeout=2 ; // refresh après maj.
 
 if(!isset($session) || $session == "")

--- a/includes/plugins/cet/plugin_uninstall.php
+++ b/includes/plugins/cet/plugin_uninstall.php
@@ -4,7 +4,7 @@ defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
 $timeout=2 ; // refresh après maj.
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 if(!isset($session) || $session == "")
     $URL = "$PHP_SELF";

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -167,7 +167,7 @@ class Fonctions {
     public static function lance_install($lang)
     {
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
         include CONFIG_PATH .'dbconnect.php' ;
         include ROOT_PATH .'version.php' ;
@@ -205,7 +205,7 @@ class Fonctions {
             $sql_update_lang="UPDATE conges_config SET conf_valeur = '$lang' WHERE conf_nom='lang' ";
             $result_update_lang = \includes\SQL::query($sql_update_lang) ;
 
-            $tab_url=explode("/", $_SERVER['PHP_SELF']);
+            $tab_url=explode("/", filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
             array_pop($tab_url);
             array_pop($tab_url);
@@ -233,7 +233,7 @@ class Fonctions {
     public static function lance_maj($lang, $installed_version, $config_php_conges_version, $etape)
     {
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         include CONFIG_PATH .'dbconnect.php' ;
 
 

--- a/install/index.php
+++ b/install/index.php
@@ -10,7 +10,7 @@ include_once INCLUDE_PATH .'fonction.php';
 
 include_once ROOT_PATH .'fonctions_conges.php' ;
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 $session= htmlentities(session_id());
 

--- a/install/install.php
+++ b/install/install.php
@@ -6,7 +6,7 @@ require_once ROOT_PATH . 'define.php';
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 //recup de la langue
 $lang=(isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : "") ) ;

--- a/install/mise_a_jour.php
+++ b/install/mise_a_jour.php
@@ -7,7 +7,7 @@ include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 include ROOT_PATH .'version.php' ;
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 //recup de la langue
 $lang=(isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : "") ) ;

--- a/install/upgrade_from_v1.5.0.php
+++ b/install/upgrade_from_v1.5.0.php
@@ -9,7 +9,7 @@ require_once ROOT_PATH . 'define.php';
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 $version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : "")) ;
 $version = htmlentities($version, ENT_QUOTES | ENT_HTML401);

--- a/install/upgrade_from_v1.6.0.php
+++ b/install/upgrade_from_v1.6.0.php
@@ -9,7 +9,7 @@ require_once ROOT_PATH . 'define.php';
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 $version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : "")) ;
 $version = htmlentities($version, ENT_QUOTES | ENT_HTML401);

--- a/install/upgrade_from_v1.7.0.php
+++ b/install/upgrade_from_v1.7.0.php
@@ -11,10 +11,12 @@ include ROOT_PATH .'fonctions_conges.php' ;
 include INCLUDE_PATH .'fonction.php';
 //include 'fonctions_install.php' ;
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 $version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : "")) ;
+$version = htmlentities($version, ENT_QUOTES | ENT_HTML401);
 $lang = (isset($_GET['lang']) ? $_GET['lang'] : (isset($_POST['lang']) ? $_POST['lang'] : "")) ;
+$lang = htmlentities($lang, ENT_QUOTES | ENT_HTML401);
 if (!in_array($lang, ['fr_FR', 'en_US', 'es_ES'], true)) {
     $lang = '';
 }

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -10,9 +10,10 @@ defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 include ROOT_PATH .'fonctions_conges.php' ;
 include INCLUDE_PATH .'fonction.php';
 
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 $version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : "")) ;
+$version = htmlentities($version, ENT_QUOTES | ENT_HTML401);
 $lang = (isset($_GET['lang']) ? $_GET['lang'] : (isset($_POST['lang']) ? $_POST['lang'] : "")) ;
 $lang = htmlentities($lang, ENT_QUOTES | ENT_HTML401);
 if (!in_array($lang, ['fr_FR', 'en_US', 'es_ES'], true)) {

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -20,7 +20,7 @@ class Fonctions
         // $tab_new_nb_conges_all[$id_conges]= nb_jours
         // $tab_calcul_proportionnel[$id_conges]= TRUE / FALSE
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -79,7 +79,7 @@ class Fonctions
 
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -140,7 +140,7 @@ class Fonctions
 
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -177,7 +177,7 @@ class Fonctions
 
     public static function affichage_saisie_globale_groupe($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -253,7 +253,7 @@ class Fonctions
 
     public static function affichage_saisie_globale_pour_tous($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -292,7 +292,7 @@ class Fonctions
 
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_resp, $tab_all_users_du_grand_resp)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -415,7 +415,7 @@ class Fonctions
 
     public static function saisie_ajout( $tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -517,7 +517,7 @@ class Fonctions
     // cloture / debut d'exercice pour TOUS les users d'un groupe'
     public static function cloture_globale_groupe($group_id, $tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -541,7 +541,7 @@ class Fonctions
     // cloture / debut d'exercice pour TOUS les users du resp (ou grand resp)
     public static function cloture_globale($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -670,7 +670,7 @@ class Fonctions
     // cloture / debut d'exercice user par user pour les users du resp (ou grand resp)
     public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -708,7 +708,7 @@ class Fonctions
 
     public static function affichage_cloture_globale_groupe($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -784,7 +784,7 @@ class Fonctions
 
     public static function affichage_cloture_globale_pour_tous($tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -844,7 +844,7 @@ class Fonctions
 
     public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_resp, $tab_all_users_du_grand_resp)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -918,7 +918,7 @@ class Fonctions
 
     public static function saisie_cloture( $tab_type_conges)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -1146,7 +1146,7 @@ class Fonctions
 
     public static function new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -1198,7 +1198,7 @@ class Fonctions
 
     public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id();
         $return = '';
 
@@ -1284,7 +1284,7 @@ class Fonctions
 
     public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -1333,7 +1333,7 @@ class Fonctions
     //affiche l'état des conges du user (avec le formulaire pour le responsable)
     public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -1483,7 +1483,7 @@ class Fonctions
     //affiche l'état des demande en attente de 2ieme validation du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_2_valid_user_for_resp($user_login)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id() ;
         $return = '';
 
@@ -1587,7 +1587,7 @@ class Fonctions
     //affiche l'état des demandes du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id();
         $return = '';
 
@@ -1703,7 +1703,7 @@ class Fonctions
 
     public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF']; ;
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
         $session=session_id();
         $return = '';
 

--- a/responsable/resp_index.php
+++ b/responsable/resp_index.php
@@ -18,7 +18,7 @@ verif_droits_user($session, "is_resp");
     /*************************************/
     // recup des parametres reçus :
     // SERVER
-    $PHP_SELF=$_SERVER['PHP_SELF'];
+    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
     // GET / POST
     $onglet = getpost_variable('onglet', "page_principale");
 

--- a/template/reboot/menu_header.php
+++ b/template/reboot/menu_header.php
@@ -13,7 +13,7 @@
     }
     //user mode
     $user_mode = '';
-    $tmp = dirname($_SERVER['PHP_SELF']);
+    $tmp = dirname(filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL));
     $tmp = explode('/',$tmp);
     $tmp = array_pop($tmp);
     $adminActive = $userActive = $respActive = $hrActive = $calendarActive = '';

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -57,7 +57,7 @@ class Fonctions
         $new_fin = convert_date($new_fin);
         $return = '';
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
 
         // verif validité des valeurs saisies
@@ -239,7 +239,7 @@ class Fonctions
 
     public static function modifier($p_num_to_update, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $p_etat, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
         $VerifNb = verif_saisie_decimal($new_nb_jours);
@@ -272,7 +272,7 @@ class Fonctions
 
     public static function confirmer($p_num, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -433,7 +433,7 @@ class Fonctions
 
     public static function suppression($p_num_to_delete, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -463,7 +463,7 @@ class Fonctions
 
     public static function confirmerSuppression($p_num, $onglet)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id() ;
         $return = '';
 
@@ -560,7 +560,7 @@ class Fonctions
 
     public static function change_passwd( $new_passwd1, $new_passwd2)
     {
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $return = '';
 
@@ -609,7 +609,7 @@ class Fonctions
         if($change_passwd==1) {
             $return .= \utilisateur\Fonctions::change_passwd($new_passwd1, $new_passwd2);
         } else {
-            $PHP_SELF=$_SERVER['PHP_SELF'];
+            $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
             $session=session_id();
 
             $return .= '<h1>' . _('user_change_password') . '</h1>';
@@ -817,7 +817,7 @@ class Fonctions
     {
         $return = '';
 
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
 
         $duree_demande_1="";
@@ -1095,7 +1095,7 @@ class Fonctions
     public static function saisie_echange_rtt($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet)
     {
         $return = '';
-        $PHP_SELF=$_SERVER['PHP_SELF'];
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session=session_id();
         $mois_calendrier_saisie_debut_prec=0; $year_calendrier_saisie_debut_prec=0;
         $mois_calendrier_saisie_debut_suiv=0; $year_calendrier_saisie_debut_suiv=0;

--- a/utilisateur/user_index.php
+++ b/utilisateur/user_index.php
@@ -15,7 +15,7 @@ if ($_SESSION['config']['where_to_find_user_email']=="ldap") {
 }
 
 // SERVER
-$PHP_SELF=$_SERVER['PHP_SELF'];
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet');
 


### PR DESCRIPTION
La variable SERVER_['PHP_SELF'] n'est pas sécurisée et il faut la traiter comme toutes variables venant de l'utilisateur.
http://stackoverflow.com/questions/10272282/how-to-secure-serverphp-self
Voir réponse de alganet pour comprendre pourquoi on utilise filter_input au lieu de htmlspecialchars