### PR TITLE
Fix le bug d'affichage des badges en double dans le cas où l'utilisateur avait le même responsable direct que le chef de groupe

### DIFF
--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -400,12 +400,13 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
 
-
         $usersResp = [];
         $usersResp = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupId);
         $usersRespDirect = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
-        $usersResp = array_merge($usersResp,$usersRespDirect);
 
+        // merge tous les utilisateurs dont il est le responsable direct et tous les utilisateurs dont il est le chef de groupe
+        // si un utilisateur est dans les deux tableaux on supprime le doublon
+        $usersResp = array_unique(array_merge($usersResp,$usersRespDirect));
         // un utilisateur ne peut etre son propre responsable
         $usersResp = array_diff($usersResp,[$_SESSION['userlogin']]);
 


### PR DESCRIPTION
Dans la page de traitement des congés du responsable, parfois il y avait un badge qui indiquait le double du nombre de demande à traiter.
Reproduction du bug : 
Georges a pour responsable direct Paolo
Georges et Paolo font partie du même groupe dont Paolo est le responsable

Alors si Georges prenait un congés Paolo voyait 2 badges par demande.
Le problème a été réglé en supprimant les doublons dans la liste des utilisateurs gérés par Paolo