### PR TITLE
Echappement d'une variable

### DIFF
--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1563,7 +1563,7 @@ function insert_dans_periode($login, $date_deb, $demi_jour_deb, $date_fin, $demi
     else
         $num_new_demande = 1;
 
-    $sql2 = "INSERT INTO conges_periode SET p_login='$login',p_date_deb='$date_deb', p_demi_jour_deb='$demi_jour_deb',p_date_fin='$date_fin', p_demi_jour_fin='$demi_jour_fin', p_nb_jours='$nb_jours', p_commentaire='$commentaire', p_type='$id_type_abs', p_etat='$etat', ";
+    $sql2 = "INSERT INTO conges_periode SET p_login='$login',p_date_deb='$date_deb', p_demi_jour_deb='$demi_jour_deb',p_date_fin='$date_fin', p_demi_jour_fin='$demi_jour_fin', p_nb_jours='$nb_jours', p_commentaire='" . addslashes( $commentaire ) . "', p_type='$id_type_abs', p_etat='$etat', ";
 
     if($id_fermeture!=0)
         $sql2 = $sql2." p_fermeture_id='$id_fermeture' ," ;


### PR DESCRIPTION
Échappement du commentaire d'ajout de congé avant insertion en base.
Idéalement, il faudrait utiliser mysqli_prepare (et donc revoir toute l'implémentation de mysql dans le projet) pour éviter ces problèmes.
Cf issue #326 .