### PR TITLE
Correction validation par le responsable

### DIFF
--- a/App/ProtoControllers/Groupe.php
+++ b/App/ProtoControllers/Groupe.php
@@ -156,7 +156,8 @@ class Groupe
                 )';
         $query = $sql->query($req);
 
-        return $query->fetch_array() && 0 < (int) $query->fetch_array()[0];
+        $results = $query->fetch_array();
+        return $results && (0 < (int) $results[0]);
     }
 
     /**


### PR DESCRIPTION
Je n'ai pas compris pourquoi mais " $query->fetch_array() && 0 < (int) $query->fetch_array()[0];" renvoit toujours faux chez moi. Surement le double appel à fetch_array.