### PR TITLE
[Traitement demande] interdiction de valider soit même

### DIFF
--- a/App/ProtoControllers/Employe/AHeure.php
+++ b/App/ProtoControllers/Employe/AHeure.php
@@ -164,7 +164,7 @@ abstract class AHeure
         $jour  = \App\Helpers\Formatter::dateFr2Iso($post['jour']);
         $debut = strtotime($jour . ' ' . $post['debut_heure']);
         $fin   = strtotime($jour . ' ' . $post['fin_heure']);
-        $statut = !empty(Responsable::getRespsUtilisateur($user))
+        $statut = !empty(Responsable::getResponsablesUtilisateur($user))
             ? Models\AHeure::STATUT_DEMANDE
             : Models\AHeure::STATUT_VALIDATION_FINALE
         ;

--- a/App/ProtoControllers/Groupe/Utilisateur.php
+++ b/App/ProtoControllers/Groupe/Utilisateur.php
@@ -30,7 +30,8 @@ class Utilisateur {
         $sql = \includes\SQL::singleton();
         $req = 'SELECT gu_login
                 FROM `conges_groupe_users`
-                WHERE gu_gid IN (' . implode(',', $groupeIds) . ')';
+                WHERE gu_gid IN (' . implode(',', $groupeIds) . ') 
+                AND gu_login != "'. $_SESSION['userlogin'] .'"';
         $res = $sql->query($req);
 
         $users = [];

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -159,7 +159,7 @@ class Responsable
         $sql = \includes\SQL::singleton();
         $req = 'SELECT gr_login FROM conges_groupe_resp 
                     WHERE gr_gid IN (\'' . implode(',', $groupesId) . '\')
-                    AND gr_gid =! "'. $_SESSION['userlogin'] .'"';
+                    AND gr_login != "'. $_SESSION['userlogin'] .'"';
         $res = $sql->query($req);
 
          while ($data = $res->fetch_array()) {

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -94,23 +94,6 @@ class Responsable
     }
 
     /**
-     * Retourne les responsables de groupes et direct d'un utilisateur
-     *
-     * @param string $user
-     * @return array
-     */
-    public static function getRespsUtilisateur($user){
-        $groupeIds = \App\ProtoControllers\Utilisateur::getGroupesId($user);
-        $responsablesGroupe = \App\ProtoControllers\Groupe\Responsable::getListResponsableByGroupeIds($groupeIds);
-        $responsableDirect = \App\ProtoControllers\Responsable::getRespDirect($user);
-        if (!empty($responsableDirect)) {
-            return array_unique(array_merge($responsablesGroupe + [$responsableDirect]));
-        }
-
-        return $responsablesGroupe;
-    }
-
-    /**
      * Vérifie si le responsable est absent
      *
      * @param string $resp identifiant du responsable
@@ -145,6 +128,12 @@ class Responsable
         return $grandResp;
     }
 
+    /**
+     * Retourne les responsables de groupes et direct d'un utilisateur
+     *
+     * @param string $user
+     * @return array
+     */
     public static function getResponsablesUtilisateur($user) {
         
         $responsables = \App\ProtoControllers\Responsable::getResponsableGroupe(\App\ProtoControllers\Utilisateur::getGroupesId($user));
@@ -168,7 +157,9 @@ class Responsable
         $responsable = [];
         
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT gr_login FROM conges_groupe_resp WHERE gr_gid IN (\'' . implode(',', $groupesId) . '\')';
+        $req = 'SELECT gr_login FROM conges_groupe_resp 
+                    WHERE gr_gid IN (\'' . implode(',', $groupesId) . '\')
+                    AND gr_gid =! "'. $_SESSION['userlogin'] .'"';
         $res = $sql->query($req);
 
          while ($data = $res->fetch_array()) {
@@ -187,7 +178,9 @@ class Responsable
      * @return bool
      */
     public static function isRespDeUtilisateur($resp, $user) {
-        return \App\ProtoControllers\Responsable::isRespDirect($resp, $user) || \App\ProtoControllers\Responsable::isRespGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($user));
+        return $resp != $user 
+                && (\App\ProtoControllers\Responsable::isRespDirect($resp, $user) 
+                || \App\ProtoControllers\Responsable::isRespGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($user)));
     }
 
     /**
@@ -216,7 +209,7 @@ class Responsable
             return FALSE;
         }
 
-        $RespsUser = \App\ProtoControllers\Responsable::getRespsUtilisateur($user);
+        $RespsUser = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($user);
         $RespUserPresent = array_diff($RespsUser,$usersRespRespAbs);
         if (empty($RespUserPresent)){
             return TRUE;

--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -467,7 +467,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         $ids = [];
         foreach ($usersRespAbsent as $userResp){
             $delegation = TRUE;
-            $respsUser = \App\ProtoControllers\Responsable::getRespsUtilisateur($userResp);
+            $respsUser = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($userResp);
             foreach ($respsUser as $respUser){
                 if (!\App\ProtoControllers\Responsable::isRespAbsent($respUser)){
                     $delegation = FALSE;


### PR DESCRIPTION
Si le responsable d'un groupe fait aussi parti de ce même groupe en tant qu'employé, il ne doit pas être en mesure de traiter ses propres demandes. 
- si pas de resp : validation automatique
- si double validation : la demande passe directement au grand responsable du groupe.

et en prime, fusion de getRespUtilisateur() et getResponsablesUtilisateur(). Ce doublon est certainement apparu durant un rebase ou merge...